### PR TITLE
Do not calculate attendance totals until after the table is prepared …

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -307,7 +307,7 @@ class Tribe__Tickets__Main {
 		add_action( 'embed_head', array( $this, 'embed_head' ) );
 
 		// Attendee screen enhancements
-		add_action( 'tribe_tickets_attendees_page_inside', array( $this, 'setup_attendance_totals' ), 20 );
+		add_action( 'tribe_events_tickets_attendees_event_details_top', array( $this, 'setup_attendance_totals' ), 20 );
 
 		// CSV Import options
 		if ( class_exists( 'Tribe__Events__Main' ) ) {

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -187,7 +187,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		add_filter( 'post_updated_messages', array( $this, 'updated_messages' ) );
 		add_action( 'rsvp_checkin', array( $this, 'purge_attendees_transient' ) );
 		add_action( 'rsvp_uncheckin', array( $this, 'purge_attendees_transient' ) );
-		add_action( 'tribe_tickets_attendees_page_inside', array( $this, 'setup_attendance_totals' ) );
+		add_action( 'tribe_events_tickets_attendees_event_details_top', array( $this, 'setup_attendance_totals' ) );
 	}
 
 	/**


### PR DESCRIPTION
Moves calculation of event attendance to a later point in time.

This is required because code handling things such as check-in and deletion lives in the attendee list table class, which doesn't run until right before the table is rendered.

https://central.tri.be/issues/61992