### PR TITLE
Finish up QR code support in emails

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -17,6 +17,30 @@ class Tribe__Tickets__Main {
 	const REQUIRED_TEC_VERSION = '3.9.2';
 
 	/**
+	 * Name of the provider
+	 * @var
+	 */
+	public $plugin_name;
+
+	/**
+	 * Directory of the plugin
+	 * @var
+	 */
+	public $plugin_dir;
+
+	/**
+	 * Path of the plugin
+	 * @var
+	 */
+	public $plugin_path;
+
+	/**
+	 * URL of the plugin
+	 * @var
+	 */
+	public $plugin_url;
+
+	/**
 	 * Get (and instantiate, if necessary) the instance of the class
 	 *
 	 * @static

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -701,7 +701,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		public function generate_tickets_email_content( $tickets ) {
 			ob_start();
-			include $this->getTemplateHierarchy( 'tickets/email.php' );
+			$file = $this->getTemplateHierarchy( 'tickets/email.php' );
+
+			if ( ! file_exists( $file ) ) {
+				include Tribe__Tickets__Main::instance()->plugin_path . 'src/views/tickets/email.php';
+			}
 
 			return ob_get_clean();
 		}

--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -223,188 +223,181 @@
 <body yahoo="fix" alink="#006caa" link="#006caa" text="#000000" bgcolor="#ffffff" style="width:100% !important; -webkit-text-size-adjust:100%; -ms-text-size-adjust:100%; margin:0 auto; padding:20px 0 0 0; background:#ffffff; min-height:1000px;">
 	<div style="margin:0; padding:0; width:100% !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:14px; line-height:145%; text-align:left;">
 		<center>
-
-			<?php do_action( 'tribe_tickets_ticket_email_top' ); ?>
-
 			<?php
+			do_action( 'tribe_tickets_ticket_email_top' );
+
 			$count = 0;
 			$break = '';
 			foreach ( $tickets as $ticket ) {
-			$count ++;
+				$count ++;
 
-			if ( $count == 2 ) {
-				$break = 'page-break-before: always !important;';
-			}
-
-			$event      = get_post( $ticket['event_id'] );
-			$header_id  = Tribe__Tickets__Tickets_Handler::instance()->get_header_image_id( $ticket['event_id'] );
-			$header_img = false;
-			if ( ! empty( $header_id ) ) {
-				$header_img = wp_get_attachment_image_src( $header_id, 'full' );
-			}
-
-			$venue_label = '';
-
-			if ( function_exists( 'tribe_get_venue_id' ) ) {
-				$venue_id = tribe_get_venue_id( $event->ID );
-				if ( ! empty( $venue_id ) ) {
-					$venue = get_post( $venue_id );
+				if ( $count == 2 ) {
+					$break = 'page-break-before: always !important;';
 				}
 
-				$venue_label = tribe_get_venue_label_singular();
-
-				$venue_name = $venue_phone = $venue_address = $venue_city = $venue_web = '';
-				if ( ! empty( $venue ) ) {
-					$venue_name    = $venue->post_title;
-					$venue_phone   = get_post_meta( $venue_id, '_VenuePhone', true );
-					$venue_address = get_post_meta( $venue_id, '_VenueAddress', true );
-					$venue_city    = get_post_meta( $venue_id, '_VenueCity', true );
-					$venue_web     = get_post_meta( $venue_id, '_VenueURL', true );
+				$event      = get_post( $ticket['event_id'] );
+				$header_id  = Tribe__Tickets__Tickets_Handler::instance()->get_header_image_id( $ticket['event_id'] );
+				$header_img = false;
+				if ( ! empty( $header_id ) ) {
+					$header_img = wp_get_attachment_image_src( $header_id, 'full' );
 				}
 
-			}
+				$venue_label = '';
 
-			if ( function_exists( 'tribe_get_start_date' ) ) {
-				$start_date = tribe_get_start_date( $event, true );
-			}
+				if ( function_exists( 'tribe_get_venue_id' ) ) {
+					$venue_id = tribe_get_venue_id( $event->ID );
+					if ( ! empty( $venue_id ) ) {
+						$venue = get_post( $venue_id );
+					}
 
-			if ( function_exists( 'tribe_get_organizer_ids' ) ) {
-				$organizers = tribe_get_organizer_ids( $event->ID );
-			}
+					$venue_label = tribe_get_venue_label_singular();
 
-			?>
+					$venue_name = $venue_phone = $venue_address = $venue_city = $venue_web = '';
+					if ( ! empty( $venue ) ) {
+						$venue_name    = $venue->post_title;
+						$venue_phone   = get_post_meta( $venue_id, '_VenuePhone', true );
+						$venue_address = get_post_meta( $venue_id, '_VenueAddress', true );
+						$venue_city    = get_post_meta( $venue_id, '_VenueCity', true );
+						$venue_web     = get_post_meta( $venue_id, '_VenueURL', true );
+					}
+				}
 
-			<table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff" style="margin:0 auto; padding:0;<?php echo $break; ?>">
-				<tr>
-					<td align="center" valign="top" class="wrapper" width="620">
-						<table class="inner-wrapper" border="0" cellpadding="0" cellspacing="0" width="620" bgcolor="#f7f7f7" style="margin:0 auto !important; width:620px; padding:0;">
-							<tr>
-								<td valign="top" class="ticket-content" align="left" width="580" border="0" cellpadding="20" cellspacing="0" style="padding:20px; background:#f7f7f7;">
-									<?php if ( ! empty( $header_img ) ) {
-										$header_width = esc_attr( $header_img[1] );
-										if ( $header_width > 580 ) {
-											$header_width = 580;
+				if ( function_exists( 'tribe_get_start_date' ) ) {
+					$start_date = tribe_get_start_date( $event, true );
+				}
+
+				if ( function_exists( 'tribe_get_organizer_ids' ) ) {
+					$organizers = tribe_get_organizer_ids( $event->ID );
+				}
+
+				?>
+				<table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff" style="margin:0 auto; padding:0;<?php echo $break; ?>">
+					<tr>
+						<td align="center" valign="top" class="wrapper" width="620">
+							<table class="inner-wrapper" border="0" cellpadding="0" cellspacing="0" width="620" bgcolor="#f7f7f7" style="margin:0 auto !important; width:620px; padding:0;">
+								<tr>
+									<td valign="top" class="ticket-content" align="left" width="580" border="0" cellpadding="20" cellspacing="0" style="padding:20px; background:#f7f7f7;">
+										<?php
+										if ( ! empty( $header_img ) ) {
+											$header_width = esc_attr( $header_img[1] );
+											if ( $header_width > 580 ) {
+												$header_width = 580;
+											}
+											?>
+											<table border="0" cellpadding="0" cellspacing="0" width="100%">
+												<tr>
+													<td class="ticket-image" valign="top" align="left" width="100%" style="padding-bottom:15px !important;">
+														<img src="<?php echo esc_attr( $header_img[0] ); ?>" width="<?php echo esc_attr( $header_width ); ?>" alt="<?php echo esc_attr( $event->post_title ); ?>" style="border:0; outline:none; height:auto; max-width:100%; display:block;" />
+													</td>
+												</tr>
+											</table>
+											<?php
 										}
 										?>
-										<table border="0" cellpadding="0" cellspacing="0" width="100%">
+										<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
 											<tr>
-												<td class="ticket-image" valign="top" align="left" width="100%" style="padding-bottom:15px !important;">
-													<img src="<?php echo esc_attr( $header_img[0] ); ?>" width="<?php echo esc_attr( $header_width ); ?>" alt="<?php echo esc_attr( $event->post_title ); ?>" style="border:0; outline:none; height:auto; max-width:100%; display:block;" />
+												<td valign="top" align="center" width="100%" style="padding: 0 !important; margin:0 !important;">
+													<h2 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:28px; letter-spacing:normal; text-align:left;line-height: 100%;">
+														<span style="color:#0a0a0e !important"><?php echo $event->post_title; ?></span>
+													</h2>
+													<?php if ( ! empty( $start_date ) ): ?>
+														<h4 style="color:#0a0a0e; margin:0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:15px; letter-spacing:normal; text-align:left;line-height: 100%;">
+															<span style="color:#0a0a0e !important"><?php echo $start_date; ?></span>
+														</h4>
+													<?php endif; ?>
 												</td>
 											</tr>
 										</table>
-									<?php } ?>
-									<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
-										<tr>
-											<td valign="top" align="center" width="100%" style="padding: 0 !important; margin:0 !important;">
-
-												<h2 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:28px; letter-spacing:normal; text-align:left;line-height: 100%;">
-													<span style="color:#0a0a0e !important"><?php echo $event->post_title; ?></span>
-												</h2>
-												<?php if ( ! empty( $start_date ) ): ?>
-													<h4 style="color:#0a0a0e; margin:0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:15px; letter-spacing:normal; text-align:left;line-height: 100%;">
-														<span style="color:#0a0a0e !important"><?php echo $start_date; ?></span>
-													</h4>
-												<?php endif; ?>
-											</td>
-										</tr>
-									</table>
-									<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
-										<tr>
-											<td valign="top" align="left" width="100%" height="30" style="height:30px; background:#f7f7f7; padding: 0 !important; margin:0 !important;">
-												<div style="margin:0; height:30px;"></div>
-											</td>
-										</tr>
-									</table>
-									<table class="ticket-details" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
-										<tr>
-											<td class="ticket-details" valign="top" align="left" width="100" style="padding: 0; width:100px; margin:0 !important;">
-												<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Ticket #', 'event-tickets' ); ?></h6>
-												<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['ticket_id']; ?></span>
-											</td>
-											<td class="ticket-details" valign="top" align="left" width="120" style="padding: 0; width:120px; margin:0 !important;">
-												<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Ticket Type', 'event-tickets' ); ?></h6>
-												<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['ticket_name']; ?></span>
-											</td>
-											<td class="ticket-details" valign="top" align="left" width="120" style="padding: 0 !important; width:120px; margin:0 !important;">
-												<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Purchaser', 'event-tickets' ); ?></h6>
-												<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['holder_name']; ?></span>
-											</td>
-											<td class="ticket-details new-row new-left-row" valign="top" align="left" width="120" style="padding: 0; width:120px; margin:0 !important;">
-												<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Security Code', 'event-tickets' ); ?></h6>
-												<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['security_code']; ?></span>
-											</td>
-										</tr>
-									</table>
-									<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
-										<tr>
-											<td valign="top" align="left" width="100%" height="30" style="height:30px; background:#f7f7f7; padding: 0 !important; margin:0 !important;">
-												<div style="margin:0; height:30px;"></div>
-											</td>
-										</tr>
-									</table>
-									<table class="ticket-venue" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
-										<tr>
-											<td class="ticket-venue" valign="top" align="left" width="300" style="padding: 0 !important; width:300px; margin:0 !important;">
-												<h6 style="color:#909090 !important; margin:0 0 4px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( $venue_label, 'event-tickets' ); ?></h6>
-												<table class="venue-details" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
-													<tr>
-														<td class="ticket-venue-child" valign="top" align="left" width="130" style="padding: 0 10px 0 0 !important; width:130px; margin:0 !important;">
-															<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; display:block; margin-bottom:5px;"><?php echo $venue_name; ?></span>
-															<a style="color:#006caa !important; display:block; margin:0; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;">
-																<?php echo $venue_address; ?><br />
-																<?php echo $venue_city; ?>
-															</a>
-														</td>
-														<td class="ticket-venue-child" valign="top" align="left" width="100" style="padding: 0 !important; width:140px; margin:0 !important;">
-															<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; display:block; margin-bottom:5px;"><?php echo $venue_phone; ?></span>
-															<?php if ( ! empty( $venue_web ) ): ?>
-																<a href="<?php echo esc_url( $venue_web ) ?>" style="color:#006caa !important; display:block; margin:0; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;"><?php echo $venue_web; ?></a>
-															<?php endif ?>
-														</td>
-													</tr>
-												</table>
-											</td>
-											<td class="ticket-organizer" valign="top" align="left" width="140" style="padding: 0 !important; width:140px; margin:0 !important;">
-
-												<?php if ( ! empty( $organizers ) ): ?>
-													<h6 style="color:#909090 !important; margin:0 0 4px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php echo tribe_get_organizer_label( count( $organizers ) < 2 ); ?></h6>
-													<?php foreach ( $organizers as $organizer_id ) { ?>
-														<span
-															style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; display:block; padding-bottom:5px;"><?php echo tribe_get_organizer( $organizer_id ); ?></span>
-													<?php } ?>
-												<?php endif; ?>
-											</td>
-
-											<?php $qr_code_url = apply_filters( 'tribe_tickets_ticket_qr_code', '', $ticket ); ?>
-											<?php if ( ! empty( $qr_code_url ) ): ?>
-												<td class="ticket-qr" valign="top" align="right" width="160"
-												    style="padding: 0 !important; width:160px; margin:0 !important;">
-													<img src="<?php echo esc_url( $qr_code_url ); ?>" width="140"
-													     height="140" alt="QR Code Image"
-													     style="border:0; outline:none; height:auto; max-width:100%; display:block; float:right"/>
+										<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
+											<tr>
+												<td valign="top" align="left" width="100%" height="30" style="height:30px; background:#f7f7f7; padding: 0 !important; margin:0 !important;">
+													<div style="margin:0; height:30px;"></div>
 												</td>
-											<?php endif; ?>
-										</tr>
-									</table>
-									<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
-										<tr>
-											<td class="ticket-footer" valign="top" align="left" width="100%" style="padding: 0 !important; width:100%; margin:0 !important;">
-												<a href="<?php echo esc_url( home_url() ); ?>" style="color:#006caa !important; display:block; margin-top:20px; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;"><?php echo home_url(); ?></a>
-											</td>
-										</tr>
-									</table>
-								</td>
-							</tr>
-						</table>
-						<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
-							<tr>
-								<td valign="top" align="left" width="100%" height="100" style="height:100px; background:#ffffff; padding: 0 !important; margin:0 !important;">
-									<div style="margin:0; height:100px;"></div>
-								</td>
-							</tr>
-						</table>
-						<?php
+											</tr>
+										</table>
+										<table class="ticket-details" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+											<tr>
+												<td class="ticket-details" valign="top" align="left" width="100" style="padding: 0; width:100px; margin:0 !important;">
+													<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Ticket #', 'event-tickets' ); ?></h6>
+													<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['ticket_id']; ?></span>
+												</td>
+												<td class="ticket-details" valign="top" align="left" width="120" style="padding: 0; width:120px; margin:0 !important;">
+													<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Ticket Type', 'event-tickets' ); ?></h6>
+													<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['ticket_name']; ?></span>
+												</td>
+												<td class="ticket-details" valign="top" align="left" width="120" style="padding: 0 !important; width:120px; margin:0 !important;">
+													<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Purchaser', 'event-tickets' ); ?></h6>
+													<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['holder_name']; ?></span>
+												</td>
+												<td class="ticket-details new-row new-left-row" valign="top" align="left" width="120" style="padding: 0; width:120px; margin:0 !important;">
+													<h6 style="color:#909090 !important; margin:0 0 10px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( 'Security Code', 'event-tickets' ); ?></h6>
+													<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px;"><?php echo $ticket['security_code']; ?></span>
+												</td>
+											</tr>
+										</table>
+										<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
+											<tr>
+												<td valign="top" align="left" width="100%" height="30" style="height:30px; background:#f7f7f7; padding: 0 !important; margin:0 !important;">
+													<div style="margin:0; height:30px;"></div>
+												</td>
+											</tr>
+										</table>
+										<table class="ticket-venue" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+											<tr>
+												<td class="ticket-venue" valign="top" align="left" width="300" style="padding: 0 !important; width:300px; margin:0 !important;">
+													<h6 style="color:#909090 !important; margin:0 0 4px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php esc_html_e( $venue_label, 'event-tickets' ); ?></h6>
+													<table class="venue-details" border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+														<tr>
+															<td class="ticket-venue-child" valign="top" align="left" width="130" style="padding: 0 10px 0 0 !important; width:130px; margin:0 !important;">
+																<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; display:block; margin-bottom:5px;"><?php echo $venue_name; ?></span>
+																<a style="color:#006caa !important; display:block; margin:0; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;">
+																	<?php echo $venue_address; ?><br />
+																	<?php echo $venue_city; ?>
+																</a>
+															</td>
+															<td class="ticket-venue-child" valign="top" align="left" width="100" style="padding: 0 !important; width:140px; margin:0 !important;">
+																<span style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; display:block; margin-bottom:5px;"><?php echo $venue_phone; ?></span>
+																<?php if ( ! empty( $venue_web ) ): ?>
+																	<a href="<?php echo esc_url( $venue_web ) ?>" style="color:#006caa !important; display:block; margin:0; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;"><?php echo $venue_web; ?></a>
+																<?php endif ?>
+															</td>
+														</tr>
+													</table>
+												</td>
+												<td class="ticket-organizer" valign="top" align="left" width="140" style="padding: 0 !important; width:140px; margin:0 !important;">
+
+													<?php if ( ! empty( $organizers ) ): ?>
+														<h6 style="color:#909090 !important; margin:0 0 4px 0; font-family: 'Helvetica Neue', Helvetica, sans-serif; text-transform:uppercase; font-size:13px; font-weight:700 !important;"><?php echo tribe_get_organizer_label( count( $organizers ) < 2 ); ?></h6>
+														<?php foreach ( $organizers as $organizer_id ) { ?>
+															<span
+																style="color:#0a0a0e !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:15px; display:block; padding-bottom:5px;"><?php echo tribe_get_organizer( $organizer_id ); ?></span>
+														<?php } ?>
+													<?php endif; ?>
+												</td>
+											</tr>
+										</table>
+										<table border="0" cellpadding="0" cellspacing="0" width="100%" align="center">
+											<tr>
+												<td class="ticket-footer" valign="top" align="left" width="100%" style="padding: 0 !important; width:100%; margin:0 !important;">
+													<a href="<?php echo esc_url( home_url() ); ?>" style="color:#006caa !important; display:block; margin-top:20px; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-size:13px; text-decoration:underline;"><?php echo home_url(); ?></a>
+												</td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+							<?php do_action( 'tribe_tickets_ticket_email_ticket_bottom', $ticket ); ?>
+							<table class="whiteSpace" border="0" cellpadding="0" cellspacing="0" width="100%">
+								<tr>
+									<td valign="top" align="left" width="100%" height="100" style="height:100px; background:#ffffff; padding: 0 !important; margin:0 !important;">
+										<div style="margin:0; height:100px;"></div>
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+				<?php
 			}//end foreach
 
 			do_action( 'tribe_tickets_ticket_email_bottom' );


### PR DESCRIPTION
- Remove QR code reference in event-tickets and relocate to event-tickets-plus
- Fix HTML issue in ticket email
- Add action so QR codes can be injected in a cleaner manner
- Always load the email.php template from event-tickets if it cannot be found in event-tickets-plus or the user's theme

_NOTE:_ this is best viewed with `?w=1`

Related: https://github.com/moderntribe/event-tickets-plus/pull/10 & https://github.com/moderntribe/event-tickets-plus/pull/11

See: https://central.tri.be/issues/34363
