### PR TITLE
Remove unused var | spotfix

### DIFF
--- a/src/Tribe/RSVP/Attendance_Totals.php
+++ b/src/Tribe/RSVP/Attendance_Totals.php
@@ -47,7 +47,6 @@ class Tribe__Tickets__RSVP__Attendance_Totals extends Tribe__Tickets__Abstract_A
 				<li> <strong>$total_rsvps_label</strong> $total_rsvps </li>
 				<li> <strong>$going_label</strong> $going </li>
 				<li> <strong>$not_going_label</strong> $not_going </li>
-				$attendance_lines_after
 			</ul>
 		";
 


### PR DESCRIPTION
Removes unused var. 

Discussion [here](https://github.com/moderntribe/event-tickets/pull/259#discussion_r80913711) and [here](https://tribe.slack.com/archives/products-dev/p1475069038003538) (basically - safe to remove).