### PR TITLE
Remove deprecation notice | spotfix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -244,6 +244,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Fix some layout issues with the "Email Attendees" modal in the Attendees list admin view, especially when viewed on phones or tablets (props to @event-control for reporting this!) [80975]
 * Fix - Avoid notice-level errors when calling ticket stock functions in relation to events with unlimited stock (props to Lou Anne for highlighting this) [78685]
 * Tweak - Documented filter for available Ticket Modules, and used its method instead more places [66421]
+* Tweak - The `tribe_events_tickets_modules` filter has now been deprecated and should not be used
 
 = [4.5.5] 2017-09-06 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -425,9 +425,14 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			add_action( 'tribe_events_tickets_metabox_advanced', array( $this, 'do_metabox_advanced_options' ), 10, 2 );
 
-			// @TODO: Remove in 4.6. This only exists because version =<4.5.10 of TEC runs apply_filter() instead of calling this method directly.
+			/**
+			 * @deprecated TBD `tribe_events_tickets_modules` should no longer be used and direct
+			 *                 calls to Tribe__Tickets__Tickets::modules() are now preferred
+			 *
+			 * @todo remove in 4.6. This only exists because version =<4.5.10 of TEC runs apply_filter()
+			 *       instead of calling this method directly.
+			 */
 			add_filter( 'tribe_events_tickets_modules', array( $this, 'modules' ) );
-			add_filter( 'tribe_events_tickets_modules', array( Tribe__Deprecation::instance(), 'deprecated_filter_message' ) );
 
 			// Admin AJAX actions for each provider
 			add_action( 'wp_ajax_tribe-ticket-add-' . $this->className, array( $this, 'ajax_handler_ticket_add' ) );


### PR DESCRIPTION
This changes the way we deprecate the `tribe_events_tickets_modules` hook, to avoid generating deprecation notices even when no custom or 3rd party code utilizes the filter in question.

Instead, I've added a `@deprecated` tag and extra changelog entry to highlight the change.