### PR TITLE
Fix/67176 sales arithmetic

### DIFF
--- a/src/Tribe/Admin/Columns/Tickets.php
+++ b/src/Tribe/Admin/Columns/Tickets.php
@@ -132,7 +132,7 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 			$this_sold  = $ticket->qty_sold();
 			$this_stock = $global_stock !== false
 				? $global_stock
-				: $this_stock = $ticket->stock() + $this_sold;
+				: $ticket->stock() + $this_sold;
 
 			// sanity check
 			if ( $this_sold > $this_stock ) {

--- a/src/Tribe/Admin/Columns/Tickets.php
+++ b/src/Tribe/Admin/Columns/Tickets.php
@@ -129,10 +129,11 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 				return '';
 			}
 
-			$this_sold  = $ticket->qty_sold();
+			$this_sold = $ticket->qty_sold();
+
 			$this_stock = $global_stock !== false ?
 				$global_stock
-				: $ticket->stock() + $ticket->qty_sold() + $ticket->qty_pending();
+				: $ticket->stock() + $ticket->qty_pending();
 
 			// sanity check
 			if ( $this_sold > $this_stock ) {

--- a/src/Tribe/Admin/Columns/Tickets.php
+++ b/src/Tribe/Admin/Columns/Tickets.php
@@ -129,11 +129,10 @@ class Tribe__Tickets__Admin__Columns__Tickets {
 				return '';
 			}
 
-			$this_sold = $ticket->qty_sold();
-
-			$this_stock = $global_stock !== false ?
-				$global_stock
-				: $ticket->stock() + $ticket->qty_pending();
+			$this_sold  = $ticket->qty_sold();
+			$this_stock = $global_stock !== false
+				? $global_stock
+				: $this_stock = $ticket->stock() + $this_sold;
 
 			// sanity check
 			if ( $this_sold > $this_stock ) {


### PR DESCRIPTION
Removes pending sales from the sum used to calculate total ticket stock - this is because the sales figure includes those items already.

https://central.tri.be/issues/67176