### PR TITLE
Revise "tickets unavailable" messaging, prevent duplicates when multiple ticket providers are active

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,6 +194,7 @@ Our Premium Plugins:
 = [4.2.7] TBD =
 
 * Fix - Stop logic for dealing with recurring events from impacting other post types [45008]
+* Tweak - Share "tickets unavailable" messaging across ticketing providers to prevent unnecessary duplication [65687]
 
 = [4.2.6] 2016-08-31 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -70,6 +70,22 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		private $parentUrl;
 
+		/**
+		 * Records batches of tickets that are currently unavailable (used for
+		 * displaying the correct "tickets are unavailable" message).
+		 *
+		 * @var array
+		 */
+		protected static $currently_unavailable_tickets = array();
+
+		/**
+		 * Records posts for which tickets *are* available (used to determine if
+		 * a "tickets are unavailable" message should even display).
+		 *
+		 * @var array
+		 */
+		protected static $posts_with_available_tickets = array();
+
 		// start API Definitions
 		// Child classes must implement all these functions / properties
 
@@ -319,7 +335,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			// Front end
 			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'front_end_tickets_form' ), 5 );
-			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ) );
+			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'show_tickets_unavailable_message' ), 6 );
+			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ), 11 );
+			add_filter( 'the_content', array( $this, 'show_tickets_unavailable_message_in_content' ), 12 );
 
 			// Ensure ticket prices and event costs are linked
 			add_filter( 'tribe_events_event_costs', array( $this, 'get_ticket_prices' ), 10, 2 );
@@ -1304,6 +1322,97 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			return $message;
 		}
+
+		/**
+		 * Indicates that, from an individual ticket provider's perspective, the only tickets for the
+		 * event are currently unavailable and unless a different ticket provider reports differently
+		 * the "tickets unavailable" message should be displayed.
+		 *
+		 * @param array $tickets
+		 * @param int $post_id = null (defaults to the current post)
+		 */
+		public function maybe_show_tickets_unavailable_message( $tickets, $post_id = null ) {
+			if ( null === $post_id ) {
+				$post_id = get_the_ID();
+			}
+
+			$existing_tickets = ! empty( self::$currently_unavailable_tickets[ (int) $post_id ] )
+				? self::$currently_unavailable_tickets[ (int) $post_id ]
+				: array();
+
+			self::$currently_unavailable_tickets[ (int) $post_id ] = array_merge( $existing_tickets, $tickets );
+		}
+
+		/**
+		 * Indicates that, from an individual ticket provider's perspective, the event does have some
+		 * currently available tickets and so the "tickets unavailable" message should probably not
+		 * be displayed.
+		 *
+		 * @param null $post_id
+		 */
+		public function do_not_show_tickets_unavailable_message( $post_id = null ) {
+			if ( null === $post_id ) {
+				$post_id = get_the_ID();
+			}
+
+			self::$posts_with_available_tickets[] = (int) $post_id;
+		}
+
+		/**
+		 * If appropriate, displayed a "tickets unavailable" message.
+		 */
+		public function show_tickets_unavailable_message() {
+			$post_id = (int) get_the_ID();
+
+			// So long as at least one ticket provider has tickets available, do not show an unavailability message
+			if ( in_array( $post_id, self::$posts_with_available_tickets ) ) {
+				return;
+			}
+
+			// Bail if no ticket providers reported that all their tickets for the event were unavailable
+			if ( empty( self::$currently_unavailable_tickets[ $post_id ] ) ) {
+				return;
+			}
+
+			// Prepare the message
+			$message = '<div class="tickets-unavailable">'
+				. $this->get_tickets_unavailable_message( self::$currently_unavailable_tickets[ $post_id ] )
+				. '</div>';
+
+			/**
+			 * Sets the tickets unavailable message.
+			 *
+			 * @param string $message
+			 * @param int    $post_id
+			 * @param array  $unavailable_event_tickets
+			 */
+			echo apply_filters( 'tribe_tickets_unavailable_message', $message, $post_id, self::$currently_unavailable_tickets[ $post_id ] );
+
+			// Remove the record of unavailable tickets to avoid duplicate messages being rendered for the same event
+			unset( self::$currently_unavailable_tickets[ $post_id ] );
+		}
+
+		/**
+		 * Takes care of adding a "tickets unavailable" message by injecting it into the post content
+		 * (where the template settings require such an approach).
+		 *
+		 * @param string $content
+		 *
+		 * @return string
+		 */
+		public function show_tickets_unavailable_message_in_content( $content ) {
+			if ( ! $this->should_inject_ticket_form_into_post_content() ) {
+				return $content;
+			}
+
+			ob_start();
+			$this->show_tickets_unavailable_message();
+			$form = ob_get_clean();
+
+			$content .= $form;
+
+			return $content;
+		}
 		// end Helpers
 
 		/**
@@ -1324,33 +1433,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		public function front_end_tickets_form_in_content( $content ) {
-			global $post;
-
-			// Prevents firing more then it needs too outside of the loop
-			$in_the_loop = isset( $GLOBALS['wp_query']->in_the_loop ) && $GLOBALS['wp_query']->in_the_loop;
-
-			if ( is_admin() || ! $in_the_loop ) {
-				return $content;
-			}
-
-			// if this isn't a post for some reason, bail
-			if ( ! $post instanceof WP_Post ) {
-				return $content;
-			}
-
-			// if this isn't a supported post type, bail
-			if ( ! in_array( $post->post_type, Tribe__Tickets__Main::instance()->post_types() ) ) {
-				return $content;
-			}
-
-			// if this is a tribe_events post, let's bail because those post types are handled with a different hook
-			if ( 'tribe_events' === $post->post_type ) {
-				return $content;
-			}
-
-			// if there aren't any tickets, bail
-			$tickets = $this->get_tickets( $post->ID );
-			if ( empty( $tickets ) ) {
+			if ( ! $this->should_inject_ticket_form_into_post_content() ) {
 				return $content;
 			}
 
@@ -1361,6 +1444,46 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$content .= $form;
 
 			return $content;
+		}
+
+		/**
+		 * Determines if this is a suitable opportunity to inject ticket form content into a post.
+		 * Expects to run within "the_content".
+		 *
+		 * @return bool
+		 */
+		protected function should_inject_ticket_form_into_post_content() {
+			global $post;
+
+			// Prevents firing more then it needs too outside of the loop
+			$in_the_loop = isset( $GLOBALS['wp_query']->in_the_loop ) && $GLOBALS['wp_query']->in_the_loop;
+
+			if ( is_admin() || ! $in_the_loop ) {
+				return false;
+			}
+
+			// if this isn't a post for some reason, bail
+			if ( ! $post instanceof WP_Post ) {
+				return false;
+			}
+
+			// if this isn't a supported post type, bail
+			if ( ! in_array( $post->post_type, Tribe__Tickets__Main::instance()->post_types() ) ) {
+				return false;
+			}
+
+			// if this is a tribe_events post, let's bail because those post types are handled with a different hook
+			if ( 'tribe_events' === $post->post_type ) {
+				return false;
+			}
+
+			// if there aren't any tickets, bail
+			$tickets = $this->get_tickets( $post->ID );
+			if ( empty( $tickets ) ) {
+				return false;
+			}
+
+			return true;
 		}
 
 		/**

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -2,7 +2,7 @@
 /**
  * This template renders the RSVP ticket form
  *
- * @version 4.2
+ * @version 4.2.7
  *
  * @var bool $must_login
  */
