### PR TITLE
Fix the broken warning icon for cancelled/refunded orders

### DIFF
--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -144,9 +144,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		// If the warning flag is set, add the appropriate icon
 		if ( $warning ) {
-			$resources_url = plugins_url( 'resources', dirname( dirname( __FILE__ ) ) );
-
-			$icon = sprintf( "<span class='warning'><img src='%s'/></span> ", $resources_url . '/images/warning.png' );
+			$icon = sprintf( "<span class='warning'><img src='%s'/></span> ", Tribe__Tickets__Main::instance()->plugin_url . 'src/resources/images/warning.png' );
 		}
 
 

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -144,9 +144,8 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		// If the warning flag is set, add the appropriate icon
 		if ( $warning ) {
-			$icon = sprintf( "<span class='warning'><img src='%s'/></span> ", Tribe__Tickets__Main::instance()->plugin_url . 'src/resources/images/warning.png' );
+			$icon = sprintf( "<span class='warning'><img src='%s'/></span> ", esc_url( Tribe__Tickets__Main::instance()->plugin_url . 'src/resources/images/warning.png' ) );
 		}
-
 
 		// Look for an order_status_label, fall back on the actual order_status string @todo remove fallback in 3.4.3
 		if ( empty( $item['order_status'] ) ) {


### PR DESCRIPTION
See: https://central.tri.be/issues/44194