### PR TITLE
Prevent Empty () to show up when TEC is inactive

### DIFF
--- a/src/views/shortcodes/my-attendance-list.php
+++ b/src/views/shortcodes/my-attendance-list.php
@@ -6,10 +6,14 @@
 
 <ul class="tribe-tickets my-attendance-list">
 	<?php foreach ( $event_ids as $id ): ?>
-
+		<?php $start_date = tribe_get_start_date( $id ); ?>
 		<li class="event-<?php echo esc_attr( $id ) ?>">
-			<a href="<?php echo esc_url( get_permalink( $id ) ); ?>" target="_blank"><?php echo get_the_title( $id ); ?>
-			<span class="datetime">(<?php echo tribe_get_start_date( $id ); ?>)</span></a>
+			<a href="<?php echo esc_url( get_permalink( $id ) ); ?>" target="_blank">
+				<?php echo get_the_title( $id ); ?>
+				<?php if ( $start_date ): ?>
+					<span class="datetime">(<?php echo $start_date; ?>)</span>
+				<?php endif; ?>
+			</a>
 		</li>
 
 	<?php endforeach; ?>


### PR DESCRIPTION
The usage of `tribe_get_start_date` created by #159 was throwing some notices when The Events Calendar was not active. This PR will resolve that problem.

_Rel:_ moderntribe/tribe-common#92