### PR TITLE
Avoid doing arithmetic with types that are not numeric | spotfix

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1140,7 +1140,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$return->end_date       = get_post_meta( $ticket_id, '_ticket_end_date', true );
 
 		$return->manage_stock( 'yes' === get_post_meta( $ticket_id, '_manage_stock', true ) );
-		$return->stock( get_post_meta( $ticket_id, '_stock', true ) - $qty );
+		$return->stock( (int) get_post_meta( $ticket_id, '_stock', true ) - $qty );
 		$return->qty_sold( $qty );
 
 		return $return;


### PR DESCRIPTION
`get_post_meta( $ticket_id, '_stock', true )` can and will return an empty string at times - cast to an int to avoid warnings before performing arithmetic with it.