### PR TITLE
add response param to 2nd edit-ticket.tribe trigger 

### DIFF
--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -612,7 +612,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 
 						$tribe_tickets
 							.trigger( 'set-advanced-fields.tribe' )
-							.trigger( 'edit-ticket.tribe' );
+							.trigger( 'edit-ticket.tribe', response );
 
 					},
 					'json'


### PR DESCRIPTION
in edit ticket `$post` success callback.

For some reason `edit-ticket.tribe` is triggered twice, once at the very [beginning](https://github.com/moderntribe/event-tickets/blob/develop/src/resources/js/tickets.js#L473) and again at the [very end](https://github.com/moderntribe/event-tickets/blob/develop/src/resources/js/tickets.js#L615) of the success callback. But the second trigger doesn't have the `response`  variable passed through so any listener trying to set the values for some custom inputs will fail (ie. *not* properly set the inputs in the metabox with the response values) when running on the 2nd trigger because the `response` variable is no longer there. 

example of some custom inputs:
![image](https://cloud.githubusercontent.com/assets/507025/19489536/422b8dba-9531-11e6-8f1a-8ed5920af35c.png)

