### PR TITLE
Bugfixes for moving tickets/ticket types

### DIFF
--- a/src/Tribe/Admin/Move_Ticket_Types.php
+++ b/src/Tribe/Admin/Move_Ticket_Types.php
@@ -2,8 +2,7 @@
 class Tribe__Tickets__Admin__Move_Ticket_Types extends Tribe__Tickets__Admin__Move_Tickets {
 	protected $dialog_name = 'move_ticket_types';
 
-	public function __construct() {
-		parent::__construct();
+	public function setup() {
 		add_action( 'wp_ajax_move_ticket_types_post_list', array( $this, 'update_post_choices' ) );
 		add_action( 'wp_ajax_move_ticket_type', array( $this, 'move_ticket_type_requests' ) );
 		add_action( 'tribe_tickets_ticket_type_moved', array( $this, 'notify_event_attendees' ), 100, 3 );

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -15,7 +15,7 @@ class Tribe__Tickets__Admin__Move_Tickets {
 	 */
 	protected $attendees = array();
 
-	public function __construct() {
+	public function setup() {
 		$this->ticket_history();
 
 		add_action( 'admin_init', array( $this, 'dialog' ) );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -436,6 +436,7 @@ class Tribe__Tickets__Main {
 	public function move_tickets() {
 		if ( empty( $this->move_tickets ) ) {
 			$this->move_tickets = new Tribe__Tickets__Admin__Move_Tickets;
+			$this->move_tickets->setup();
 		}
 
 		return $this->move_tickets;
@@ -447,6 +448,7 @@ class Tribe__Tickets__Main {
 	public function move_ticket_types() {
 		if ( empty( $this->move_ticket_types ) ) {
 			$this->move_ticket_types = new Tribe__Tickets__Admin__Move_Ticket_Types;
+			$this->move_ticket_types->setup();
 		}
 
 		return $this->move_ticket_types;


### PR DESCRIPTION
Separates out the process of adding actions/filters from object construction, so we can still inherit methods but don't double up on callbacks unnecessarily.

[C#61724](https://central.tri.be/issues/61724)