### PR TITLE
Escape underscores in LIKE query parameter so the column's index can be used properly

### DIFF
--- a/src/Tribe/Cache/Abstract_Cache.php
+++ b/src/Tribe/Cache/Abstract_Cache.php
@@ -61,7 +61,7 @@ abstract class Tribe__Tickets__Cache__Abstract_Cache implements Tribe__Tickets__
 				LEFT JOIN {$wpdb->posts} p
 				ON pm.meta_value = p.ID
 				WHERE p.post_type IN {$post_types}
-				AND pm.meta_key LIKE '_tribe_%_for_event'
+				AND pm.meta_key LIKE '\\_tribe\\_%\\_for\\_event'
 				AND pm.meta_value IS NOT NULL";
 
 		if ( class_exists( 'Tribe__Events__Main' ) ) { // if events are among the supported post types then exclude past events


### PR DESCRIPTION
MySQL treats underscores as a single-character wildcard in LIKE comparisons. Starting a search with a wildcard prevents MySQL from using any indexes on the column being compared.

This change enables MySQL to use the index on meta_key for this query and better reflects the intended behavior of the query.

In our case, we have a very large wp_postmeta table so this query was taking a long time to complete since it had to scan every row.

References:
https://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html#operator_like
https://dev.mysql.com/doc/refman/5.7/en/index-btree-hash.html