### PR TITLE
TC Email settings

### DIFF
--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -865,8 +865,8 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 
 		$content = apply_filters( 'tribe_tpp_email_content', $this->generate_tickets_email_content( $to_send ) );
 		$headers = array( 'Content-type: text/html' );
-		$from = apply_filters( 'tribe_tpp_email_from_name', tribe_get_option( 'ticket-paypal-confirmation-email-sender-name', false ) );
-		$from_email = apply_filters( 'tribe_tpp_email_from_email', tribe_get_option( 'ticket-paypal-confirmation-email-sender-email', false ) );
+		$from = apply_filters( 'tribe_tpp_email_from_name', tribe_get_option( 'ticket-confirmation-email-sender-name', false ) );
+		$from_email = apply_filters( 'tribe_tpp_email_from_email', tribe_get_option( 'ticket-confirmation-email-sender-email', false ) );
 		if ( ! empty( $from ) && ! empty( $from_email ) ) {
 			$headers[] = sprintf( 'From: %s <%s>', filter_var( $from, FILTER_SANITIZE_STRING ), filter_var( $from_email, FILTER_SANITIZE_EMAIL ) );
 		}
@@ -875,7 +875,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		$to = apply_filters( 'tribe_tpp_email_recipient', $to );
 		$site_name = stripslashes_deep( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) );
 		$default_subject = sprintf( __( 'Your tickets from %s', 'event-tickets' ), $site_name );
-		$subject = apply_filters( 'tribe_tpp_email_subject', tribe_get_option( 'ticket-paypal-confirmation-email-subject', $default_subject ) );
+		$subject = apply_filters( 'tribe_tpp_email_subject', tribe_get_option( 'ticket-confirmation-email-subject', $default_subject ) );
 
 		wp_mail( $to, $subject, $content, $headers, $attachments );
 	}

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -714,6 +714,11 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		 * @param int    $event_id
 		 * @param int    $order_id
 		 */
+		$from       = apply_filters( 'tribe_rsvp_email_from_name', tribe_get_option( 'ticket-confirmation-email-sender-name', false ) );
+ 		$from_email = apply_filters( 'tribe_rsvp_email_from_email', tribe_get_option( 'ticket-confirmation-email-sender-email', false ) );
+ 		if ( ! empty( $from ) && ! empty( $from_email ) ) {
+ 			$headers[] = sprintf( 'From: %s <%s>', filter_var( $from, FILTER_SANITIZE_STRING ), filter_var( $from_email, FILTER_SANITIZE_EMAIL ) );
+ 		}
 		$headers = apply_filters( 'tribe_rsvp_email_headers', array( 'Content-type: text/html' ), $event_id, $order_id );
 
 		/**
@@ -748,7 +753,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		 * @param int     $order_id
 		 */
 		$subject     = apply_filters( 'tribe_rsvp_email_subject',
-			sprintf( __( 'Your tickets from %s', 'event-tickets' ), stripslashes_deep( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) ) ),
+			tribe_get_option( 'rsvp-confirmation-email-subject', $default_subject ),
 			$event_id,
 			$order_id
 		);

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -706,6 +706,25 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		}
 
 		/**
+		 * Filters the RSVP tickets email from name
+		 *
+		 * @since TBD
+		 *
+		 * @param string    name via 'ticket-confirmation-email-sender-name' option
+		 */
+		$from       = apply_filters( 'tribe_rsvp_email_from_name', tribe_get_option( 'ticket-confirmation-email-sender-name', false ) );
+		/**
+		 * Filters the RSVP tickets email from email address
+		 *
+		 * @since TBD
+		 *
+		 * @param string    name via 'ticket-confirmation-email-sender-email' option
+		 */
+ 		$from_email = apply_filters( 'tribe_rsvp_email_from_email', tribe_get_option( 'ticket-confirmation-email-sender-email', false ) );
+ 		if ( ! empty( $from ) && ! empty( $from_email ) ) {
+ 			$headers[] = sprintf( 'From: %s <%s>', filter_var( $from, FILTER_SANITIZE_STRING ), filter_var( $from_email, FILTER_SANITIZE_EMAIL ) );
+ 		}
+		/**
 		 * Filters the RSVP tickets email headers
 		 *
 		 * @since 4.5.2 added new parameters $event_id and $order_id
@@ -714,11 +733,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		 * @param int    $event_id
 		 * @param int    $order_id
 		 */
