### PR TITLE
Use actions to signal when ET has loaded/failed to load | #61156

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -104,6 +104,12 @@ class Tribe__Tickets__Main {
 			|| ( class_exists( 'Tribe__Events__Main' ) && ! version_compare( Tribe__Events__Main::VERSION, self::MIN_TEC_VERSION, '>=' ) )
 		) {
 			add_action( 'admin_notices', array( $this, 'tec_compatibility_notice' ) );
+
+			/**
+			 * Fires if Event Tickets cannot load due to compatibility or other problems.
+			 */
+			do_action( 'tribe_tickets_plugin_failed_to_load' );
+
 			return;
 		}
 
@@ -124,6 +130,11 @@ class Tribe__Tickets__Main {
 
 		// Load the Hooks on JSON_LD
 		Tribe__Tickets__JSON_LD__Order::hook();
+
+		/**
+		 * Fires once Event Tickets has completed basic setup.
+		 */
+		do_action( 'tribe_tickets_plugin_loaded' );
 	}
 
 	/**


### PR DESCRIPTION
Use actions to signal when the plugin has finished initial loading, or when it has decided to bail out of loading (such as if there are compatibility problems with The Events Calendar). These actions can then be used by dependants like Event Tickets Plus.

https://central.tri.be/issues/61156