### PR TITLE
Event Tickets should let tribe-common handle its own deprecated classes

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -241,7 +241,7 @@ class Tribe__Tickets__Main {
 		require_once $this->plugin_path . 'src/template-tags/tickets.php';
 
 		// deprecated classes are registered in a class to path fashion
-		foreach ( array_merge( glob( $this->plugin_path . 'common/src/deprecated/*.php' ), glob( $this->plugin_path . 'src/deprecated/*.php' ) ) as $file ) {
+		foreach ( glob( $this->plugin_path . 'src/deprecated/*.php' ) as $file ) {
 			$class_name = str_replace( '.php', '', basename( $file ) );
 			$autoloader->register_class( $class_name, $file );
 		}


### PR DESCRIPTION
Builds on tribe-common pr 210: moves the task of loading tribe-common's deprecated classes from the dependent plugin to tribe-common itself.

https://github.com/moderntribe/tribe-common/pull/210
https://central.tri.be/issues/66872