### PR TITLE
Make get_attendees_by_transaction() public

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -491,7 +491,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		wp_mail( $to, $subject, $content, $headers, $attachments );
 	}
 
-	protected function get_attendees_by_transaction( $order_id ) {
+	public function get_attendees_by_transaction( $order_id ) {
 		$attendees = array();
 		$query     = new WP_Query( array(
 			'post_type'      => self::ATTENDEE_OBJECT,


### PR DESCRIPTION
I see no reason for this to private, but it is a very useful public function.