### PR TITLE
Allowing setting ticket obj $stock to the `UNLIMITED_STOCK` value.

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -391,7 +391,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 */
 		public function stock( $value = null ) {
 			// If the Value was passed as numeric value overwrite
-			if ( is_numeric( $value ) ) {
+			if ( is_numeric( $value ) || $value === self::UNLIMITED_STOCK ) {
 				$this->stock = $value;
 			}
 


### PR DESCRIPTION
Forum post here: https://theeventscalendar.com/support/forums/topic/tribe_events_has_unlimited_stock_tickets-can-never-be-true

`tribe_events_has_unlimited_stock_tickets()` loops through all associated tickets to an event, then does this check:

```
Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $ticket->stock()
```

This will never be true because `Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK` is equal to `''` (`const UNLIMITED_STOCK = '';`), and `Tribe__Tickets__Ticket_Object::stock()` Only allows setting numeric values, and the default value is `0`.