### PR TITLE
Removed a space

### DIFF
--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -233,7 +233,7 @@
 				$count ++;
 
 				if ( $count == 2 ) {
-					$break = 'page-break-before: always !important;';
+					$break = 'page-break-before:always !important;';
 				}
 
 				$event      = get_post( $ticket['event_id'] );


### PR DESCRIPTION
Due to a space in a CSS code the page break didn't render into the final html markup in some email clients like Thunderbird for Windows. Surprisingly without the space it does. :)