### PR TITLE
Action for 3rd Party plugins

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -408,7 +408,14 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		}
 
 		$has_tickets = $event_id = false;
-
+		/**
+		* RSVP specific action fired just before a RSVP-driven attendee ticket for an event is generated
+		* 
+		* @param $event_id ID of event
+		* @param $_POST post paremeters comes from RSVP Form
+		*/
+		do_action( 'tribe_tickets_rsvp_before_tickets_generated', $event_id, $_POST);
+		
 		$order_id = md5( time() . rand() );
 
 		$attendee_email = empty( $_POST['attendee']['email'] ) ? null : sanitize_email( $_POST['attendee']['email'] );


### PR DESCRIPTION
I added it for 3rd party plugins can hook to this action.
I customized error_handler to achieve what i need, but should consider to create a global error handler on Main class, so internally or 3rd party plugins can throw that specific error. 
So IMO it should be like this

do_action( 'tribe_tickets_rsvp_before_tickets_generated', $event_id, $_POST);
/*check tribe_tickets_global_error after this line and redirect to page if there is any error*/