### PR TITLE
'Total sold' should equal the sum of 'finalized' and 'pending' | #45538

### DIFF
--- a/src/Tribe/Attendance.php
+++ b/src/Tribe/Attendance.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Utilities for tracking ticket provider-agnostic attendance data.
+ */
+class Tribe__Tickets__Attendance {
+	/**
+	 * Meta key used to track the number of attendees that have been deleted
+	 * for each event.
+	 */
+	const DELETED_ATTENDEES_COUNT = '_tribe_deleted_attendees_count';
+
+	/**
+	 * Container for our instances (one per event/post).
+	 *
+	 * @var array
+	 */
+	protected static $instances = array();
+
+	/**
+	 * @var int
+	 */
+	protected $post_id = 0;
+
+
+	/**
+	 * Returns a Tribe__Tickets__Attendance object for the specified post ID.
+	 * 
+	 * @param int $post_id
+	 * 
+	 * @return Tribe__Tickets__Attendance
+	 */
+	public static function instance( $post_id ) {
+		if ( ! isset( self::$instances[ $post_id ] ) ) {
+			self::$instances[ $post_id ] = new self( $post_id );
+		}
+
+		return self::$instances[ $post_id ];
+	}
+
+	protected function __construct( $post_id ) {
+		$this->post_id = $post_id;
+	}
+
+	/**
+	 * Increments the count of deleted attendees for an event/post
+	 * (defaults to 1 unit).
+	 *
+	 * @param int $units
+	 */
+	public function increment_deleted_attendees_count( $units = 1 ) {
+		$deleted = absint( get_post_meta( $this->post_id, self::DELETED_ATTENDEES_COUNT, true ) );
+		update_post_meta( $this->post_id, self::DELETED_ATTENDEES_COUNT, absint( $deleted + $units ) );
+	}
+
+	/**
+	 * Returns the count of deleted attendees.
+	 *
+	 * Note that this was not tracked prior to 4.1.4 release, so inaccuracies may
+	 * result where attendees were deleted before then.
+	 *
+	 * @return int
+	 */
+	public function get_deleted_attendees_count() {
+		return absint( get_post_meta( $this->post_id, self::DELETED_ATTENDEES_COUNT, true ) );
+	}
+
+}

