### PR TITLE
Link report column content to Attendees report

### DIFF
--- a/src/Tribe/Admin/Columns/Tickets.php
+++ b/src/Tribe/Admin/Columns/Tickets.php
@@ -12,6 +12,11 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 	 * @var string
 	 */
 	protected $post_type;
+
+	/**
+	 * @var array A map that related supported columns to the methods used to render
+	 *            their content.
+	 */
 	protected $supported_columns = array( 'tickets' => 'render_tickets_entry' );
 
 	/**
@@ -46,7 +51,7 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 	 *              type is not supported.
 	 */
 	public function render_column( $column, $post_id ) {
-		if ( ! in_array( $column, $this->supported_columns ) ) {
+		if ( ! isset( $this->supported_columns[ $column ] ) ) {
 			return false;
 		}
 

--- a/src/Tribe/Admin/Columns/Tickets.php
+++ b/src/Tribe/Admin/Columns/Tickets.php
@@ -77,7 +77,10 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 			return '—';
 		}
 
-		return '<div>' . $this->get_sold( $tickets ) . '</div>' . $this->get_percentage_string( $tickets, $post_id );
+		$content = sprintf( '<div>%s</div>%s', $this->get_sold( $tickets ), $this->get_percentage_string( $tickets, $post_id ) );
+		$attendees_link = tribe( 'tickets.handler' )->get_attendee_report_link( get_post( $post_id ) );
+
+		return sprintf( '<a href="%s" target="_blank">%s</a>', $attendees_link, $content );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -331,6 +331,9 @@ class Tribe__Tickets__Main {
 			add_filter( 'tribe_event_import_rsvp_column_names', array( Tribe__Tickets__CSV_Importer__Column_Names::instance(), 'filter_rsvp_column_names' ) );
 		}
 
+		// Register singletons we might need
+		tribe_singleton( 'tickets.handler', 'Tribe__Tickets__Tickets_Handler' );
+
 		// Caching
 		tribe_singleton( 'tickets.cache-central', 'Tribe__Tickets__Cache__Central', array( 'hook' ) );
 		tribe_singleton( 'tickets.cache', tribe( 'tickets.cache-central' )->get_cache() );

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -711,12 +711,7 @@ class Tribe__Tickets__Tickets_Handler {
 	 * @return Tribe__Tickets__Tickets_Handler
 	 */
 	public static function instance() {
-		if ( ! isset( self::$instance ) ) {
-			$className      = __CLASS__;
-			self::$instance = new $className;
-		}
-
-		return self::$instance;
+		return tribe( 'tickets.handler' );
 	}
 
 	/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67176

This PR:

* fixes a check that was preventing the display
* links the content to the Attendees report (in a new tab)
* registers the `Tribe__Tickets__Tickets_Handler` as a singleton
* finally replaces that class `instance` method to use the container (as a service locator)
* replaces all calls to `Tribe__Tickets__Tickets_Handler::instance()` in this plugin code to use the container