### PR TITLE
Adjust verbiage per QA feedback | #44363

### DIFF
--- a/src/views/shortcodes/my-attendance-list-logged-out.php
+++ b/src/views/shortcodes/my-attendance-list-logged-out.php
@@ -1,1 +1,1 @@
-<p><?php _e( 'To see a list of events you are attending you will need to login first of all!', 'event-tickets' ); ?></p>
+<p><?php _e( 'To see a list of events you are attending you will need to login.', 'event-tickets' ); ?></p>

--- a/src/views/shortcodes/my-attendance-list-logged-out.php
+++ b/src/views/shortcodes/my-attendance-list-logged-out.php
@@ -1,1 +1,1 @@
-<p><?php _e( 'To see a list of events you are attending you will need to login.', 'event-tickets' ); ?></p>
+<p><?php esc_html_e( 'To see a list of events you are attending you will need to login.', 'event-tickets' ); ?></p>

--- a/src/views/shortcodes/my-attendance-list.php
+++ b/src/views/shortcodes/my-attendance-list.php
@@ -17,7 +17,7 @@
 	<?php if ( empty( $event_ids ) ): ?>
 
 		<li class="event-none">
-			<?php _e( 'You have not indicated your attendance for any upcoming events.', 'event-tickets' ); ?>
+			<?php esc_html_e( 'You have not indicated your attendance for any upcoming events.', 'event-tickets' ); ?>
 		</li>
 
 	<?php endif; ?>


### PR DESCRIPTION
Modifies wording of you-need-to-login message per feedback.

https://central.tri.be/issues/44363