### PR TITLE
Use the current post's post_type rather than Tribe__Events__Main

### DIFF
--- a/src/admin-views/list.php
+++ b/src/admin-views/list.php
@@ -63,7 +63,7 @@
 					<?php
 					$attendees_url = add_query_arg(
 						array(
-							'post_type' => Tribe__Events__Main::POSTTYPE,
+							'post_type' => $post_type,
 							'page' => Tribe__Tickets__Tickets_Handler::$attendees_slug,
 							'event_id' => $post_id,
 						),


### PR DESCRIPTION
Related: https://github.com/moderntribe/event-tickets-plus/pull/24

See: https://central.tri.be/issues/41384
