### PR TITLE
Add clear_attendees_cache(), and used it when moving tickets

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -238,6 +238,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Prevent occasional issue with email content-type not being reset after ticket emails were sent. Props to @jappleton in the forums for reporting this! [62976]
 * Fix - Hide unused Back button when moving Tickets to another post [80604]
 * Fix - Prevent multiple instances of the "View your RSVPs and Tickets" link from showing on single events (or other ticket-enabled post types). Props to @svkg in the forums for reporting this. [87429]
+* Fix - Clear attendee cache when a ticket gets moved to another post [80200]
 * Fix - Open the exportable CSV file of Attendees in a new tab to accommodate Google Chrome's strict handling of file and MIME types, preventing some console errors and notices in Chrome. [70750]
 * Fix - Added "View Tickets" link to Custom Post Types when appropriate. Thank you @19ideas for helping identify this. [67570]
 * Fix - Fix some layout issues with the "Email Attendees" modal in the Attendees list admin view, especially when viewed on phones or tablets. Props to @event-control for reporting this! [80975]

--- a/src/Tribe/Admin/Move_Ticket_Types.php
+++ b/src/Tribe/Admin/Move_Ticket_Types.php
@@ -166,6 +166,9 @@ class Tribe__Tickets__Admin__Move_Ticket_Types extends Tribe__Tickets__Admin__Mo
 			return false;
 		}
 
+		$provider->clear_attendees_cache( $src_post_id );
+		$provider->clear_attendees_cache( $destination_post_id );
+
 		$history_message = sprintf(
 			__( 'Ticket type was moved to <a href="%1$s" target="_blank">%2$s</a> from <a href="%3$s" target="_blank">%4$s</a>', 'event-tickets' ),
 			get_permalink( $destination_post_id ),

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -565,6 +565,10 @@ class Tribe__Tickets__Admin__Move_Tickets {
 			$successful_moves++;
 		}
 
+		// Clear attendee cache now that the attendees have moved.
+		$provider_class->clear_attendees_cache( $src_event_id );
+		$provider_class->clear_attendees_cache( $tgt_event_id );
+
 		/**
 		 * Fires when all of the specified ticket IDs have been moved
 		 *

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1855,12 +1855,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		/**
 		 * Clears the attendees cache for a given post
 		 *
-		 * @param string $post_id The Post ID, can also be a WP_Post
+		 * @param int|WP_Post $post The parent post or ID
 		 *
 		 * @return bool Was the operation successful?
 		 */
-		public function clear_attendees_cache( $post_id ) {
-			return Tribe__Post_Transient::instance()->delete( $post_id, self::ATTENDEES_CACHE );
+		public function clear_attendees_cache( $post ) {
+			return Tribe__Post_Transient::instance()->delete( $post, self::ATTENDEES_CACHE );
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1848,9 +1848,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		private function maybe_update_attendees_cache( $operation_did_complete ) {
 			if ( $operation_did_complete && ! empty( $_POST['event_ID'] ) ) {
-				$post_transient = Tribe__Post_Transient::instance();
-				$post_transient->delete( $_POST['event_ID'], self::ATTENDEES_CACHE );
+				$this->clear_attendees_cache( $_POST['event_ID'] );
 			}
+		}
+
+		/**
+		 * Clears the attendees cache for a given post
+		 *
+		 * @param string $post_id The Post ID, can also be a WP_Post
+		 *
+		 * @return bool Was the operation successful?
+		 */
+		public function clear_attendees_cache( $post_id ) {
+			return Tribe__Post_Transient::instance()->delete( $post_id, self::ATTENDEES_CACHE );
 		}
 
 		/**


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/80200

Turns out we have an attendee cache, that's news to me. It was not clearing when we moved a ticket, now it will.