### PR TITLE
Optionally adjust total_sales following deletion of an RSVP ticket/attendee

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -858,9 +858,16 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		}
 		$product_id = get_post_meta( $ticket_id, self::ATTENDEE_PRODUCT_KEY, true );
 
-		// Decrement the sales figure
-		$sales = (int) get_post_meta( $product_id, 'total_sales', true );
-		update_post_meta( $product_id, 'total_sales', -- $sales );
+		// For attendees whose status ('going' or 'not going') for whom a stock adjustment is required?
+		$rsvp_options    = $this->tickets_view->get_rsvp_options( null, false );
+		$attendee_status = get_post_meta( $ticket_id, self::ATTENDEE_RSVP_KEY, true );
+		$adjustment      = absint( $rsvp_options[ $attendee_status ]['decrease_stock_by'] );
+
+		// Adjust the sales figure if required
+		if ( $adjustment ) {
+			$sales = (int) get_post_meta( $product_id, 'total_sales', true );
+			update_post_meta( $product_id, 'total_sales', $sales + $adjustment );
+		}
 
 		//Store name so we can still show it in the attendee list
 		$attendees      = $this->get_attendees( $event_id );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -862,7 +862,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$rsvp_options    = $this->tickets_view->get_rsvp_options( null, false );
 		$attendee_status = get_post_meta( $ticket_id, self::ATTENDEE_RSVP_KEY, true );
 
-		$adjustment = isset( $rsvp_options[ $attendee_status ] )
+		$adjustment = isset( $rsvp_options[ $attendee_status ]['decrease_stock_by']  )
 			? absint( $rsvp_options[ $attendee_status ]['decrease_stock_by'] )
 			: false;
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -866,7 +866,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		// Adjust the sales figure if required
 		if ( $adjustment ) {
 			$sales = (int) get_post_meta( $product_id, 'total_sales', true );
-			update_post_meta( $product_id, 'total_sales', $sales + $adjustment );
+			update_post_meta( $product_id, 'total_sales', $sales - $adjustment );
 		}
 
 		//Store name so we can still show it in the attendee list

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -861,7 +861,10 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		// For attendees whose status ('going' or 'not going') for whom a stock adjustment is required?
 		$rsvp_options    = $this->tickets_view->get_rsvp_options( null, false );
 		$attendee_status = get_post_meta( $ticket_id, self::ATTENDEE_RSVP_KEY, true );
-		$adjustment      = absint( $rsvp_options[ $attendee_status ]['decrease_stock_by'] );
+
+		$adjustment = isset( $rsvp_options[ $attendee_status ] )
+			? absint( $rsvp_options[ $attendee_status ]['decrease_stock_by'] )
+			: false;
 
 		// Adjust the sales figure if required
 		if ( $adjustment ) {


### PR DESCRIPTION
Previous behaviour: `total_sales` was being reduced by one every time an attendee was deleted (this was done to re-stock RSVP tickets). New behaviour: it is only reduced if configured to do so - by default this means if the deleted attendee was 'Going' we re-stock, but not otherwise.

https://central.tri.be/issues/61992
https://central.tri.be/issues/64669