### PR TITLE
Supplementary fix: add global stock level to available stock count | …

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1127,6 +1127,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			$global_stock = new Tribe__Tickets__Global_Stock( $event_id );
 			$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
+
+			$types['tickets']['available'] += $global_stock;
 			$types['tickets']['stock'] += $global_stock;
 
 			return $types;


### PR DESCRIPTION
Initially found by Sydney [here](https://central.tri.be/issues/83703#note-4) we have a miscount when global stock is in use. The count of `'available'` tickets must also be incremented.

:ticket: [#82684](https://central.tri.be/issues/82684)