### PR TITLE
Added ticket form location settings

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -361,7 +361,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			// Front end
 			$ticket_form_hook = $this->get_ticket_form_hook();
-			add_action( $ticket_form_hook, array( $this, 'front_end_tickets_form' ), 5 );
+			if ( ! empty( $ticket_form_hook ) ) {
+				add_action( $ticket_form_hook, array( $this, 'front_end_tickets_form' ), 5 );
+			}
 			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'show_tickets_unavailable_message' ), 6 );
 			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ), 11 );
 			add_filter( 'the_content', array( $this, 'show_tickets_unavailable_message_in_content' ), 12 );
@@ -1621,10 +1623,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				 *
 				 * While this setting can be handled using the Events > Settings > Tickets > "Location of RSVP form"
 				 * setting this filter allows developers to override the general setting in particular cases.
+				 * Returning an empty value here will prevent the ticket form from printing on the page.
 				 *
-				 * @param string $ticket_form_hook The set action tag to print front-end RSVP tickets form.
+				 * @param string                  $ticket_form_hook The set action tag to print front-end RSVP tickets form.
+				 * @param Tribe__Tickets__Tickets $this             The current instance of the class that's hooking its front-end ticket form.
 				 */
-				$ticket_form_hook = apply_filters( 'tribe_tickets_rsvp_tickets_form_hook', $ticket_form_hook );
+				$ticket_form_hook = apply_filters( 'tribe_tickets_rsvp_tickets_form_hook', $ticket_form_hook, $this );
 			} else {
 				$ticket_form_hook = Tribe__Settings_Manager::get_option( 'ticket-commerce-form-location',
 					'tribe_events_single_event_after_the_meta' );
@@ -1634,10 +1638,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				 *
 				 * While this setting can be handled using the Events > Settings > Tickets > "Location of Tickets form"
 				 * setting this filter allows developers to override the general setting in particular cases.
+				 * Returning an empty value here will prevent the ticket form from printing on the page.
 				 *
-				 * @param string $ticket_form_hook The set action tag to print front-end commerce tickets form.
+				 * @param string                  $ticket_form_hook The set action tag to print front-end commerce tickets form.
+				 * @param Tribe__Tickets__Tickets $this             The current instance of the class that's hooking its front-end ticket form.
 				 */
-				$ticket_form_hook = apply_filters( 'tribe_tickets_commerce_tickets_form_hook', $ticket_form_hook );
+				$ticket_form_hook = apply_filters( 'tribe_tickets_commerce_tickets_form_hook', $ticket_form_hook, $this );
 			}
 
 			return $ticket_form_hook;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -360,7 +360,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			add_action( 'wp_ajax_tribe-ticket-uncheckin-' . $this->className, array( $this, 'ajax_handler_attendee_uncheckin' ) );
 
 			// Front end
-			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'front_end_tickets_form' ), 5 );
+			$ticket_form_hook = $this->get_ticket_form_hook();
+			add_action( $ticket_form_hook, array( $this, 'front_end_tickets_form' ), 5 );
 			add_action( 'tribe_events_single_event_after_the_meta', array( $this, 'show_tickets_unavailable_message' ), 6 );
 			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ), 11 );
 			add_filter( 'the_content', array( $this, 'show_tickets_unavailable_message_in_content' ), 12 );
@@ -1600,6 +1601,46 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$post_transient = Tribe__Post_Transient::instance();
 				$post_transient->delete( $_POST['event_ID'], self::ATTENDEES_CACHE );
 			}
