### PR TITLE
Fix lagging ticket count and initial state

### DIFF
--- a/src/Tribe/Admin/Views/Ticketed.php
+++ b/src/Tribe/Admin/Views/Ticketed.php
@@ -33,6 +33,8 @@ class Tribe__Tickets__Admin__Views__Ticketed {
 		/** @var Tribe__Tickets__Cache__Cache_Interface $cache */
 		$cache = tribe( 'tickets.cache' );
 
+		$cache->include_past( true );
+
 		$ticketed_query_var = Tribe__Tickets__Query::$has_tickets;
 
 		$ticketed_args  = array(
@@ -42,7 +44,7 @@ class Tribe__Tickets__Admin__Views__Ticketed {
 		);
 		$ticketed_url   = add_query_arg( $ticketed_args );
 		$ticketed_label = __( 'Ticketed', 'event-tickets' );
-		$ticketed_count = count( $cache->posts_with_ticket_types( array( $this->post_type ) ) );
+		$ticketed_count = count( $cache->posts_with_ticket_types( array( $this->post_type ), true ) );
 
 		$views['tickets-ticketed'] = sprintf( '<a href="%s">%s</a> (%d)', $ticketed_url, $ticketed_label, $ticketed_count );
 
@@ -53,10 +55,12 @@ class Tribe__Tickets__Admin__Views__Ticketed {
 		);
 		$unticketed_url   = add_query_arg( $unticketed_args );
 		$unticketed_label = __( 'Unticketed', 'event-tickets' );
-		$unticketed_count = count( $cache->posts_without_ticket_types( array( $this->post_type ) ) );
+		$unticketed_count = count( $cache->posts_without_ticket_types( array( $this->post_type ), true ) );
 
 		$views['tickets-unticketed'] = sprintf( '<a href="%s">%s</a> (%d)', $unticketed_url, $unticketed_label,
 			$unticketed_count );
+
+		$cache->include_past( false );
 
 		return $views;
 	}

--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -21,6 +21,11 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 	protected $expiration = 60;
 
 	/**
+	 * @var bool Whether "past" post types should be included or not.
+	 */
+	protected $include_past = false;
+
+	/**
 	 * Sets the expiration time for the cache.
 	 *
 	 * @param int $seconds
@@ -60,7 +65,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 				AND pm.meta_value IS NOT NULL";
 
 		if ( class_exists( 'Tribe__Events__Main' ) ) { // if events are among the supported post types then exclude past events
-			if ( in_array( Tribe__Events__Main::POSTTYPE, $supported_types ) ) {
+			if ( in_array( Tribe__Events__Main::POSTTYPE, $supported_types ) && ! $this->include_past ) {
 				$past_events = $this->past_events();
 				if ( ! empty( $past_events ) ) {
 					$past_events_interval = '(' . implode( ',', $past_events ) . ')';
@@ -101,7 +106,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 				WHERE post_type IN {$post_types}
 				AND post_status != 'auto-draft'";
 
-		$posts_with_tickets = $this->posts_with_ticket_types();
+		$posts_with_tickets = $this->posts_with_ticket_types( null, true );
 
 		if ( ! empty( $posts_with_tickets ) ) {
 			$excluded = '(' . implode( ',', $posts_with_tickets ) . ')';
@@ -131,5 +136,17 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 		$ids = $wpdb->get_col( $query );
 
 		return is_array( $ids ) ? $ids : array();
+	}
+
+	/**
+	 * Whether "past" post types should be included or not.
+	 *
+	 * Some post types, like Events, have a notion of "past". By default the cache
+	 * will not take "past" posts into account.
+	 *
+	 * @param bool $include_past
+	 */
+	public function include_past( $include_past ) {
+		$this->include_past = $include_past;
 	}
 }

--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -61,8 +61,11 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 
 		if ( class_exists( 'Tribe__Events__Main' ) ) { // if events are among the supported post types then exclude past events
 			if ( in_array( Tribe__Events__Main::POSTTYPE, $supported_types ) ) {
-				$past_events = '(' . implode( ',', $this->past_events() ) . ')';
-				$query .= " AND pm.meta_value NOT IN {$past_events}";
+				$past_events = $this->past_events();
+				if ( ! empty( $past_events ) ) {
+					$past_events_interval = '(' . implode( ',', $past_events ) . ')';
+					$query .= " AND pm.meta_value NOT IN {$past_events_interval}";
+				}
 			}
 		}
 

--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -21,7 +21,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 	protected $expiration = 60;
 
 	/**
-	 * @var bool Whether "past" post types should be included or not.
+	 * @var bool Whether "past" posts should be included or not.
 	 */
 	protected $include_past = false;
 
@@ -139,7 +139,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 	}
 
 	/**
-	 * Whether "past" post types should be included or not.
+	 * Whether "past" posts should be included or not.
 	 *
 	 * Some post types, like Events, have a notion of "past". By default the cache
 	 * will not take "past" posts into account.

--- a/src/Tribe/Cache/Cache_Interface.php
+++ b/src/Tribe/Cache/Cache_Interface.php
@@ -56,7 +56,7 @@ interface Tribe__Tickets__Cache__Cache_Interface {
 	public function set_expiration_time( $seconds );
 
 	/**
-	 * Whether "past" post types should be included or not.
+	 * Whether "past" posts should be included or not.
 	 *
 	 * Some post types, like Events, have a notion of "past". By default the cache
 	 * will not take "past" posts into account.

--- a/src/Tribe/Cache/Cache_Interface.php
+++ b/src/Tribe/Cache/Cache_Interface.php
@@ -19,10 +19,11 @@ interface Tribe__Tickets__Cache__Cache_Interface {
 	 * Please note that the list is aware of supported types.
 	 *
 	 * @param array $post_types An array of post types overriding the supported ones.
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
 	 *
 	 * @return array
 	 */
