### PR TITLE
Fix the way "moved to/assigned to" strings are composed | #68432

### DIFF
--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -450,8 +450,8 @@ class Tribe__Tickets__Admin__Move_Tickets {
 		wp_send_json_success( array(
 			'message' => sprintf(
 				_n(
-					'%1$d attendee for %2$s was successfully moved to %3$s. Please adjust stock manually as needed. This attendee will receive an email notifying them of the change.',
-					'%1$d attendees for %2$s were successfully moved to %3$s. Please adjust stock manually as needed. These attendees will receive an email notifying them of the change.',
+					'%1$d attendee for %2$s was successfully %3$s. Please adjust stock manually as needed. This attendee will receive an email notifying them of the change.',
+					'%1$d attendees for %2$s were successfully %3$s. Please adjust stock manually as needed. These attendees will receive an email notifying them of the change.',
 					$moved_tickets,
 					'event-tickets'
 				),


### PR DESCRIPTION
Strips duplicate 'moved to' text (the `%3$s` placeholder/`$moved_to`) already contains either 'moved to' or 'assigned to' as appropriate.

:ticket: [#68432](https://central.tri.be/issues/68432)