### PR TITLE
Set current screen to avoid notices/warnings | spotfix

### DIFF
--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -73,6 +73,7 @@ class Tribe__Tickets__Admin__Move_Tickets {
 			'multiple_providers' => $this->has_multiple_providers,
 		) );
 
+		set_current_screen();
 		define( 'IFRAME_REQUEST', true );
 		$this->dialog_assets();
 		iframe_header( $template_vars[ 'title'] );


### PR DESCRIPTION
The move tickets/ticket type dialog is generated quite early on in the request and the `$current_screen` global is not yet set. This creates some problems which we can resolve by setting it ourselves.