### PR TITLE
Fixing reference to deprecated class file

### DIFF
--- a/src/admin-views/list.php
+++ b/src/admin-views/list.php
@@ -55,7 +55,7 @@
 					$attendees_url = add_query_arg(
 						array(
 							'post_type' => Tribe__Events__Main::POSTTYPE,
-							'page' => Tribe__Events__Tickets__Tickets_Pro::$attendees_slug,
+							'page' => Tribe__Tickets__Tickets_Handler::$attendees_slug,
 							'event_id' => $post_id,
 						),
 						admin_url( 'edit.php' )


### PR DESCRIPTION
This was a regression from a [merge commit](https://github.com/moderntribe/event-tickets/commit/b876d419405fc48e20c03981a10410ef1fed6a84#diff-b445f576f6fe5e7da27c7804265681d5R58).
