### PR TITLE
Set the admin-menu parent-item to the parent post type of a ticket on…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -241,6 +241,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Open the exportable CSV file of Attendees in a new tab to accommodate Google Chrome's strict handling of file and MIME types, preventing some console errors and notices in Chrome. [70750]
 * Fix - Added "View Tickets" link to Custom Post Types when appropriate. Thank you @19ideas for helping identify this. [67570]
 * Fix - Fix some layout issues with the "Email Attendees" modal in the Attendees list admin view, especially when viewed on phones or tablets. Props to @event-control for reporting this! [80975]
+* Fix - Set the admin-menu parent-item to the parent post type of a ticket on the Attendees page [81284]
 * Fix - Avoid notice-level errors when calling ticket stock functions in relation to events with unlimited stock (props to Lou Anne for highlighting this) [78685]
 
 = [4.5.5] 2017-09-06 =

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -178,6 +178,9 @@ class Tribe__Tickets__Tickets_Handler {
 		add_action( 'admin_enqueue_scripts', array( $this, 'attendees_page_load_pointers' ) );
 		add_action( 'load-' . $this->attendees_page, array( $this, 'attendees_page_screen_setup' ) );
 
+		// Set the post type to get highlighted in the admin menu.
+		add_filter( 'admin_head', array( $this, 'set_typenow' ) );
+
 		/**
 		 * This is a workaround to fix the problem
 		 *
@@ -258,6 +261,17 @@ class Tribe__Tickets__Tickets_Handler {
 	}
 
 	/**
+	 * Checks if this is the attendees page.
+	 *
+	 * @return bool
+	 */
+	public function is_attendees_page() {
+		$has_query_var = Tribe__Utils__Array::get( $_GET, 'page' ) === self::$attendees_slug;
+
+		return is_admin() && $has_query_var;
+	}
+
+	/**
 	 * Setups the Attendees screen data.
 	 */
 	public function attendees_page_screen_setup() {
@@ -272,7 +286,7 @@ class Tribe__Tickets__Tickets_Handler {
 		 */
 		static $has_run = false;
 
-		if ( $has_run || ( is_admin() && ( empty( $_GET['page'] ) || self::$attendees_slug !== $_GET['page'] ) ) ) {
+		if ( $has_run || ! $this->is_attendees_page() ) {
 			return;
 		}
 
@@ -319,9 +333,6 @@ class Tribe__Tickets__Tickets_Handler {
 			add_filter( 'admin_title', array( $this, 'attendees_admin_title' ), 10, 2 );
 			add_filter( 'admin_body_class', array( $this, 'attendees_admin_body_class' ) );
 		}
-
-		// Set the post type to get highlighed in the admin menu.
-		add_filter( 'admin_head', array( $this, 'set_typenow' ) );
 	}
 
 	public function attendees_admin_body_class( $body_classes ) {
@@ -793,18 +804,16 @@ class Tribe__Tickets__Tickets_Handler {
 	}
 
 	/**
-	 * Sets the `$typenow` var to the post_type
-	 *
-	 * Causes parent post type to be highlighted in admin menus.
+	 * Set post type highlighted in admin menus when viewing the attendees page.
 	 *
 	 * @see `admin_head` action
 	 */
 	public function set_typenow() {
 		global $typenow;
 
-		if ( ! empty( $_REQUEST['post_type'] ) ) {
-			// $typenow gets compared against a whitelist of post types, no security concern.
-			$typenow = $_REQUEST['post_type'];
+		if ( $this->is_attendees_page() ) {
+			// Set to the parent post type.
+			$typenow = tribe_get_request_var( 'post_type' );
 		}
 	}
 }

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -793,7 +793,9 @@ class Tribe__Tickets__Tickets_Handler {
 	}
 
 	/**
-	 * Sets the `$typenow` var to the post_type, which will cause that post type to be highlight in admin menus
+	 * Sets the `$typenow` var to the post_type
+	 *
+	 * Causes parent post type to be highlighted in admin menus.
 	 *
 	 * @see `admin_head` action
 	 */

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -319,6 +319,9 @@ class Tribe__Tickets__Tickets_Handler {
 			add_filter( 'admin_title', array( $this, 'attendees_admin_title' ), 10, 2 );
 			add_filter( 'admin_body_class', array( $this, 'attendees_admin_body_class' ) );
 		}
+
+		// Set the post type to get highlighed in the admin menu.
+		add_filter( 'admin_head', array( $this, 'set_typenow' ) );
 	}
 
 	public function attendees_admin_body_class( $body_classes ) {
@@ -789,4 +792,13 @@ class Tribe__Tickets__Tickets_Handler {
 		return $url;
 	}
 
+	/**
+	 * Sets the `$typenow` var to the post_type, which will cause that post type to be highlight in admin menus
+	 *
+	 * @see `admin_head` action
+	 */
+	public function set_typenow() {
+		global $typenow;
+		$typenow = $_REQUEST['post_type'];
+	}
 }

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -801,6 +801,10 @@ class Tribe__Tickets__Tickets_Handler {
 	 */
 	public function set_typenow() {
 		global $typenow;
-		$typenow = $_REQUEST['post_type'];
+
+		if ( ! empty( $_REQUEST['post_type'] ) ) {
+			// $typenow gets compared against a whitelist of post types, no security concern.
+			$typenow = $_REQUEST['post_type'];
+		}
 	}
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/81284

For some reason this variable gets set to blank sometime between where it gets set in WP ( /wp-admin/admin.php:124 ) and here. So I just copied the code from WP which sets this:

`$typenow = $_REQUEST['post_type'];`

Since that what WP uses, there is no security vulnerabilities. $typenow is whitelisted, so if it doesn't match a known post_type WP errors out.