### PR TITLE
Global sales count helper | 43020

### DIFF
--- a/src/Tribe/Global_Stock.php
+++ b/src/Tribe/Global_Stock.php
@@ -100,4 +100,22 @@ class Tribe__Tickets__Global_Stock {
 	public function get_stock_level() {
 		return (int) get_post_meta( $this->post_id, self::GLOBAL_STOCK_LEVEL, true );
 	}
+
+	/**
+	 * Returns a count of the number of global ticket sales for this event.
+	 *
+	 * @return int
+	 */
+	public function tickets_sold() {
+		$sales = 0;
+
+		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $this->post_id ) as $ticket ) {
+			/**
+			 * @var Tribe__Tickets__Ticket_Object $ticket
+			 */
+			$sales += (int) $ticket->qty_sold();
+		}
+
+		return $sales;
+	}
 }

--- a/src/admin-views/meta-box.php
+++ b/src/admin-views/meta-box.php
@@ -82,7 +82,7 @@ $modules = Tribe__Tickets__Tickets::modules();
 						<td>
 							<input type="number" name="tribe-tickets-global-stock" id="tribe-tickets-global-stock" value="<?php echo esc_attr( $global_stock->get_stock_level() ); ?>" />
 							<span class="tribe-tickets-global-sales">
-								<?php echo esc_html( sprintf( _n( '(%s sold)', '(%s sold)', 0, 'event-tickets' ), 0 ) ); ?>
+								<?php echo esc_html( sprintf( _n( '(%s sold)', '(%s sold)', $global_stock->tickets_sold(), 'event-tickets' ), $global_stock->tickets_sold() ) ); ?>
 							</span>
 						</td>
 					</tr>


### PR DESCRIPTION
Implementing a count of global stock sales - simple helper function plus linking it to the global stock field in the event meta box.

[C#43020](https://central.tri.be/issues/43020)