### PR TITLE
Fix/73539 confirm rsvp visibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -237,6 +237,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 * Fix - Avoid using TEC functions if TEC isn't activated [72499]
 * Fix - Fixed bug where the ticket page link template filter on the_content was being executed on every post type regardless of whether the post type had tickets enabled (props to nichestudio on our forums) [70485]
+* Fix - Ensure the Confirm RSVP button is always visible when ticket stock is available [73539]
 
 = [4.4.2] 2017-02-09 =
 

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -92,7 +92,7 @@ $now = current_time( 'timestamp' );
 		}
 		?>
 
-		<?php if ( $are_any_products_on_sale ): ?>
+		<?php if ( $are_any_products_on_sale ) : ?>
 			<tr class="tribe-tickets-meta-row">
 				<td colspan="4" class="tribe-tickets-attendees">
 					<header><?php esc_html_e( 'Send RSVP confirmation to:', 'event-tickets' ); ?></header>

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -6,13 +6,14 @@
  *
  *     [your-theme]/tribe-events/tickets/rsvp.php
  *
- * @version 4.4.1
+ * @version 4.4.3
  *
  * @var bool $must_login
  */
 
 $is_there_any_product         = false;
 $is_there_any_product_to_sell = false;
+$are_any_products_on_sale     = false;
 
 ob_start();
 $messages = Tribe__Tickets__RSVP::get_instance()->get_messages();
@@ -51,6 +52,10 @@ $now = current_time( 'timestamp' );
 
 			$is_there_any_product = true;
 			$is_there_any_product_to_sell = $ticket->is_in_stock();
+
+			if ( $is_there_any_product_to_sell ) {
+				$are_any_products_on_sale = true;
+			}
 		?>
 		<tr>
 			<td class="tribe-ticket quantity" data-product-id="<?php echo esc_attr( $ticket->ID ); ?>">
@@ -87,7 +92,7 @@ $now = current_time( 'timestamp' );
 		}
 		?>
 
-		<?php if ( $is_there_any_product_to_sell ): ?>
+		<?php if ( $are_any_products_on_sale ): ?>
 			<tr class="tribe-tickets-meta-row">
 				<td colspan="4" class="tribe-tickets-attendees">
 					<header><?php esc_html_e( 'Send RSVP confirmation to:', 'event-tickets' ); ?></header>

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -13,7 +13,7 @@
 
 $is_there_any_product         = false;
 $is_there_any_product_to_sell = false;
-$are_any_products_on_sale     = false;
+$are_products_available       = false;
 
 ob_start();
 $messages = Tribe__Tickets__RSVP::get_instance()->get_messages();
@@ -54,7 +54,7 @@ $now = current_time( 'timestamp' );
 			$is_there_any_product_to_sell = $ticket->is_in_stock();
 
 			if ( $is_there_any_product_to_sell ) {
-				$are_any_products_on_sale = true;
+				$are_products_available = true;
 			}
 		?>
 		<tr>
@@ -92,7 +92,7 @@ $now = current_time( 'timestamp' );
 		}
 		?>
 
-		<?php if ( $are_any_products_on_sale ) : ?>
+		<?php if ( $are_products_available ) : ?>
 			<tr class="tribe-tickets-meta-row">
 				<td colspan="4" class="tribe-tickets-attendees">
 					<header><?php esc_html_e( 'Send RSVP confirmation to:', 'event-tickets' ); ?></header>


### PR DESCRIPTION
We were iterating across the available (RSVP) tickets within the ticket form and setting a truthy flag each iteration, indicating if stock was available or not. 

This same flag was then used to decide if the "Confirm RSVP" button should show, meaning if the _last_ ticket had no availability the button wouldn't show even if other tickets _did_ have availability. This change should resolve that.

https://central.tri.be/issues/73539