### PR TITLE
whitelist composer dependencies

### DIFF
--- a/package-whitelist.json
+++ b/package-whitelist.json
@@ -20,6 +20,10 @@
   "common/vendor/datatables/media/js/jquery.dataTables*.js",
   "common/vendor/jquery/*.css",
   "common/vendor/jquery/images/*.png",
+  "common/vendor/autoload.php",
+  "common/vendor/autoload_52.php",
+  "common/vendor/composer/*",
+  "common/vendor/lucatume/di52/src/**",
   "lang/**/*",
   "license.txt",
   "readme.txt"


### PR DESCRIPTION
This PR whitelists the composer and di52 dependencies we need in production.

Please check my globbing is correct:

* `vendor/composer` only contains files
* `vendor/lucatume/di52/src` contains folders