@@ -30,7 +30,7 @@ $now = current_time( 'timestamp' );
 		}//end if
 		?>
 		<div class="tribe-rsvp-message tribe-rsvp-message-error tribe-rsvp-message-confirmation-error" style="display:none;">
-			<?php echo esc_html_e( 'Please fill in the RSVP confirmation name and email fields.', 'event-tickets' ); ?>
+			<?php esc_html_e( 'Please fill in the RSVP confirmation name and email fields.', 'event-tickets' ); ?>
 		</div>
 	</div>
 	<table width="100%" class="tribe-events-tickets tribe-events-tickets-rsvp">
@@ -162,17 +162,13 @@ $now = current_time( 'timestamp' );
 $content = ob_get_clean();
 if ( $is_there_any_product ) {
 	echo $content;
+
+	// If we have rendered tickets there is generally no need to display a 'tickets unavailable' message
+	// for this post
+	$this->do_not_show_tickets_unavailable_message();
 } else {
-	$unavailability_message = $this->get_tickets_unavailable_message( $tickets );
-
-	// if there isn't an unavailability message, bail
-	if ( ! $unavailability_message ) {
-		return;
-	}
-
-	?>
-	<div class="tickets-unavailable">
-		<?php echo esc_html( $unavailability_message ); ?>
-	</div>
-	<?php
+	// Indicate that we did not render any tickets, so a 'tickets unavailable' message may be
+	// appropriate (depending on whether other ticket providers are active and have a similar
+	// result)
+	$this->maybe_show_tickets_unavailable_message( $tickets );
 }


### PR DESCRIPTION
Introduce a system for displaying "tickets unavailable" messages that can be shared by multiple active ticket providers. We should only ever see one "tickets are unavailable" message per event.

[#65687](https://central.tri.be/issues/65687)