### PR TITLE
Fix/61992 bulk row actions

### DIFF
--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -501,18 +501,6 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 				do_action( 'tribe_events_tickets_attendees_table_process_bulk_action', $this->current_action() );
 				break;
 		}
-
-		// With the bulk/individual action handled, let's redirect back to the attendee list
-		// to avoid resubmissions etc
-		$attendee_list_url = add_query_arg( array(
-				'event_id' => absint( $_GET[ 'event_id' ] ),
-				'page'     => 'tickets-attendees'
-			),
-			get_admin_url( null, 'post.php' )
-		);
-
-		wp_safe_redirect( $attendee_list_url );
-		exit();
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -856,6 +856,12 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		if ( empty( $event_id ) ) {
 			$event_id = get_post_meta( $ticket_id, self::ATTENDEE_EVENT_KEY, true );
 		}
+
+		// Additional check (in case we were passed an invalid ticket ID and still can't determine the event)
+		if ( empty( $event_id ) ) {
+			return false;
+		}
+
 		$product_id = get_post_meta( $ticket_id, self::ATTENDEE_PRODUCT_KEY, true );
 
 		// Decrement the sales figure


### PR DESCRIPTION
Removes attempt to redirect after processing bulk/row actions within the attendee table (it's too late in the request to do this).

Additionally, adds a safeguard in the RSVP provider to avoid notices if an invalid or deleted ticket ID is passed to the delete handler.

https://central.tri.be/issues/61992