### PR TITLE
Remove meta details column during attendee export

### DIFF
--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -380,6 +380,7 @@ class Tribe__Tickets__Tickets_Handler {
 		// We dont want HTML inputs, private data or other columns that are superfluous in a CSV export
 		$hidden = array_merge( get_hidden_columns( $this->attendees_page ), array(
 			'cb',
+			'meta_details',
 			'provider',
 			'purchaser',
 			'status',


### PR DESCRIPTION
The meta details column (which contains the _view details_ link but not the submitted details themselves) is superfluous during CSV/email export of attendee data.

https://central.tri.be/issues/71251