### PR TITLE
Tidy unlimited stock arithmetic

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -241,6 +241,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Open the exportable CSV file of Attendees in a new tab to accommodate Google Chrome's strict handling of file and MIME types, preventing some console errors and notices in Chrome. [70750]
 * Fix - Added "View Tickets" link to Custom Post Types when appropriate. Thank you @19ideas for helping identify this. [67570]
 * Fix - Fix some layout issues with the "Email Attendees" modal in the Attendees list admin view, especially when viewed on phones or tablets. Props to @event-control for reporting this! [80975]
+* Fix - Avoid notice-level errors when calling ticket stock functions in relation to events with unlimited stock (props to Lou Anne for highlighting this) [78685]
 
 = [4.5.5] 2017-09-06 =
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -110,11 +110,15 @@ if ( ! function_exists( 'tribe_events_partially_soldout' ) ) {
 		$some_have_soldout = false;
 
 		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
-			if ( ! $stock_is_available && 0 < $ticket->stock() ) {
+			$ticket_stock    = $ticket->stock();
+			$unlimited_stock = $ticket_stock === '';
+			$has_stock       = (int) $ticket_stock > 0 || $unlimited_stock;
+
+			if ( ! $stock_is_available && $has_stock ) {
 				$stock_is_available = true;
 			}
 
-			if ( ! $some_have_soldout && 0 == $ticket->stock() ) {
+			if ( ! $some_have_soldout && ! $has_stock ) {
 				$some_have_soldout = true;
 			}
 		}
@@ -149,7 +153,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 			}
 
 			$stock_level = $global_stock_mode === Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE ? $ticket->global_stock_cap : $ticket->stock;
-			$count += $stock_level;
+			$count += (int) $stock_level; // Explicit cast needed because it's possible $stock_level will be an empty string (unlimited stock)
 		}
 
 		$global_stock = new Tribe__Tickets__Global_Stock( $event->ID );


### PR DESCRIPTION
Modifies two functions (below) so that they don't try to do arithmetic with strings, which can happen when dealing with unlimited stock and triggers notice-level errors under modern runtimes. Behaviour of both functions should be unchanged.

* tribe_events_partially_soldout()
* tribe_events_count_available_tickets()

:ticket: [#78685](https://central.tri.be/issues/78685)