### PR TITLE
Use correct var to obtain ticket stock | #83703

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1113,7 +1113,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				} else {
 					$types['rsvp']['count'] ++;
 
-					$types['rsvp']['stock'] += $stock_level;
+					$types['rsvp']['stock'] += $ticket->stock;
 					if ( 0 !== $types['rsvp']['stock'] ) {
 						$types['rsvp']['available'] ++;
 					}


### PR DESCRIPTION
* In the case of RSVPs `$stock_level` may not be defined/no need for it anyway
* No further changelog entry, one was already added via #82684

:ticket: [#83703](https://central.tri.be/issues/83703)