### PR TITLE
allow parent page to be passed and fix JS error

### DIFF
--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -321,6 +321,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			'TB_iframe' => true,
 			'width' => 410,
 			'height' => 300,
+			'parent' => 'admin.php',
 		) );
 
 		$nav = array(

--- a/src/resources/js/tickets-attendees.js
+++ b/src/resources/js/tickets-attendees.js
@@ -1,6 +1,6 @@
 jQuery( document ).ready( function( $ ) {
 
-	if ( AttendeesPointer ) {
+	if ( typeof AttendeesPointer !== 'undefined' && null !== AttendeesPointer ) {
 		options = $.extend( AttendeesPointer.options, {
 			close: function() {
 				$.post( ajaxurl, {


### PR DESCRIPTION
This keeps the Thickbox working on the Community Tickets front end as well as in the Dashboard.

See related pull request: https://github.com/moderntribe/tribe-common/pull/101

See ticket: https://central.tri.be/issues/61823