### PR TITLE
Options to hide ticket form from logged out users (per module basis)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,7 @@ Our Premium Plugins:
 
 = [4.2] TBD =
 
+* Feature - Make it possible to disable the ticket form for logged out users [44347]
 * Tweak - Language files in the `wp-content/languages/plugins` path will be loaded before attempting to load internal language files [36246]
 * Tweak - Add messaging on the RSVP form when tickets are not yet or are no longer on sale (props to masteradhoc on GitHub for this change) [45467]
 * Tweak - Improved our JSON-LD output to include tickets [43595]

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -614,7 +614,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	public function front_end_tickets_form( $content ) {
 		static $done;
 
-		if ( $done ) {
+		if ( $done || ! $this->form_is_enabled() ) {
 			return;
 		}
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -614,7 +614,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	public function front_end_tickets_form( $content ) {
 		static $done;
 
-		if ( $done || ! $this->form_is_enabled() ) {
+		if ( $done ) {
 			return;
 		}
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1291,7 +1291,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		public function front_end_tickets_form_in_content( $content ) {
 			global $post;
 
-			if ( is_admin() ) {
+			if ( is_admin() || ! $this->form_is_enabled() ) {
 				return $content;
 			}
 
@@ -1323,6 +1323,42 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$content .= $form;
 
 			return $content;
+		}
+
+
+		/**
+		 * Indicates if the ticket form is enabled.
+		 *
+		 * Generally this will return true, but there may be special occasions such
+		 * as access being denied to logged out users and similar where it returns
+		 * false.
+		 *
+		 * @return bool
+		 */
+		protected function form_is_enabled() {
+			$enabled = true;
+
+			if ( ! is_user_logged_in() && $this->disable_for_logged_out_users() ) {
+				$enabled = false;
+			}
+			
+			/**
+			 * Controls whether the ticket form is enabled or not.
+			 *
+			 * @param bool $enabled
+			 * @param Tribe__Tickets__Tickets $ticket_object
+			 */
+			return apply_filters( 'tribe_tickets_frontend_ticket_form_is_enabled', $enabled, $this );
+		}
+
+		/**
+		 * If we should disable the ticket form for logged out users.
+		 * 
+		 * @return bool
+		 */
+		protected function disable_for_logged_out_users() {
+			$should_disable = (array) tribe_get_option( 'ticket-authentication-requirements', array() );
+			return in_array( get_class( $this ), $should_disable );
 		}
 	}
 }

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -309,7 +309,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			add_action( 'wp_ajax_tribe-ticket-uncheckin-' . $this->className, array( $this, 'ajax_handler_attendee_uncheckin' ) );
 
 			// Front end
-			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'front_end_tickets_form' ), 5 );
+			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'front_end_tickets_form_in_events' ), 5 );
 			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ) );
 
 			// Ensure ticket prices and event costs are linked
@@ -1287,6 +1287,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			return $message;
 		}
 		// end Helpers
+
+		/**
+		 * Renders the front end ticket form (within single event posts) when
+		 * they are enabled.
+		 */
+		public function front_end_tickets_form_in_events() {
+			if ( $this->form_is_enabled() ) {
+				$this->front_end_tickets_form( '' );
+			}
+		}
 
 		public function front_end_tickets_form_in_content( $content ) {
 			global $post;

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -27,6 +27,16 @@ foreach ( $all_post_type_objects as $post_type => $post_type_object ) {
 $all_post_types = apply_filters( 'tribe_tickets_settings_post_types', $all_post_types );
 $options = get_option( Tribe__Main::OPTIONNAME, array() );
 
+/**
+ * List of ticketing solutions that support login requirements (ie, disabling or
+ * enabling the ticket form according to whether a user is logged in or not).
+ *
+ * @param array $ticket_systems
+ */
+$ticket_addons = apply_filters( 'tribe_tickets_settings_systems_supporting_login_requirements',
+	Tribe__Tickets__Tickets::modules()
+);
+
 $tickets_tab = array(
 	'priority' => 20,
 	'fields' => apply_filters(
@@ -46,6 +56,13 @@ $tickets_tab = array(
 				// only set the default to tribe_events if the ticket-endabled-post-types index has never been saved
 				'default' => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
 				'options' => $all_post_types,
+				'validation_type' => 'options_multi',
+				'can_be_empty' => true,
+			),
+			'ticket-authentication-requirements' => array(
+				'type' => 'checkbox_list',
+				'label' => esc_html__( 'Remove ticket form for logged out users', 'event-tickets' ),
+				'options' => $ticket_addons,
 				'validation_type' => 'options_multi',
 				'can_be_empty' => true,
 			),


### PR DESCRIPTION
Makes it easier to stop sales/RSVPs for logged-out users. Setting can be selectively applied to individual ticket modules (ie, so we can disable RSVPing but still allow sales for logged out users, etc).

[#44347](https://central.tri.be/issues/44347)