### PR TITLE
Generate a cookie-based invoice number (and purge it after complete)

### DIFF
--- a/src/Tribe/Commerce/PayPal/Handler/IPN.php
+++ b/src/Tribe/Commerce/PayPal/Handler/IPN.php
@@ -37,6 +37,9 @@ class Tribe__Tickets__Commerce__PayPal__Handler__IPN {
 
 		if ( 'completed' === trim( strtolower( $data['payment_status'] ) ) ) {
 			$paypal->generate_tickets();
+
+			// since the purchase has completed, reset the invoice number
+			$gateway->reset_invoice_number();
 		}
 	}
 

--- a/src/Tribe/Commerce/PayPal/Handler/PDT.php
+++ b/src/Tribe/Commerce/PayPal/Handler/PDT.php
@@ -29,6 +29,9 @@ class Tribe__Tickets__Commerce__PayPal__Handler__PDT {
 		$gateway->set_transaction_data( $results );
 
 		$paypal->generate_tickets();
+
+		// since the purchase has completed, reset the invoice number
+		$gateway->reset_invoice_number();
 	}
 
 	/**


### PR DESCRIPTION
This does not, however, cause the sandbox to _observe_ the [invoice number](https://developer.paypal.com/docs/classic/paypal-payments-standard/integration-guide/Appx_websitestandard_htmlvariables/) despite it being passed/regenerated after successful completion. The issue in the PayPal sandbox that is causing subsequent attempts at checking out to fail appears to be a bug. A quick clearing of Domain Cookies on the PayPal side resolves the issue.

See: https://central.tri.be/issues/81566