### PR TITLE
Stop using the GLOB_BRACE flag

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -226,7 +226,7 @@ class Tribe__Tickets__Main {
 		require_once $this->plugin_path . 'src/template-tags/tickets.php';
 
 		// deprecated classes are registered in a class to path fashion
-		foreach ( glob( $this->plugin_path . '{common/src,src}/deprecated/*.php', GLOB_BRACE ) as $file ) {
+		foreach ( array_merge( glob( $this->plugin_path . 'common/src/deprecated/*.php' ), glob( $this->plugin_path . 'src/deprecated/*.php' ) ) as $file ) {
 			$class_name = str_replace( '.php', '', basename( $file ) );
 			$autoloader->register_class( $class_name, $file );
 		}


### PR DESCRIPTION
The `GLOB_BRACE` flag for `glob()` is not available on all systems. Most notably it's not supported on Solaris and Alpine (a quite popular lightweight linux distribution used mostly for running docker containers). On this PR I propose a way of achieving the same result which doesn't use such flag and hence improves compatibility.

Related: https://github.com/moderntribe/the-events-calendar/pull/750

See: https://central.tri.be/issues/63172