### PR TITLE
Shorten message about start/end times when adding tickets to non-events

### DIFF
--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -395,7 +395,6 @@ class Tribe__Tickets__Tickets_Handler {
 		$endMeridianOptions   = Tribe__View_Helpers::getMeridianOptions( null );
 
 		$tickets = Tribe__Tickets__Tickets::get_event_tickets( $post_id );
-		$post = get_post( $post_id );
 		include $this->path . 'src/admin-views/meta-box.php';
 	}
 

--- a/src/admin-views/meta-box.php
+++ b/src/admin-views/meta-box.php
@@ -160,7 +160,7 @@ $modules = Tribe__Tickets__Tickets::modules();
 							<?php esc_html_e( 'When will ticket sales occur?', 'event-tickets' ); ?>
 							<?php
 							// Why break in and out of PHP? because I want the space between the phrases without including them in the translations
-							if ( ! empty( $post->post_type ) && 'tribe_events' === $post->post_type ) {
+							if ( class_exists( 'Tribe__Events__Main' ) && Tribe__Events__Main::POSTTYPE === get_post_type( $post_id ) ) {
 								esc_html_e( "If you don't set a start/end date for sales, tickets will be available from now until the event ends.", 'event-tickets' );
 							}
 							?>


### PR DESCRIPTION
Only mention events if adding tickets to TEC events.

See: https://central.tri.be/issues/41697
