### PR TITLE
fix/64778-rsvp-mail-apostrophe-support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -191,6 +191,10 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [4.2.5] unreleased =
+
+* Fix - Garbled site title in RSVP confirmation email [64778]
+
 = [4.2.4] 2016-08-03 =
 
 * Tweak - Changed "Event Add-Ons" to load faster [64286]

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -570,7 +570,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$attachments = apply_filters( 'tribe_rsvp_email_attachments', array() );
 		$to          = apply_filters( 'tribe_rsvp_email_recipient', $to );
 		$subject     = apply_filters( 'tribe_rsvp_email_subject',
-			sprintf( __( 'Your tickets from %s', 'event-tickets' ), get_bloginfo( 'name' ) ) );
+			sprintf( __( 'Your tickets from %s', 'event-tickets' ), stripslashes_deep( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) ) ) );
 
 		wp_mail( $to, $subject, $content, $headers, $attachments );
 	}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/64778

Parse the site title before adding it as a subject to the RSVP email confirmation.				