### PR TITLE
'Subsubsub' admin view links should always take users to 'page 1'

### DIFF
--- a/src/Tribe/Admin/Views/Ticketed.php
+++ b/src/Tribe/Admin/Views/Ticketed.php
@@ -41,6 +41,7 @@ class Tribe__Tickets__Admin__Views__Ticketed {
 			'post_type'         => $this->post_type,
 			$ticketed_query_var => '1',
 			'post_status'       => 'any',
+			'paged'             => 1,
 		);
 		$ticketed_url   = add_query_arg( $ticketed_args );
 		$ticketed_label = __( 'Ticketed', 'event-tickets' );
@@ -52,6 +53,7 @@ class Tribe__Tickets__Admin__Views__Ticketed {
 			'post_type'         => $this->post_type,
 			$ticketed_query_var => '0',
 			'post_status'       => 'any',
+			'paged'             => 1,
 		);
 		$unticketed_url   = add_query_arg( $unticketed_args );
 		$unticketed_label = __( 'Unticketed', 'event-tickets' );


### PR DESCRIPTION
If a user is browsing the admin events list and is currently viewing page 10, then the `ticketed` and `unticketed` view links will try to take them to page 10 of those views.

We don't actually want to do this, though, because it's inconsistent with regular views like `published`, `draft` etc and also because there may not be 10 pages of ticketed or unticketed events.

https://central.tri.be/issues/70694