-	public function posts_without_ticket_types( array $post_types = null );
+	public function posts_without_ticket_types( array $post_types = null, $refetch = false );
 
 	/**
 	 * Returns array of post IDs of posts that have at least one ticket assigned.
@@ -30,17 +31,20 @@ interface Tribe__Tickets__Cache__Cache_Interface {
 	 * Please note that the list is aware of supported types.
 	 *
 	 * @param array $post_types An array of post types overriding the supported ones.
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
 	 *
 	 * @return array
 	 */
-	public function posts_with_ticket_types( array $post_types = null );
+	public function posts_with_ticket_types( array $post_types = null, $refetch = false );
 
 	/**
 	 * Returns an array of all past events post IDs.
 	 *
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
+	 *
 	 * @return array
 	 */
-	public function past_events();
+	public function past_events( $refetch = false );
 
 	/**
 	 * Sets the expiration time for the cache.
@@ -50,4 +54,14 @@ interface Tribe__Tickets__Cache__Cache_Interface {
 	 * @return void
 	 */
 	public function set_expiration_time( $seconds );
+
+	/**
+	 * Whether "past" post types should be included or not.
+	 *
+	 * Some post types, like Events, have a notion of "past". By default the cache
+	 * will not take "past" posts into account.
+	 *
+	 * @param bool $include_past
+	 */
+	public function include_past( $include_past );
 }

--- a/src/Tribe/Cache/Transient_Cache.php
+++ b/src/Tribe/Cache/Transient_Cache.php
@@ -25,17 +25,18 @@ class Tribe__Tickets__Cache__Transient_Cache extends Tribe__Tickets__Cache__Abst
 	 * Please note that the list is aware of supported types.
 	 *
 	 * @param array $post_types An array of post types overriding the supported ones.
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
 	 *
 	 * @return array
 	 */
-	public function posts_without_ticket_types( array $post_types = null ) {
+	public function posts_without_ticket_types( array $post_types = null, $refetch = false ) {
 		if ( ! empty( $post_types ) ) {
 			$cache_key = __CLASS__ . 'posts_without_tickets' . md5( serialize( $post_types ) );
 		} else {
 			$cache_key = __CLASS__ . 'posts_without_tickets';
 		}
 
-		$ids = get_transient( $cache_key );
+		$ids = $refetch ? false : get_transient( $cache_key );
 
 		if ( false === $ids ) {
 			$ids = $this->fetch_posts_without_ticket_types( $post_types );
@@ -52,17 +53,18 @@ class Tribe__Tickets__Cache__Transient_Cache extends Tribe__Tickets__Cache__Abst
 	 * Please note that the list is aware of supported types.
 	 *
 	 * @param array $post_types An array of post types overriding the supported ones.
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
 	 *
 	 * @return array
 	 */
-	public function posts_with_ticket_types( array $post_types = null ) {
+	public function posts_with_ticket_types( array $post_types = null, $refetch = false ) {
 		if ( ! empty( $post_types ) ) {
 			$cache_key = __CLASS__ . 'posts_with_tickets' . md5( serialize( $post_types ) );
 		} else {
 			$cache_key = __CLASS__ . 'posts_with_tickets';
 		}
 
-		$ids = get_transient( $cache_key );
+		$ids = $refetch ? false : get_transient( $cache_key );
 
 		if ( false === $ids ) {
 			$ids = $this->fetch_posts_with_ticket_types( $post_types );
@@ -76,10 +78,12 @@ class Tribe__Tickets__Cache__Transient_Cache extends Tribe__Tickets__Cache__Abst
 	/**
 	 * Returns an array of all past events post IDs.
 	 *
+	 * @param bool $refetch Whether the method should try to get the data from the cache first or not.
+	 *
 	 * @return array
 	 */
-	public function past_events() {
-		$ids = get_transient( __CLASS__ . 'past_events' );
+	public function past_events( $refetch = false ) {
+		$ids = $refetch ? false : get_transient( __CLASS__ . 'past_events' );
 
 		if ( false === $ids ) {
 			$ids = $this->fetch_past_events();

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -642,9 +642,9 @@ class Tribe__Tickets__Main {
 
 		// if the ticket-enabled-post-types index has never been set, default it to tribe_events
 		if ( ! array_key_exists( 'ticket-enabled-post-types', $options ) ) {
-			$options['ticket-enabled-post-types'] = array(
-				'tribe_events',
-			);
+			$defaults                             = array( 'tribe_events' );
+			$options['ticket-enabled-post-types'] = $defaults;
+			tribe_update_option( 'ticket-enabled-post-types', $defaults );
 		}
 
 		/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/67175

This PR:
* fixes the count of ticketed/unticketed to not lag, when on the admin screen, due to cache
* hence adds some control on the cache
* fixes an initial state issue where the events post type was misspelled