### PR TITLE
bug/63039-hide-attendees-settings-discrepancy

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Our Premium Plugins:
 = [4.2.2] unreleased =
 
 * Tweak - Add a period to the ticket header image setting [44797]
+* Fix - Fixes an issue where the 'Hide me on the public attendee list.' is visible even when the 'hide attendees list' is checked on the backend [63039]
 
 = [4.2.1] 2016-06-22 =
 * Tweak - Create a readable ID on CSV and email exports when they're available

--- a/src/views/tickets/orders-rsvp.php
+++ b/src/views/tickets/orders-rsvp.php
@@ -47,13 +47,15 @@ $attendee_groups = $view->get_event_rsvp_attendees_by_purchaser( $post_id, $user
 				?>
 			</p>
 			<?php
-				/**
-				* Inject content into the RSVP User Details block on the orders page
-				*
-				* @param array $attendee_group Attendee array
-				* @param int $post_id
-				*/
-				do_action( 'event_tickets_user_details_rsvp', $attendee_group, $post_id );
+		if ( ( class_exists( 'Tribe__Tickets_Plus__Attendees_List' ) ) && ! Tribe__Tickets_Plus__Attendees_List::is_hidden_on( get_the_ID() ) ) {
+			/**
+			 * Inject content into the RSVP User Details block on the orders page
+			 *
+			 * @param array $attendee_group Attendee array
+			 * @param int $post_id
+			 */
+			do_action( 'event_tickets_user_details_rsvp', $attendee_group, $post_id );
+		}
 				?>
 		</div>
 		<ul class="tribe-rsvp-list tribe-list">


### PR DESCRIPTION
https://central.tri.be/issues/63039

Leaving the conditional in `orders-rsvp.php` to continue discussion from previous PR.  

The action `event_tickets_user_details_rsvp` is calling a template part from Tickets Plus that should only be visible if 
1) Tickets plus is active and/or 
2) the attendee list is hidden box is NOT checked in the admin area.