### PR TITLE
Ensure response data is always passed when edit-ticket.tribe is triggered 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -207,6 +207,10 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [4.3.2] TBD =
+
+* Tweak - Include more Edited data on the `edit-ticket.tribe` action on JavaScript [68557]
+
 = [4.3.1.1] 2016-10-20 =
 
 * Fix - Corrected a packaging issue from the 4.3.1 release [67936]

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -612,7 +612,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 
 						$tribe_tickets
 							.trigger( 'set-advanced-fields.tribe' )
-							.trigger( 'edit-ticket.tribe' );
+							.trigger( 'edit-ticket.tribe', response );
 
 					},
 					'json'


### PR DESCRIPTION
_Ref:_ [C#68557](https://central.tri.be/issues/68557)
_Rel:_ #285 