### PR TITLE
Fix/73885 email event dates

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,7 +235,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 = [4.5.5] TBD =
 
-* 
+* Tweak - Include full event start and end date in Tickets Email. Thank you @pagan11460 for the suggestion. [73885]
 
 = [4.5.4] 2017-08-24 =
 

--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -298,12 +298,12 @@
 				 * @var bool Include event date? Defaults to false.
 				 * @var int  Event ID
 				 */
-				$include_event_date = apply_filters( 'event_tickets_email_include_event_date', false, $event->ID );
+				$include_event_date = apply_filters( 'tribe_tickets_email_include_event_date', false, $event->ID );
 
 				/**
 				 * Filters whether or not the event date should be included in the ticket email.
 				 *
-				 * @deprecated TBD Use `event_tickets_email_include_event_date` instead.
+				 * @deprecated TBD Use `tribe_tickets_email_include_event_date` instead.
 				 *
 				 * @var bool Include event date? Defaults to false.
 				 * @var int  Event ID
@@ -350,7 +350,7 @@
 													<h2 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:28px; letter-spacing:normal; text-align:left;line-height: 100%;">
 														<a style="color:#0a0a0e !important" href="<?php echo esc_url( $event_link ); ?>"><?php echo $event->post_title; ?></a>
 													</h2>
-													<?php if ( ! empty( $event_date ) ): ?>
+													<?php if ( ! empty( $event_date ) ) : ?>
 														<h4 style="color:#0a0a0e; margin:0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:15px; letter-spacing:normal; text-align:left;line-height: 100%;">
 															<span style="color:#0a0a0e !important"><?php echo $event_date; ?></span>
 														</h4>

--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -288,7 +288,7 @@
 					}
 				}
 
-				$start_date = null;
+				$event_date = null;
 
 				/**
 				 * Filters whether or not the event date should be included in the ticket email.
@@ -311,7 +311,7 @@
 				$include_event_date = apply_filters( 'event_tickets_email_include_start_date', false, $event->ID );
 
 				if ( $include_event_date && function_exists( 'tribe_events_event_schedule_details' ) ) {
-					$start_date = tribe_events_event_schedule_details( $event );
+					$event_date = tribe_events_event_schedule_details( $event );
 				}
 
 				if ( function_exists( 'tribe_get_organizer_ids' ) ) {
@@ -350,9 +350,9 @@
 													<h2 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:28px; letter-spacing:normal; text-align:left;line-height: 100%;">
 														<a style="color:#0a0a0e !important" href="<?php echo esc_url( $event_link ); ?>"><?php echo $event->post_title; ?></a>
 													</h2>
-													<?php if ( ! empty( $start_date ) ): ?>
+													<?php if ( ! empty( $event_date ) ): ?>
 														<h4 style="color:#0a0a0e; margin:0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; font-weight:700; font-size:15px; letter-spacing:normal; text-align:left;line-height: 100%;">
-															<span style="color:#0a0a0e !important"><?php echo $start_date; ?></span>
+															<span style="color:#0a0a0e !important"><?php echo $event_date; ?></span>
 														</h4>
 													<?php endif; ?>
 												</td>

--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -16,7 +16,7 @@
  *                              'security_code')
  *
  * @package TribeEventsCalendar
- * @version 4.5.3
+ * @version TBD
  *
  */
 ?>
@@ -286,21 +286,32 @@
 						$venue_address_tag = 'a';
 						$venue_address_style .= ' color:#006caa !important; text-decoration:underline;';
 					}
-
 				}
 
 				$start_date = null;
 
 				/**
-				 * Filters whether or not the event start date should be included in the ticket email
+				 * Filters whether or not the event date should be included in the ticket email.
 				 *
-				 * @var boolean Include start date? Defaults to false
-				 * @var int Event ID
+				 * @since TBD
+				 *
+				 * @var bool Include event date? Defaults to false.
+				 * @var int  Event ID
 				 */
-				$include_start_date = apply_filters( 'event_tickets_email_include_start_date', false, $event->ID );
+				$include_event_date = apply_filters( 'event_tickets_email_include_event_date', false, $event->ID );
 
-				if ( $include_start_date && function_exists( 'tribe_get_start_date' ) ) {
-					$start_date = tribe_get_start_date( $event, true );
+				/**
+				 * Filters whether or not the event date should be included in the ticket email.
+				 *
+				 * @deprecated TBD Use `event_tickets_email_include_event_date` instead.
+				 *
+				 * @var bool Include event date? Defaults to false.
+				 * @var int  Event ID
+				 */
+				$include_event_date = apply_filters( 'event_tickets_email_include_start_date', false, $event->ID );
+
+				if ( $include_event_date && function_exists( 'tribe_events_event_schedule_details' ) ) {
+					$start_date = tribe_events_event_schedule_details( $event, true );
 				}
 
 				if ( function_exists( 'tribe_get_organizer_ids' ) ) {

--- a/src/views/tickets/email.php
+++ b/src/views/tickets/email.php
@@ -311,7 +311,7 @@
 				$include_event_date = apply_filters( 'event_tickets_email_include_start_date', false, $event->ID );
 
 				if ( $include_event_date && function_exists( 'tribe_events_event_schedule_details' ) ) {
-					$start_date = tribe_events_event_schedule_details( $event, true );
+					$start_date = tribe_events_event_schedule_details( $event );
 				}
 
 				if ( function_exists( 'tribe_get_organizer_ids' ) ) {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/73885

Deprecated "start_date" filter and replaced it with a general "date" one, then swapped out our displaying of the start date for the full date.