### PR TITLE
Switch to tribe_tickets_get_template_part() for increased flexibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 == Changelog ==
 
+= [4.4.8] TBD =
+
+* Tweak - Now uses tribe_tickets_get_template_part() to load the email/tickets template for increased flexibility [69660]
+
 = [4.4.7] 2017-05-04 =
 
 * Fix — Fixed "Email attendees" modal window display on mobile devices [72558]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1081,16 +1081,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return string
 		 */
 		public function generate_tickets_email_content( $tickets ) {
-			ob_start();
-			$file = $this->getTemplateHierarchy( 'tickets/email.php' );
-
-			if ( ! file_exists( $file ) ) {
-				$file = Tribe__Tickets__Main::instance()->plugin_path . 'src/views/tickets/email.php';
-			}
-
-			include $file;
-
-			return ob_get_clean();
+			return tribe_tickets_get_template_part( 'tickets/email', null, array( 'tickets' => $tickets ), false );
 		}
 
 		/**


### PR DESCRIPTION
Switch to using `tribe_tickets_get_template_part()` for cleaner code and greater flexibility (themers/3rd party devs can then take advantage of sundry hooks and other goodies).

:ticket: [#69660](https://central.tri.be/issues/69660)