### PR TITLE
Only count global stock sales | #44569

### DIFF
--- a/src/Tribe/Global_Stock.php
+++ b/src/Tribe/Global_Stock.php
@@ -113,7 +113,12 @@ class Tribe__Tickets__Global_Stock {
 			/**
 			 * @var Tribe__Tickets__Ticket_Object $ticket
 			 */
-			$sales += (int) $ticket->qty_sold();
+			switch ( $ticket->global_stock_mode() ) {
+				case Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE:
+				case Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE:
+					$sales += (int) $ticket->qty_sold();
+				break;
+			}
 		}
 
 		return $sales;

--- a/src/Tribe/Global_Stock.php
+++ b/src/Tribe/Global_Stock.php
@@ -114,8 +114,8 @@ class Tribe__Tickets__Global_Stock {
 			 * @var Tribe__Tickets__Ticket_Object $ticket
 			 */
 			switch ( $ticket->global_stock_mode() ) {
-				case Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE:
-				case Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE:
+				case self::CAPPED_STOCK_MODE:
+				case self::GLOBAL_STOCK_MODE:
 					$sales += (int) $ticket->qty_sold();
 				break;
 			}


### PR DESCRIPTION
When getting the total sales of global stock for an event, do not count sales from independent stocks.

[C#44569](https://central.tri.be/issues/44569)