### PR TITLE
Twiddle stock handling on the attendees report so it reads accurately

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,10 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [4.0.4] 2015-12-23 =
+
+* Fix - Resolved issue with stock calculations on the Attendees report
+
 = [4.0.3] 2015-12-22 =
 
 * Tweak - Leverage the original_stock() method when rendering ticket availability to avoid funky math problems with different Event Tickets Plus commerce providers (Thank you liblogger for reporting this issue!)

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -12,10 +12,10 @@ $total_pending = 0;
 $total_completed = 0;
 
 foreach ( $tickets as $ticket ) {
-	$total_sold += $ticket->qty_sold();
+	$total_sold += $ticket->qty_sold() + $ticket->qty_pending();
 	$total_pending += $ticket->qty_pending();
-	$total_completed = $total_sold - $total_pending;
 }
+$total_completed = $total_sold - $total_pending;
 
 ?>
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -199,7 +199,7 @@ if ( ! function_exists( 'tribe_tickets_get_ticket_stock_message' ) ) {
 	 * @return string
 	 */
 	function tribe_tickets_get_ticket_stock_message( $ticket ) {
-		$stock = $ticket->stock();
+		$stock = $ticket->original_stock();
 		$sold = $ticket->qty_sold();
 		$pending = $ticket->qty_pending();
 


### PR DESCRIPTION
See: https://central.tri.be/issues/42355