### PR TITLE
#93339 Make Edit-Event Link Filterable for Community Tickets

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 = [4.6.2] TBD =
 
+* New - Introduced the `tribe_tickets_event_action_links_edit_url` filter for more granular control over "edit event" links in various views [93339]
 * Tweak - Make sure on front-end we only allow WooCommerce as a provider [91758]
 * Fix - Sorting for Tickets now allows moving them to the first and last position of the ordering [92558]
 * Fix - Make sure Stock is updated accordingly based on total sales when updating capacity [93601]

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -90,14 +90,24 @@ class Tribe__Tickets__Attendees {
 	 * @param $event_id
 	 */
 	public function event_action_links( $event_id ) {
+
+		/**
+		 * Allows for control of the specific "edit post" URLs used for event Sales and Attendees Reports.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $link The deafult "edit post" URL.
+		 * @param int $event_id The Post ID of the event.
+		 */
+		$edit_post_link = apply_filters( 'tribe_tickets_event_action_links_edit_url', get_edit_post_link( $event_id ), $event_id ); 
+
 		$action_links = array(
-			'<a href="' . esc_url( get_edit_post_link( $event_id ) ) . '" title="' . esc_attr_x( 'Edit', 'attendee event actions', 'event-tickets' ) . '">' . esc_html_x( 'Edit Event', 'attendee event actions', 'event-tickets' ) . '</a>',
+			'<a href="' . esc_url( $edit_post_link ) . '" title="' . esc_attr_x( 'Edit', 'attendee event actions', 'event-tickets' ) . '">' . esc_html_x( 'Edit Event', 'attendee event actions', 'event-tickets' ) . '</a>',
 			'<a href="' . esc_url( get_permalink( $event_id ) ) . '" title="' . esc_attr_x( 'View', 'attendee event actions', 'event-tickets' ) . '">' . esc_html_x( 'View Event', 'attendee event actions', 'event-tickets' ) . '</a>',
 		);
 
 		/**
-		 * Provides an opportunity to add and remove action links from the
-		 * attendee screen summary box.
+		 * Provides an opportunity to add and remove action links from the attendee screen summary box.
 		 *
 		 * @param array $action_links
 		 * @param int $event_id

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -99,7 +99,7 @@ class Tribe__Tickets__Attendees {
 		 * @param string $link The deafult "edit post" URL.
 		 * @param int $event_id The Post ID of the event.
 		 */
-		$edit_post_link = apply_filters( 'tribe_tickets_event_action_links_edit_url', get_edit_post_link( $event_id ), $event_id ); 
+		$edit_post_link = apply_filters( 'tribe_tickets_event_action_links_edit_url', get_edit_post_link( $event_id ), $event_id );
 
 		$action_links = array(
 			'<a href="' . esc_url( $edit_post_link ) . '" title="' . esc_attr_x( 'Edit', 'attendee event actions', 'event-tickets' ) . '">' . esc_html_x( 'Edit Event', 'attendee event actions', 'event-tickets' ) . '</a>',

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -2,8 +2,8 @@
 tribe( 'tickets.attendees' )->attendees_table->prepare_items();
 
 $event_id = tribe( 'tickets.attendees' )->attendees_table->event->ID;
-$event = tribe( 'tickets.attendees' )->attendees_table->event;
-$tickets = Tribe__Tickets__Tickets::get_event_tickets( $event_id );
+$event    = tribe( 'tickets.attendees' )->attendees_table->event;
+$tickets  = Tribe__Tickets__Tickets::get_event_tickets( $event_id );
 
 /**
  * Wether or not we should display attendees title


### PR DESCRIPTION
**Ticket:** [**#93339**](http://central.tri.be/issues/93339)

**Code Review Note:** Other changelog entries exist for this ticket.
Just adding a note about new filter in _this_ PR.

---

**Related PR:** https://github.com/moderntribe/events-community-tickets/pull/102