### PR TITLE
Only pass a stock quantity to the front end if stock is being managed

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -879,7 +879,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					$data[ 'tickets' ][ $ticket->ID ][ 'cap' ] = $ticket->global_stock_cap();
 				}
 
-				if ( Tribe__Tickets__Global_Stock::OWN_STOCK_MODE === $stock_mode ) {
+				if (
+					Tribe__Tickets__Global_Stock::OWN_STOCK_MODE === $stock_mode
+					&& $ticket->managing_stock()
+				) {
 					$data[ 'tickets' ][ $ticket->ID ][ 'stock' ] = $ticket->stock();
 				}
 


### PR DESCRIPTION
If a stock of `0` is provided, then ticket quantities above `0` are not allowed. That's inconvenient for tickets with unlimited stock.

See: https://central.tri.be/issues/44939