### PR TITLE
Update tickets.php for Bug #81967

### DIFF
--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -131,7 +131,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 	 * @param null $event
 	 *
 	 * @return int
-	 */ 
+	 */
 	function tribe_events_count_available_tickets( $event = null ) {
 
 		$count = 0;
@@ -141,8 +141,8 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 		}
 
 		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-			
-			$global_stock_mode = $ticket->global_stock_mode();		
+
+			$global_stock_mode = $ticket->global_stock_mode();	
 
 			if ( $global_stock_mode === Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE ) {
 				continue;
@@ -154,7 +154,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 
 		$global_stock = new Tribe__Tickets__Global_Stock( $event->ID );
 		$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
-		$count += $global_stock; 
+		$count += $global_stock;
 
 		return $count;
 	}

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -131,8 +131,9 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 	 * @param null $event
 	 *
 	 * @return int
-	 */
+	 */ 
 	function tribe_events_count_available_tickets( $event = null ) {
+
 		$count = 0;
 
 		if ( null === ( $event = tribe_tickets_parent_post( $event ) ) ) {
@@ -140,8 +141,20 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 		}
 
 		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-			$count += $ticket->stock();
+			
+			$global_stock_mode = $ticket->global_stock_mode();		
+
+			if ( $global_stock_mode === Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE ) {
+				continue;
+			}
+
+			$stock_level = $global_stock_mode === Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE ? $ticket->global_stock_cap : $ticket->stock;
+			$count += $stock_level;
 		}
+
+		$global_stock = new Tribe__Tickets__Global_Stock( $event->ID );
+		$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
+		$count += $global_stock; 
 
 		return $count;
 	}

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -142,7 +142,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 
 		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
 
-			$global_stock_mode = $ticket->global_stock_mode();	
+			$global_stock_mode = $ticket->global_stock_mode();
 
 			if ( $global_stock_mode === Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE ) {
 				continue;


### PR DESCRIPTION
Similar to bug #82684, stock for tickets using global stock was being counted with each iteration, causing a multiple of the global stock to be returned for the count. Added in condition so that the ticket is "ignored" during the loop if it's using global stock, then the global stock is added to the total count at the end.