### PR TITLE
Prevent Multiple Checkins when using QR Codes

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -706,8 +706,11 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 *
 	 * @return bool
 	 */
-	public function checkin( $attendee_id ) {
+	public function checkin( $attendee_id, $qr=null ) {
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
+		if ( 'qr' != $qr ) {
+			update_post_meta( $attendee_id, '_tribe_qr_status', 'qr' );
+		}
 		do_action( 'rsvp_checkin', $attendee_id );
 
 		return true;
@@ -722,6 +725,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 */
 	public function uncheckin( $attendee_id ) {
 		delete_post_meta( $attendee_id, $this->checkin_key );
+		delete_post_meta( $attendee_id, '_tribe_qr_status' );
 		do_action( 'rsvp_uncheckin', $attendee_id );
 
 		return true;

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -706,7 +706,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 *
 	 * @return bool
 	 */
-	public function checkin( $attendee_id, $qr=null ) {
+	public function checkin( $attendee_id, $qr = null ) {
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
 		if ( 'qr' != $qr ) {
 			update_post_meta( $attendee_id, '_tribe_qr_status', 'qr' );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -703,12 +703,13 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * Marks an attendee as checked in for an event
 	 *
 	 * @param $attendee_id
+	 * @param $qr
 	 *
 	 * @return bool
 	 */
 	public function checkin( $attendee_id, $qr = null ) {
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
-		if ( 'qr' != $qr ) {
+		if ( ! $qr ) {
 			update_post_meta( $attendee_id, '_tribe_qr_status', 'qr' );
 		}
 		do_action( 'rsvp_checkin', $attendee_id );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -703,7 +703,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * Marks an attendee as checked in for an event
 	 *
 	 * @param $attendee_id
-	 * @param $qr
+	 @param $qr true if from QR checkin process
 	 *
 	 * @return bool
 	 */

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -703,16 +703,16 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 * Marks an attendee as checked in for an event
 	 *
 	 * @param $attendee_id
-	 @param $qr true if from QR checkin process
+	 * @param $qr true if from QR checkin process
 	 *
 	 * @return bool
 	 */
 	public function checkin( $attendee_id, $qr = null ) {
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
 		if ( ! $qr ) {
-			update_post_meta( $attendee_id, '_tribe_qr_status', 'qr' );
+			update_post_meta( $attendee_id, '_tribe_qr_status', 1 );
 		}
-		do_action( 'rsvp_checkin', $attendee_id );
+		do_action( 'rsvp_checkin', $attendee_id, $qr );
 
 		return true;
 	}

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -177,6 +177,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @abstract
 		 *
 		 * @param $attendee_id
+		 * @param $qr true if from QR checkin process
 		 *
 		 * @return mixed
 		 */

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -180,7 +180,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @return mixed
 		 */
-		abstract public function checkin( $attendee_id );
+		abstract public function checkin( $attendee_id, $qr );
 
 		/**
 		 * Mark an attendee as not checked in


### PR DESCRIPTION
_Ref:_ [C#42327](https://central.tri.be/issues/42327)

This is a PR for both ET and ET+

Please see the ticket for the explanation as there are better ways to do this, but that might be for a ticket involved with upgrading the whole checkin system. 