### PR TITLE
Remove unneeded and undefined var

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -232,6 +232,10 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 == Changelog ==
 
+= [4.4.8] TBD =
+
+* Fix - Remove undefined and unneeded template variable [77421]
+
 = [4.4.7] 2017-05-04 =
 
 * Fix — Fixed "Email attendees" modal window display on mobile devices [72558]

--- a/src/views/tickets/email-non-attendance.php
+++ b/src/views/tickets/email-non-attendance.php
@@ -12,7 +12,7 @@
  * @var int   $order_id
  * @var array $attendees
  *
- * @version 4.4.3
+ * @version 4.4.8
  */
 
 $start_date = function_exists( 'tribe_get_start_date' ) ? tribe_get_start_date( $event_id ) : null;
@@ -229,7 +229,7 @@ $start_date = function_exists( 'tribe_get_start_date' ) ? tribe_get_start_date( 
 		do_action( 'tribe_tickets_ticket_email_top' );
 		?>
 
-		<table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff" style="margin:0 auto; padding:0;<?php echo $break; ?>;">
+		<table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff" style="margin:0 auto; padding:0;">
 			<tr>
 				<td align="center" valign="top" class="wrapper" width="620">
 					<h2 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:28px; letter-spacing:normal; line-height: 100%; text-align:left;">


### PR DESCRIPTION
The use of `$break` in the `tickets/email-non-attendance.php` template appears to be a result of it being based upon `tickets/email.php` - however in the case of the former template it is not required and serves no purpose.

:ticket: [#77421](https://central.tri.be/issues/77421)