### PR TITLE
Reference the correct key when fetching event IDs from attendees

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -352,7 +352,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		foreach ( $query->posts as $post ) {
 			$attendees[] = array(
-				'event_id'      => get_post_meta( $post->ID, $this->attendee_product_key, true ),
+				'event_id'      => get_post_meta( $post->ID, $this->attendee_event_key, true ),
 				'ticket_name'   => get_post( get_post_meta( $post->ID, $this->attendee_product_key, true ) )->post_title,
 				'holder_name'   => get_post_meta( $post->ID, $this->full_name, true ),
 				'holder_email'  => get_post_meta( $post->ID, $this->email, true ),


### PR DESCRIPTION
This will resolve an issue where the event ticket header image could not be found due to an invalid post ID

See: https://central.tri.be/issues/41142
