### PR TITLE
Remove WP_Query from the Param on get_attendees for RSVP

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Event Tickets
 Description: Event Tickets allows your guests to RSVP from any post, page, or event.
-Version: 4.5.0.1
+Version: 4.5.0.2
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-tickets",
-  "version": "4.5.0.1",
+  "version": "4.5.0.2",
   "repository": "git@github.com:moderntribe/event-tickets.git",
   "_zipname": "event-tickets",
   "_zipfoldername": "event-tickets",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: ModernTribe, aguseo, borkweb, barry.hughes, bordoni, brianjessee, brook-tribe, courane01, faction23, GeoffBel, geoffgraham, ggwicz, jbrinley, leahkoerper, lucatume, mastromktg, mat-lipe, MZAWeb, neillmcshea, nicosantos, patriciahillebrandt, peterchester, reid.peifer, roblagatta, ryancurban, shane.pearlman, shelbelliott, tribecari, vicskf, zbtirrell
 Tags: RSVP, events, tickets, event management, calendar, ticket sales, community, registration, api, dates, date, posts, workshop, conference, meeting, seminar, concert, summit, ticket integration, event ticketing
 Requires at least: 3.9
-Stable tag: 4.5.0.1
+Stable tag: 4.5.0.2
 Tested up to: 4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -232,6 +232,10 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * [Trisha Salas](https://profiles.wordpress.org/trishasalas)
 
 == Changelog ==
+
+= [4.5.0.2] 2017-06-22 =
+
+* Fix - Prevent warnings on Strict mode for PHP 5.3 and for PHP 7
 
 = [4.5.0.1] 2017-06-22 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -5,7 +5,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '4.5.0.1';
+	const VERSION = '4.5.0.2';
 
 	/**
 	 * Min required The Events Calendar version

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1200,7 +1200,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 *
 	 * @return array
 	 */
-	protected function get_attendees( WP_Query $attendees_query, $post_id ) {
+	protected function get_attendees( $attendees_query, $post_id ) {
 
 		$attendees = array();
 


### PR DESCRIPTION
Avoid PHP 7 and Strict STD problems with Class Extending