### PR TITLE
Don't allow recurring events safeguard to impact non-events | #45008

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,8 @@ Our Premium Plugins:
 
 = [4.2.7] TBD =
 
+* Fix - Stop logic for dealing with recurring events from impacting other post types [45008]
+
 = [4.2.6] 2016-08-31 =
 
 * Add - Utilize new tribe_is_event_past() conditional to display better messaging when tickets are not available (Thank you to @Jonathan here for reporting this in the forums.)

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -824,7 +824,8 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		$post = $GLOBALS['post'];
 
-		if ( ! empty( $post->post_parent ) ) {
+		// For recurring events (child instances only), default to loading tickets for the parent event
+		if ( ! empty( $post->post_parent ) && function_exists( 'tribe_is_recurring_event' ) && tribe_is_recurring_event( $post->ID ) ) {
 			$post = get_post( $post->post_parent );
 		}
 


### PR DESCRIPTION
In the case of recurring events (child posts) we deliberately load the parent event's tickets - however this same logic should not apply to other post types such as pages.

[#45008](https://central.tri.be/issues/45008)