### PR TITLE
Adjust changelog - some entries appear to have been 'misfiled' | #66768

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -212,6 +212,8 @@ Our Premium Plugins:
 * Tweak - Added a tabbed view support for Attendeees and Ticket Orders [66015]
 * Tweak - Added the "Attendees" report column in admin lists of posts supporting tickets [67176]
 * Fix - Help page is now accessible even if The Events Calendar is not active on the site [69248]
+* Tweak - Added a tabbed view support for Attendeees and Ticket Orders
+* Tweak - Improve the Attendee Report header with improved layout and better labels [66003]
 
 = [4.3.5] 2016-12-20 =
 
@@ -247,8 +249,6 @@ Our Premium Plugins:
 * Tweak - Registered plugin as active with Tribe Common. [66657]
 * Fix - When searching in the attendees list the ticket meta details can still be toggled after search [61783]
 * Fix - Fixed an issue where long file names would break plugin updates on some Windows installations [62552]
-* Tweak - Added a tabbed view support for Attendeees and Ticket Orders
-* Tweak - Improve the Attendee Report header with improved layout and better labels [66003]
 
 = [4.3] 2016-10-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -214,6 +214,7 @@ Our Premium Plugins:
 * Fix - Help page is now accessible even if The Events Calendar is not active on the site [69248]
 * Tweak - Added a tabbed view support for Attendeees and Ticket Orders
 * Tweak - Improve the Attendee Report header with improved layout and better labels [66003]
+* Tweak - Adjust the layout of the attendee report screen [66004]
 
 = [4.3.5] 2016-12-20 =
 
@@ -256,7 +257,6 @@ Our Premium Plugins:
 * Tweak - Changed "Event Add-Ons" to load faster [64286]
 * Tweak - Reworked and reorganized the attendee list screen [61992]
 * Tweak - Added tribe_tickets_rsvp_before_order_processing and tribe_tickets_rsvp_before_attendee_ticket_creation actions (props to @sabitertan on GitHub for this!) [65836]
-* Tweak - Adjust the layout of the attendee report screen [66004]
 * Fix - Cease using GLOB_BRACE for including deprecated files due to limited server support [63172]
 * Fix - Made some untranslatable strings translatable (big thanks to @Petr from the support forums on this!) [62458]
 * Deprecated - The `process_bulk_actions()` method has been deprecated in `Tribe__Tickets__Attendees_Table` in favor of `process_actions()` in the same class


### PR DESCRIPTION
Pretty sure the adjusted entries should be under 4.4, but would appreciate confirmation.

Entries moved from under 4.3.1:

* Original PR that added them: https://github.com/moderntribe/event-tickets/pull/292
* Relevant Central ticket: https://central.tri.be/issues/66003

Entry moved out from under 4.3:

* Original PR that added it https://github.com/moderntribe/event-tickets/pull/286
* Relevant Central ticket: https://central.tri.be/issues/66004