### PR TITLE
Compare ticket {start,end}_date against current_time() in tribe_events_ticket_is_on_sale

### DIFF
--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -177,7 +177,7 @@ if ( ! function_exists( 'tribe_events_ticket_is_on_sale' ) ) {
 		}
 
 		// Timestamps for comparison purposes
-		$now    = time();
+		$now    = current_time( 'timestamp' );
 		$start  = strtotime( $ticket->start_date );
 		$finish = strtotime( $ticket->end_date );
 


### PR DESCRIPTION
Originally reported in https://theeventscalendar.com/support/forums/topic/tribe_events_ticket_is_on_sale-returning-wrong-result/.

This assigns `$now` to WordPress' `current_time()` which returns the local time (`time()` returns UTC) and fixes the broken comparison that was taking place in `tribe_events_ticket_is_on_sale`.

This is my first PR for this project (or any other PHP codebase) so please let me know if I've missed anything here. I've tested it thoroughly against our staging instance of WordPress/Event Tickets.

🎫 [#71959](https://central.tri.be/issues/71959)