### PR TITLE
Maintain the original checkin() method signature

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -771,16 +771,33 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	/**
 	 * Marks an attendee as checked in for an event
 	 *
+	 * Because we must still support our legacy ticket plugins, we cannot change the abstract
+	 * checkin() method's signature. However, the QR checkin process needs to move forward
+	 * so we get around that problem by leveraging func_get_arg() to pass a second argument.
+	 *
+	 * It is hacky, but we'll aim to resolve this issue when we end-of-life our legacy ticket plugins
+	 * OR write around it in a future major release
+	 *
 	 * @param $attendee_id
-	 * @param $qr true if from QR checkin process
+	 * @param $qr true if from QR checkin process (NOTE: this is a param-less parameter for backward compatibility)
 	 *
 	 * @return bool
 	 */
-	public function checkin( $attendee_id, $qr = null ) {
+	public function checkin( $attendee_id ) {
+		$qr = null;
+
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
-		if ( ! $qr ) {
+
+		if ( func_num_args() > 1 && $qr = func_get_arg( 1 ) ) {
 			update_post_meta( $attendee_id, '_tribe_qr_status', 1 );
 		}
+
+		/**
+		 * Fires a checkin action
+		 *
+		 * @var int $attendee_id
+		 * @var bool|null $qr
+		 */
 		do_action( 'rsvp_checkin', $attendee_id, $qr );
 
 		return true;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -201,7 +201,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @return mixed
 		 */
-		abstract public function checkin( $attendee_id, $qr = null );
+		abstract public function checkin( $attendee_id );
 
 		/**
 		 * Mark an attendee as not checked in


### PR DESCRIPTION
Rolling back the signature change that we attempted in the last MR in favor of an uglier backward compatible change.

Related: https://github.com/moderntribe/event-tickets-plus/pull/130

See: https://central.tri.be/issues/44831