--- a/src/Tribe/Attendance.php
+++ b/src/Tribe/Attendance.php
@@ -24,9 +24,9 @@ class Tribe__Tickets__Attendance {
 
 	/**
 	 * Returns a Tribe__Tickets__Attendance object for the specified post ID.
-	 * 
+	 *
 	 * @param int $post_id
-	 * 
+	 *
 	 * @return Tribe__Tickets__Attendance
 	 */
 	public static function instance( $post_id ) {

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -562,6 +562,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return false;
 		}
 
+		Tribe__Tickets__Attendance::instance( $event_id )->increment_deleted_attendees_count();
 		do_action( 'tickets_rsvp_ticket_deleted', $ticket_id, $event_id, $product_id );
 
 		return true;

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -125,14 +125,6 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		protected $qty_cancelled = 0;
 
 		/**
-		 * Number of units regarded as having been deleted. Getting/setting this value
-		 * should be done through the object's qty_deleted() method.
-		 *
-		 * @var int
-		 */
-		protected $qty_deleted = 0;
-
-		/**
 		 * Holds whether or not stock is being managed
 		 *
 		 * @var boolean

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -125,6 +125,14 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		protected $qty_cancelled = 0;
 
 		/**
+		 * Number of units regarded as having been deleted. Getting/setting this value
+		 * should be done through the object's qty_deleted() method.
+		 *
+		 * @var int
+		 */
+		protected $qty_deleted = 0;
+
+		/**
 		 * Holds whether or not stock is being managed
 		 *
 		 * @var boolean
@@ -342,16 +350,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 * @return int
 		 */
 		public function qty_sold( $value = null ) {
-			// If the Value was passed as numeric value overwrite
-			if ( is_numeric( $value ) ){
-				$this->qty_sold = $value;
-			}
-
-			// Prevents qty_sold from going negative
-			$this->qty_sold = max( (int) $this->qty_sold, 0 );
-
-			// return the new Qty Sold
-			return $this->qty_sold;
+			return $this->qty_getter_setter( $this->qty_sold, $value );
 		}
 
 		/**
@@ -362,16 +361,39 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 * @return int
 		 */
 		public function qty_pending( $value = null ) {
-			// If the Value was passed as numeric value overwrite
-			if ( is_numeric( $value ) ){
-				$this->qty_pending = $value;
+			return $this->qty_getter_setter( $this->qty_pending, $value );
+		}
+
+		/**
+		 * Gets/sets the quantity of deleted units. Disallows the setting of
+		 * negative values.
+		 *
+		 * @param int|null $value
+		 *
+		 * @return int
+		 */
+		public function qty_deleted( $value = null ) {
+			return $this->qty_getter_setter( $this->qty_deleted, $value );
+		}
+
+		/**
+		 * Method to get/set protected quantity properties, disallowing illegal
+		 * things such as setting a negative value.
+		 *
+		 * @param int      &$property
+		 * @param int|null $value
+		 *
+		 * @return int
+		 */
+		protected function qty_getter_setter( &$property, $value = null ) {
+			if ( is_numeric( $value ) ) {
+				$property = (int) $value;
 			}
 
-			// Prevents qty_pending from going negative
-			$this->qty_pending = max( (int) $this->qty_pending, 0 );
+			// Disallow negative values (and force to zero if one is passed)
+			$property = max( (int) $property, 0 );
 
-			// return the new Qty Pending
-			return $this->qty_pending;
+			return $property;
 		}
 
 		/**

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -365,18 +365,6 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		}
 
 		/**
-		 * Gets/sets the quantity of deleted units. Disallows the setting of
-		 * negative values.
-		 *
-		 * @param int|null $value
-		 *
-		 * @return int
-		 */
-		public function qty_deleted( $value = null ) {
-			return $this->qty_getter_setter( $this->qty_deleted, $value );
-		}
-
-		/**
 		 * Method to get/set protected quantity properties, disallowing illegal
 		 * things such as setting a negative value.
 		 *

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -12,7 +12,7 @@ $total_pending = 0;
 $total_completed = 0;
 
 foreach ( $tickets as $ticket ) {
-	$total_sold += $ticket->qty_sold() + $ticket->qty_pending();
+	$total_sold += $ticket->qty_sold();
 	$total_pending += $ticket->qty_pending();
 }
 $total_completed   = $total_sold - $total_pending;

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -9,15 +9,16 @@ $post_type_object = get_post_type_object( $event->post_type );
 $checkedin = Tribe__Tickets__Tickets::get_event_checkedin_attendees_count( $event_id );
 $total_sold = 0;
 $total_pending = 0;
+$total_deleted = 0;
 $total_completed = 0;
 
 foreach ( $tickets as $ticket ) {
 	$total_sold += $ticket->qty_sold();
 	$total_pending += $ticket->qty_pending();
+	$total_deleted += $ticket->qty_deleted();
 }
 $total_completed   = $total_sold - $total_pending;
 $total_attendees   = Tribe__Tickets__Tickets::get_event_attendees_count( $event_id );
-$deleted_attendees = $total_sold - $total_attendees;
 ?>
 
 <div class="wrap tribe-attendees-page">
@@ -93,10 +94,10 @@ $deleted_attendees = $total_sold - $total_attendees;
 							<span id="total_checkedin"><?php echo esc_html( $checkedin ); ?></span>
 						</li>
 
-						<?php if ( $deleted_attendees > 0 ): ?>
+						<?php if ( $total_deleted > 0 ): ?>
 							<li>
 								<strong><?php esc_html_e( 'Deleted:', 'event-tickets' ); ?></strong>
-								<span id="total_deleted"><?php echo esc_html( $deleted_attendees ); ?></span>
+								<span id="total_deleted"><?php echo esc_html( $total_deleted ); ?></span>
 							</li>
 						<?php endif; ?>
 					</ul>

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -15,10 +15,11 @@ $total_completed = 0;
 foreach ( $tickets as $ticket ) {
 	$total_sold += $ticket->qty_sold();
 	$total_pending += $ticket->qty_pending();
-	$total_deleted += $ticket->qty_deleted();
 }
-$total_completed   = $total_sold - $total_pending;
-$total_attendees   = Tribe__Tickets__Tickets::get_event_attendees_count( $event_id );
+
+$total_completed = $total_sold - $total_pending;
+$total_attendees = Tribe__Tickets__Tickets::get_event_attendees_count( $event_id );
+$total_deleted   = Tribe__Tickets__Attendance::instance( $event_id )->get_deleted_attendees_count();
 ?>
 
 <div class="wrap tribe-attendees-page">


### PR DESCRIPTION
Fixes the attendee screen arithmetic. Replaces method of reckoning how many attendees were deleted with actual tracking of that figure.

https://central.tri.be/issues/45538