### PR TITLE
Various tweaks to handling the display of stock info

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -554,7 +554,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$return->price          = get_post_meta( $ticket_id, '_price', true );
 		$return->provider_class = get_class( $this );
 		$return->admin_link     = '';
-		$return->stock          = get_post_meta( $ticket_id, '_stock', true )-$qty;
+		$return->stock          = get_post_meta( $ticket_id, '_stock', true ) - $qty;
 		$return->start_date     = get_post_meta( $ticket_id, '_ticket_start_date', true );
 		$return->end_date       = get_post_meta( $ticket_id, '_ticket_end_date', true );
 		$return->qty_sold       = $qty;

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -48,13 +48,11 @@ ob_start();
 							<input type="number" class="tribe-ticket-quantity" min="0" name="quantity_<?php echo absint( $ticket->ID ); ?>" value="0">
 							<?php
 
-							$remaining = $ticket->remaining();
-
-							if ( $remaining ) {
+							if ( $ticket->managing_stock() ) {
 								?>
 								<span class="tribe-tickets-remaining">
 									<?php
-									echo sprintf( esc_html__( '%1$s out of %2$s available', 'event-tickets' ), $remaining, $ticket->stock );
+									echo sprintf( esc_html__( '%1$s out of %2$s available', 'event-tickets' ), $ticket->remaining(), $ticket->original_stock() );
 									?>
 								</span>
 								<?php


### PR DESCRIPTION
Sydney found a bug with null stocks that led to a greater revealing of the way our ticket plugins manage stock.

Stock = current inventory
Original stock = current inventory + sold + pending
_manage_stock = indicates that the product doesn't use stock if set to no

See: https://central.tri.be/issues/40481