+		}
+
+		/**
+		 * Returns the action tag that should be used to print the front-end ticket form.
+		 *
+		 * This value is set in the Events > Settings > Tickets tab and is distinct between RSVP
+		 * tickets and commerce provided tickets.
+		 *
+		 * @return string
+		 */
+		protected function get_ticket_form_hook() {
+			if ( is_a( $this, 'Tribe__Tickets__RSVP' ) ) {
+				$ticket_form_hook = Tribe__Settings_Manager::get_option( 'ticket-rsvp-form-location',
+					'tribe_events_single_event_after_the_meta' );
+
+				/**
+				 * Filters the position of the RSVP tickets form.
+				 *
+				 * While this setting can be handled using the Events > Settings > Tickets > "Location of RSVP form"
+				 * setting this filter allows developers to override the general setting in particular cases.
+				 *
+				 * @param string $ticket_form_hook The set action tag to print front-end RSVP tickets form.
+				 */
+				$ticket_form_hook = apply_filters( 'tribe_tickets_rsvp_tickets_form_hook', $ticket_form_hook );
+			} else {
+				$ticket_form_hook = Tribe__Settings_Manager::get_option( 'ticket-commerce-form-location',
+					'tribe_events_single_event_after_the_meta' );
+
+				/**
+				 * Filters the position of the commerce-provided tickets form.
+				 *
+				 * While this setting can be handled using the Events > Settings > Tickets > "Location of Tickets form"
+				 * setting this filter allows developers to override the general setting in particular cases.
+				 *
+				 * @param string $ticket_form_hook The set action tag to print front-end commerce tickets form.
+				 */
+				$ticket_form_hook = apply_filters( 'tribe_tickets_commerce_tickets_form_hook', $ticket_form_hook );
+			}
+
+			return $ticket_form_hook;
 		}
 	}
 }

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -46,23 +46,23 @@ $ticket_form_location_options = array(
 );
 
 $tickets_fields = array(
-	'tribe-form-content-start'                   => array(
+	'tribe-form-content-start' => array(
 		'type' => 'html',
 		'html' => '<div class="tribe-settings-form-wrap">',
 	),
-	'tickets-title'                              => array(
+	'tickets-title' => array(
 		'type' => 'html',
 		'html' => '<h3>' . esc_html__( 'Ticket Settings', 'event-tickets' ) . '</h3>',
 	),
-	'ticket-enabled-post-types'                  => array(
-		'type'            => 'checkbox_list',
-		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
+	'ticket-enabled-post-types' => array(
+		'type'         => 'checkbox_list',
+		'label'        => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
 		// only set the default to tribe_events if the ticket-endabled-post-types index has never been saved
-		'default'         => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
-		'options'         => $all_post_types,
-		'can_be_empty'    => false,
+		'default'      => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
+		'options'      => $all_post_types,
+		'can_be_empty' => false,
 	),
-	'ticket-rsvp-form-location'     => array(
+	'ticket-rsvp-form-location' => array(
 		'type'            => 'dropdown',
 		'label'           => esc_html__( 'Location of RSVP form', 'event-tickets' ),
 		'options'         => $ticket_form_location_options,
@@ -82,20 +82,20 @@ $tickets_fields = array(
 		'type' => 'html',
 		'html' => '<h3>' . __( 'Login requirements', 'event-tickets' ) . '</h3>',
 	),
-	'ticket-authentication-requirements-advice'  => array(
+	'ticket-authentication-requirements-advice' => array(
 		'type' => 'html',
 		'html' => '<p>'
 		          . sprintf( __( 'You can require that users log into your site before they are able to RSVP (or buy tickets). Please review your WordPress Membership option (via the General Settings admin screen) before adjusting this setting.',
 				'event-tickets' ), '<a href="' . get_admin_url( null, 'options-general.php' ) . '" target="_blank">', '</a>' )
 		          . '</p>',
 	),
-	'ticket-authentication-requirements'         => array(
+	'ticket-authentication-requirements' => array(
 		'type'            => 'checkbox_list',
 		'options'         => $ticket_addons,
 		'validation_type' => 'options_multi',
 		'can_be_empty'    => true,
 	),
-	'tribe-form-content-end'                     => array(
+	'tribe-form-content-end' => array(
 		'type' => 'html',
 		'html' => '</div>',
 	),

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Tribe__Tickets_Plus__Main' ) ) {
  */
 $tickets_fields = apply_filters( 'tribe_tickets_settings_tab_fields', $tickets_fields );
 
-$tickets_tab   = array(
+$tickets_tab = array(
 	'priority' => 20,
 	'fields' => $tickets_fields,
 );

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -37,50 +37,88 @@ $ticket_addons = apply_filters( 'tribe_tickets_settings_systems_supporting_login
 	'event-tickets_rsvp' => __( 'Require users to log in before they RSVP', 'event-tickets' ),
 ) );
 
-$tickets_tab = array(
-	'priority' => 20,
-	'fields' => apply_filters(
-		'tribe_tickets_settings_tab_fields',
-		array(
-			'tribe-form-content-start' => array(
-				'type' => 'html',
-				'html' => '<div class="tribe-settings-form-wrap">',
-			),
-			'tickets-title' => array(
-				'type' => 'html',
-				'html' => '<h3>' . esc_html__( 'Ticket Settings', 'event-tickets' ) . '</h3>',
-			),
-			'ticket-enabled-post-types' => array(
-				'type' => 'checkbox_list',
-				'label' => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
-				// only set the default to tribe_events if the ticket-endabled-post-types index has never been saved
-				'default' => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
-				'options' => $all_post_types,
-				'validation_type' => 'options_multi',
-				'can_be_empty' => true,
-			),
-			'ticket-authentication-requirements-heading' => array(
-				'type' => 'html',
-				'html' => '<h3>' . __( 'Login requirements', 'event-tickets' ) . '</h3>',
-			),
-			'ticket-authentication-requirements-advice' => array(
-				'type' => 'html',
-				'html' => '<p>' . sprintf(
-						__( 'You can require that users log into your site before they are able to RSVP (or buy tickets). Please review your WordPress Membership option (via the General Settings admin screen) before adjusting this setting.', 'event-tickets' ),
-						'<a href="' . get_admin_url( null, 'options-general.php' ) . '" target="_blank">',
-						'</a>'
-					) . '</p>',
-			),
-			'ticket-authentication-requirements' => array(
-				'type' => 'checkbox_list',
-				'options' => $ticket_addons,
-				'validation_type' => 'options_multi',
-				'can_be_empty' => true,
-			),
-			'tribe-form-content-end' => array(
-				'type' => 'html',
-				'html' => '</div>',
-			),
-		)
+
+$ticket_form_location_options = array(
+	'tribe_events_single_event_after_the_meta'     => __( 'Below the event details [default]', 'event-tickets' ),
+	'tribe_events_single_event_before_the_meta'    => __( 'Above the event details', 'event-tickets' ),
+	'tribe_events_single_event_after_the_content'  => __( 'Below the event description', 'event-tickets' ),
+	'tribe_events_single_event_before_the_content' => __( 'Above the event description', 'event-tickets' ),
+);
+
+$tickets_fields = array(
+	'tribe-form-content-start'                   => array(
+		'type' => 'html',
+		'html' => '<div class="tribe-settings-form-wrap">',
 	),
+	'tickets-title'                              => array(
+		'type' => 'html',
+		'html' => '<h3>' . esc_html__( 'Ticket Settings', 'event-tickets' ) . '</h3>',
+	),
+	'ticket-enabled-post-types'                  => array(
+		'type'            => 'checkbox_list',
+		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
+		// only set the default to tribe_events if the ticket-endabled-post-types index has never been saved
+		'default'         => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
+		'options'         => $all_post_types,
+		'can_be_empty'    => false,
+	),
+	'ticket-rsvp-form-location'     => array(
+		'type'            => 'dropdown',
+		'label'           => esc_html__( 'Location of RSVP form', 'event-tickets' ),
+		'options'         => $ticket_form_location_options,
+		'validation_type' => 'options',
+		'parent_option'   => Tribe__Events__Main::OPTIONNAME,
+		'default'         => reset( $ticket_form_location_options ),
+	),
+	'ticket-commerce-form-location' => array(
+		'type'            => 'dropdown',
+		'label'           => esc_html__( 'Location of Tickets form', 'event-tickets' ),
+		'options'         => $ticket_form_location_options,
+		'validation_type' => 'options',
+		'parent_option'   => Tribe__Events__Main::OPTIONNAME,
+		'default'         => reset( $ticket_form_location_options ),
+	),
+	'ticket-authentication-requirements-heading' => array(
+		'type' => 'html',
+		'html' => '<h3>' . __( 'Login requirements', 'event-tickets' ) . '</h3>',
+	),
+	'ticket-authentication-requirements-advice'  => array(
+		'type' => 'html',
+		'html' => '<p>'
+		          . sprintf( __( 'You can require that users log into your site before they are able to RSVP (or buy tickets). Please review your WordPress Membership option (via the General Settings admin screen) before adjusting this setting.',
+				'event-tickets' ), '<a href="' . get_admin_url( null, 'options-general.php' ) . '" target="_blank">', '</a>' )
+		          . '</p>',
+	),
+	'ticket-authentication-requirements'         => array(
+		'type'            => 'checkbox_list',
+		'options'         => $ticket_addons,
+		'validation_type' => 'options_multi',
+		'can_be_empty'    => true,
+	),
+	'tribe-form-content-end'                     => array(
+		'type' => 'html',
+		'html' => '</div>',
+	),
+);
+
+// If Events Tickets Plus is not active there remove the related field.
+if ( ! class_exists( 'Tribe__Tickets_Plus__Main' ) ) {
+	unset( $tickets_fields['ticket-commerce-form-location'] );
+}
+
+/**
+ * Filters the fields to be registered in the Events > Settings > Tickets tab.
+ *
+ * A field definition is one suitable to be consumed by the `Tribe__Settings_Tab` class.
+ *
+ * @see Tribe__Settings_Tab
+ * @see Tribe__Field
+ *
+ * @param array $tickets_fields An associative array of fields definitions to register.
+ */
+$tickets_fields = apply_filters( 'tribe_tickets_settings_tab_fields', $tickets_fields );
+
+$tickets_tab   = array(
+	'priority' => 20,
+	'fields' => $tickets_fields,
 );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/46168

This PR:

* adds two location settings in the Events > Settings > Tickets tab to set the distinct location of tickets forms for RSVP and commerce provided tickets.
* uses that settting to hook the front-end forms accordingly