### PR TITLE
Rather than computing stock in the tpl, let's use the pre-computed value

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,10 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [4.0.3] unreleased =
+
+* Tweak - Leverage the original_stock() method when rendering ticket availability to avoid funky math problems with different Event Tickets Plus commerce providers
+
 = [4.0.2] 2015-12-16 =
 
 * Tweak - Removing dates from ticket emails when those tickets are attached to non The Events Calendar event posts

--- a/src/admin-views/list.php
+++ b/src/admin-views/list.php
@@ -91,7 +91,7 @@
 
 			<td nowrap="nowrap">
 				<?php
-				$stock = $ticket->stock();
+				$stock = $ticket->original_stock();
 				$sold  = $ticket->qty_sold();
 				$cancelled = $ticket->qty_cancelled();
 
@@ -105,7 +105,7 @@
 					));
 					$line = sprintf(
 						esc_html__( 'Sold %1$d of %2$d%3$s', 'event-tickets' ), esc_html( $sold ),
-						esc_html( $sold + $stock ), $cancelled_entry
+						esc_html( $stock ), $cancelled_entry
 					);
 
 					echo $line;


### PR DESCRIPTION
We have an `original_stock()` method. Let's use that instead.

Related: https://github.com/moderntribe/event-tickets-plus/pull/51

See: https://central.tri.be/issues/42355