### PR TITLE
Fix targeting of ticket deletion confirmation

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -269,7 +269,6 @@ class Tribe__Tickets__Main {
 		// Hook to oembeds
 		add_action( 'tribe_events_embed_after_the_cost_value', array( $this, 'inject_buy_button_into_oembed' ) );
 		add_action( 'embed_head', array( $this, 'embed_head' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_ticket_deletion_alert') );
 
 		// Attendee screen enhancements
 		add_action( 'tribe_tickets_attendees_page_inside', array( $this, 'setup_attendance_totals' ), 20 );
@@ -631,27 +630,4 @@ class Tribe__Tickets__Main {
 		<?php
 	}
 
-	/**
-	 * Enqueue and localize script for use in ticket delete alert dialogue
-	 *
-	 * @since 4.3
-	 */
-	public function add_ticket_deletion_alert() {
-		$deletion_data = array(
-			'confirm_alert' => __( 'Are you sure you want to delete this ticket?', 'event-tickets' ),
-		);
-		tribe_asset(
-			self::instance(),
-			'tribe_tickets_ticket_delete_alert',
-			'ticket-delete-alert.js',
-			array( 'jquery' ),
-			'admin_enqueue_scripts',
-			array(
-				'localize' => array(
-					'name' => 'tribe_ticket_notices',
-					'data' => $deletion_data,
-				),
-			)
-		);
-	}
 }

--- a/src/Tribe/Metabox.php
+++ b/src/Tribe/Metabox.php
@@ -78,6 +78,10 @@ class Tribe__Tickets__Metabox {
 		wp_enqueue_style( 'event-tickets', $resources_url .'/css/tickets.css', array(), Tribe__Tickets__Main::instance()->css_version() );
 		wp_enqueue_script( 'event-tickets', $resources_url .'/js/tickets.js', array( 'jquery-ui-datepicker' ), Tribe__Tickets__Main::instance()->js_version(), true );
 
+		wp_localize_script( 'event-tickets', 'tribe_ticket_notices', array(
+			'confirm_alert' => __( 'Are you sure you want to delete this ticket?', 'event-tickets' ),
+		) );
+
 		$upload_header_data = array(
 			'title'  => esc_html__( 'Ticket header image', 'event-tickets' ),
 			'button' => esc_html__( 'Set as ticket header', 'event-tickets' ),

--- a/src/resources/js/ticket-delete-alert.js
+++ b/src/resources/js/ticket-delete-alert.js
@@ -1,6 +1,0 @@
-(function( window, $ ) {
-	'use strict';
-	$( '.ticket_list' ).on( 'click', '.ticket_delete', function() {
-		return confirm( tribe_ticket_notices.confirm_alert );
-	});
-})( window, jQuery );

--- a/src/resources/js/ticket-delete-alert.min.js
+++ b/src/resources/js/ticket-delete-alert.min.js
@@ -1,1 +1,0 @@
-!function(t,i){"use strict";i(".ticket_list").on("click",".ticket_delete",function(){return confirm(tribe_ticket_notices.confirm_alert)})}(window,jQuery);

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -225,6 +225,11 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			}
 		} );
 
+		// prompt user before deleting a ticket
+		$tribe_tickets.on( 'click', '.ticket_delete', function() {
+			return confirm( tribe_ticket_notices.confirm_alert );
+		} );
+
 		if ( $event_pickers.length ) {
 			startofweek = $event_pickers.data( 'startofweek' );
 		}


### PR DESCRIPTION
Additionally, I've moved the contents of the ticket alert JS file into the larger tickets.js file to:

1. Avoid extra JS files
2. Avoid having the file (and event) executed on every admin page - we only need it for the meta box

See: https://central.tri.be/issues/46623