### PR TITLE
Ensure tribe-bumpdown is enqueued when the tickets meta box is required

### DIFF
--- a/src/Tribe/Metabox.php
+++ b/src/Tribe/Metabox.php
@@ -112,6 +112,8 @@ class Tribe__Tickets__Metabox {
 		);
 
 		wp_localize_script( 'event-tickets', 'TribeTickets', $nonces );
+
+		wp_enqueue_script( 'tribe-bumpdown' );
 	}
 }
 


### PR DESCRIPTION
`tribe-bumpdown` is registered (by tribe-common) but won't always be automatically enqueued, ie if Event Tickets is running standalone and support for pages/posts is enabled.

https://central.tri.be/issues/67895