-		$from       = apply_filters( 'tribe_rsvp_email_from_name', tribe_get_option( 'ticket-confirmation-email-sender-name', false ) );
- 		$from_email = apply_filters( 'tribe_rsvp_email_from_email', tribe_get_option( 'ticket-confirmation-email-sender-email', false ) );
- 		if ( ! empty( $from ) && ! empty( $from_email ) ) {
- 			$headers[] = sprintf( 'From: %s <%s>', filter_var( $from, FILTER_SANITIZE_STRING ), filter_var( $from_email, FILTER_SANITIZE_EMAIL ) );
- 		}
 		$headers = apply_filters( 'tribe_rsvp_email_headers', array( 'Content-type: text/html' ), $event_id, $order_id );
 
 		/**

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -180,13 +180,13 @@ if ( tribe_get_option( 'ticket-paypal-enable', true ) ) {
 		array( 'cmd' => '_profile-ipn-notify' ),
 		tribe( 'tickets.commerce.paypal.gateway' )->get_settings_url()
 	);
-	$ipn_notification_settings_link     = '<a href="' . $paypal_ipn_notify_url_setting_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update', 'event-tickets' ) . '</a>';
+	$ipn_notification_settings_link     = '<a href="' . esc_url( $paypal_ipn_notify_url_setting_link ) . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update', 'event-tickets' ) . '</a>';
 
 	$paypal_ipn_notification_history_link = add_query_arg(
 		array( 'cmd' => '_display-ipns-history' ),
 		tribe( 'tickets.commerce.paypal.gateway' )->get_settings_url()
 	);
-	$ipn_notification_history_link = '<a href="' . $paypal_ipn_notification_history_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > IPN History Page', 'event-tickets' ) . '</a>';
+	$ipn_notification_history_link = '<a href="' . esc_url( $paypal_ipn_notification_history_link ) . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > IPN History Page', 'event-tickets' ) . '</a>';
 
 	$current_user = get_user_by( 'id', get_current_user_id() );
 
@@ -271,7 +271,7 @@ if ( tribe_get_option( 'ticket-paypal-enable', true ) ) {
 }
 
 $site_name = stripslashes_deep( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) );
-$tickets_fields        = array_merge(
+$tickets_fields = array_merge(
 	$tickets_fields,
 	array(
 		'ticket-email-heading' => array(
@@ -324,7 +324,7 @@ $tickets_fields        = array_merge(
 );
 
 $tickets_fields = array_merge( $tickets_fields, array(
-	'tribe-form-content-end'                     => array(
+	'tribe-form-content-end' => array(
 		'type' => 'html',
 		'html' => '</div>',
 	),

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -82,7 +82,7 @@ $tickets_fields = array(
 		'options'         => $all_post_types,
 		'can_be_empty'    => false,
 		'validation_type' => 'options_multi',
-	)
+	),
 );
 
 /**
@@ -180,13 +180,13 @@ if ( tribe_get_option( 'ticket-paypal-enable', true ) ) {
 		array( 'cmd' => '_profile-ipn-notify' ),
 		tribe( 'tickets.commerce.paypal.gateway' )->get_settings_url()
 	);
-	$ipn_notification_settings_link     = '<a href="' . $paypal_ipn_notify_url_setting_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update','event-tickets' ) . '</a>';
+	$ipn_notification_settings_link     = '<a href="' . $paypal_ipn_notify_url_setting_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update', 'event-tickets' ) . '</a>';
 
 	$paypal_ipn_notification_history_link = add_query_arg(
 		array( 'cmd' => '_display-ipns-history' ),
 		tribe( 'tickets.commerce.paypal.gateway' )->get_settings_url()
 	);
-	$ipn_notification_history_link = '<a href="' . $paypal_ipn_notification_history_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > IPN History Page','event-tickets' ) . '</a>';
+	$ipn_notification_history_link = '<a href="' . $paypal_ipn_notification_history_link . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > IPN History Page', 'event-tickets' ) . '</a>';
 
 	$current_user = get_user_by( 'id', get_current_user_id() );
 
@@ -240,32 +240,6 @@ if ( tribe_get_option( 'ticket-paypal-enable', true ) ) {
 				'options'         => $pages,
 				'required'        => true,
 			),
-			'ticket-paypal-confirmation-email-sender-email' => array(
-				'type'            => 'email',
-				'label'           => esc_html__( 'Confirmation email sender address', 'event-tickets' ),
-				'tooltip'         => esc_html__( 'Email address PayPal tickets customers will receive confirmation from.', 'event-tickets' ),
-				'size'            => 'medium',
-				'default'         => $current_user->user_email,
-				'validation_type' => 'email',
-			),
-			'ticket-paypal-confirmation-email-sender-name' => array(
-				'type'                => 'text',
-				'label'               => esc_html__( 'Confirmation email sender name', 'event-tickets' ),
-				'tooltip'             => esc_html__( 'Sender name of the confirmation email sent to customers when confirming a ticket purchase.', 'event-tickets' ),
-				'size'                => 'medium',
-				'default'             => $current_user->user_nicename,
-				'validation_callback' => 'is_string',
-				'validation_type'     => 'textarea',
-			),
-			'ticket-paypal-confirmation-email-subject' => array(
-				'type'                => 'text',
-				'label'               => esc_html__( 'Confirmation email subject', 'event-tickets' ),
-				'tooltip'             => esc_html__( 'Subject of the confirmation email sent to customers when confirming a ticket purchase.', 'event-tickets' ),
-				'size'                => 'large',
-				'default'             => 'You have tickets!',
-				'validation_callback' => 'is_string',
-				'validation_type'     => 'textarea',
-			),
 			'ticket-currency-heading' => array(
 				'type' => 'html',
 				'html' => '<h3>' . __( 'Currency', 'event-tickets' ) . '</h3>',
@@ -295,6 +269,59 @@ if ( tribe_get_option( 'ticket-paypal-enable', true ) ) {
 		)
 	);
 }
+
+$site_name = stripslashes_deep( html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES ) );
+$tickets_fields        = array_merge(
+	$tickets_fields,
+	array(
+		'ticket-email-heading' => array(
+			'type' => 'html',
+			'html' => '<h3>' . __( 'Emails', 'event-tickets' ) . '</h3>',
+		),
+		'ticket-email-advice'  => array(
+			'type' => 'html',
+			'html' => '<p>' . apply_filters(
+				'tribe_tickets_settings_email_advice',
+				__( 'These settings control the emails sent when an attendee RSVPs or purchases a ticket for an event.', 'event-tickets' )
+			) . '</p>',
+		),
+		'ticket-confirmation-email-sender-email' => array(
+			'type'            => 'email',
+			'label'           => esc_html__( 'Sender email address', 'event-tickets' ),
+			'tooltip'         => esc_html__( 'Sender email address for the email sent to attendees.', 'event-tickets' ),
+			'size'            => 'medium',
+			'default'         => $current_user->user_email,
+			'validation_type' => 'email',
+		),
+		'ticket-confirmation-email-sender-name' => array(
+			'type'                => 'text',
+			'label'               => esc_html__( 'Sender name', 'event-tickets' ),
+			'tooltip'             => esc_html__( 'Sender name for the email sent to attendees.', 'event-tickets' ),
+			'size'                => 'medium',
+			'default'             => $current_user->user_nicename,
+			'validation_callback' => 'is_string',
+			'validation_type'     => 'textarea',
+		),
+		'ticket-confirmation-email-subject' => array(
+			'type'                => 'text',
+			'label'               => esc_html__( 'Ticket email subject line', 'event-tickets' ),
+			'tooltip'             => esc_html__( 'Subject line for the ticket email sent to attendees.', 'event-tickets' ),
+			'size'                => 'large',
+			'default'             => 'Your tickets from ' . $site_name . '!',
+			'validation_callback' => 'is_string',
+			'validation_type'     => 'textarea',
+		),
+		'rsvp-confirmation-email-subject' => array(
+			'type'                => 'text',
+			'label'               => esc_html__( 'RSVP email subject line', 'event-tickets' ),
+			'tooltip'             => esc_html__( 'Subject line for the RSVP email sent to attendees.', 'event-tickets' ),
+			'size'                => 'large',
+			'default'             => 'Your RSVPs from ' . $site_name . '!',
+			'validation_callback' => 'is_string',
+			'validation_type'     => 'textarea',
+		),
+	)
+);
 
 $tickets_fields = array_merge( $tickets_fields, array(
 	'tribe-form-content-end'                     => array(


### PR DESCRIPTION
🎫 https://central.tri.be/issues/96857

Moves existing email settings to their own section and adds a new one for RSVP subject.

Note I've removed "paypal" from the filter names because these should get used no matter the commerce plugin used.

Related/required by: https://github.com/moderntribe/event-tickets-plus/pull/490