### PR TITLE
Record the user ID associated with the creation of a new attendee

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ Our Premium Plugins:
 * Tweak - Language files in the `wp-content/languages/plugins` path will be loaded before attempting to load internal language files [36246]
 * Tweak - Add messaging on the RSVP form when tickets are not yet or are no longer on sale (props to masteradhoc on GitHub for this change) [45467]
 * Tweak - Improved our JSON-LD output to include tickets [43595]
+* Tweak - Record the user ID associated with the creation of new attendee records [44347]
 
 = [4.1.2] 2016-04-11 =
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -351,6 +351,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 				 */
 				do_action( 'event_tickets_rsvp_ticket_created', $attendee_id, $event_id, $product_id, $order_attendee_id );
 
+				$this->record_attendee_user_id( $attendee_id );
 				$order_attendee_id++;
 			}
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -95,6 +95,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		const ATTENDEES_CACHE = 'tribe_attendees';
 
+		const ATTENDEE_USER_ID = '_tribe_tickets_attendee_user_id';
+
 		/**
 		 * Returns link to the report interface for sales for an event or
 		 * null if the provider doesn't have reporting capabilities.
@@ -1287,6 +1289,23 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			return $message;
 		}
 		// end Helpers
+
+		/**
+		 * Associates an attendee record with a user, typically the purchaser.
+		 *
+		 * The $user_id param is optional and when not provided it will default to the current
+		 * user ID.
+		 *
+		 * @param int $attendee_id
+		 * @param int $user_id
+		 */
+		protected function record_attendee_user_id( $attendee_id, $user_id = null ) {
+			if ( null === $user_id ) {
+				$user_id = get_current_user_id();
+			}
+
+			update_post_meta( $attendee_id, self::ATTENDEE_USER_ID, (int) $user_id );
+		}
 
 		public function front_end_tickets_form_in_content( $content ) {
 			global $post;


### PR DESCRIPTION
When attendee posts are created, let's associate the current user ID (if any) with them. Coverage for providers besides RSVP will be added in a subsequent PR.

[#44347](https://central.tri.be/issues/44347)