### PR TITLE
Prevent RSVP recursion on RSVPing for an event with custom meta

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -112,6 +112,9 @@ class Tribe__Tickets__Main {
 		$this->hooks();
 
 		$this->has_initialized = true;
+
+		// set up the RSVP object
+		$this->rsvp();
 	}
 
 	/**
@@ -330,9 +333,6 @@ class Tribe__Tickets__Main {
 	 * Hooked to the init action
 	 */
 	public function init() {
-		// set up the RSVP object
-		$this->rsvp();
-
 		// Provide continued support for legacy ticketing modules
 		$this->legacy_provider_support = new Tribe__Tickets__Legacy_Provider_Support;
 
@@ -343,13 +343,7 @@ class Tribe__Tickets__Main {
 	 * rsvp ticket object accessor
 	 */
 	public function rsvp() {
-		static $rsvp;
-
-		if ( ! $rsvp ) {
-			$rsvp = Tribe__Tickets__RSVP::get_instance();
-		}
-
-		return $rsvp;
+		return Tribe__Tickets__RSVP::get_instance();
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -103,8 +103,8 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * @return Tribe__Tickets__RSVP
 	 */
 	public static function get_instance() {
-		if ( ! is_a( self::$instance, __CLASS__ ) ) {
-			self::$instance = new self();
+		if ( ! self::$instance ) {
+			self::$instance = new self;
 		}
 
 		return self::$instance;
@@ -123,8 +123,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		parent::__construct();
 
-		$this->init();
-		$this->hooks();
+		add_action( 'init', array( $this, 'init' ) );
 	}
 
 	/**
@@ -140,6 +139,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * Hooked to the init action
 	 */
 	public function init() {
+		$this->hooks();
 		$this->register_resources();
 		$this->register_types();
 		$this->generate_tickets();


### PR DESCRIPTION
Turns out this was causing the following reported issue: https://central.tri.be/issues/43666

Related: https://github.com/moderntribe/event-tickets-plus/pull/82