### PR TITLE
Do not re-read the stock from meta if prop set

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 *
 		 * @var mixed
 		 */
-		protected $stock = 0;
+		protected $stock;
 
 		/**
 		 * The mode of stock handling to be used for the ticket when global stock
@@ -558,8 +558,10 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 * @return int|string
 		 */
 		public function stock( $value = null ) {
-			if ( is_null( $value ) ) {
-				$value = (int) get_post_meta( $this->ID, '_stock', true );
+			if ( null === $value ) {
+				$value = null === $this->stock
+					? (int) get_post_meta( $this->ID, '_stock', true )
+					: $this->stock;
 			}
 
 			// if we aren't tracking stock, then always assume it is in stock or capacity is unlimited


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/94124

When [reading the stock to show it on the front-end](https://github.com/moderntribe/event-tickets/blob/bcb2c923440f0a91cdca25f855428c378b987dc4/src/Tribe/Tickets.php#L997) the [implicit `__get` call](https://github.com/moderntribe/event-tickets/blob/7da2fc653b9490edbfffe575bc9480c8052a9b9b/src/Tribe/Ticket_Object.php#L701) would re-fetcht the `stock` property from the database disrupting all the stock interpolation happened so far on the ticket object.