### PR TITLE
Rework Oversell notice look and behaviour, fix bug

### DIFF
--- a/src/Tribe/Commerce/PayPal/Links.php
+++ b/src/Tribe/Commerce/PayPal/Links.php
@@ -9,6 +9,15 @@
  */
 class Tribe__Tickets__Commerce__PayPal__Links {
 
+	/**
+	 * Returns the link to the IPN notification history page on PayPal.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $what Either `link` to return the URL or `tag` to return an `a` tag.
+	 *
+	 * @return string
+	 */
 	public function ipn_notification_history( $what = 'tag' ) {
 		$link = add_query_arg(
 			array( 'cmd' => '_display-ipns-history' ),
@@ -27,6 +36,15 @@ class Tribe__Tickets__Commerce__PayPal__Links {
 		return Tribe__Utils__Array::get( $map, $what, '' );
 	}
 
+	/**
+	 * Returns the link to the IPN notification settings page on PayPal.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $what Either `link` to return the URL or `tag` to return an `a` tag.
+	 *
+	 * @return string
+	 */
 	public function ipn_notification_settings( $what = 'tag' ) {
 		$link = add_query_arg(
 			array( 'cmd' => '_profile-ipn-notify' ),
@@ -37,6 +55,35 @@ class Tribe__Tickets__Commerce__PayPal__Links {
 		       . esc_attr( $link )
 		       . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update', 'event-tickets' )
 		       . '</a>';
+
+		$map = array(
+			'link' => $link,
+			'tag'  => $tag,
+		);
+
+		return Tribe__Utils__Array::get( $map, $what, '' );
+	}
+
+	/**
+	 * Returns the link to an Order page on PayPal, based on the Order ID.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $what Either `link` to return the URL or `tag` to return an `a` tag.
+	 * @param string $order_id The Order PayPal ID (hash).
+	 * @param string $text An optional message that will be used as the `tag` text; defaults to
+	 *                  the Order PayPal ID (hash).
+	 *
+	 * @return string
+	 */
+	public function order_link( $what, $order_id, $text = null ) {
+		$text = null !== $text ? $text : $order_id;
+
+		$link = Tribe__Tickets__Commerce__PayPal__Order::get_order_link( $order_id );
+		$tag  = '<a href="'
+		        . esc_attr( $link )
+		        . '" target="_blank">' . esc_html__( $text )
+		        . '</a>';
 
 		$map = array(
 			'link' => $link,

--- a/src/Tribe/Commerce/PayPal/Links.php
+++ b/src/Tribe/Commerce/PayPal/Links.php
@@ -24,7 +24,7 @@ class Tribe__Tickets__Commerce__PayPal__Links {
 			tribe( 'tickets.commerce.paypal.gateway' )->get_settings_url()
 		);
 		$tag  = '<a href="'
-		        . esc_attr( $link )
+		        . esc_url( $link )
 		        . '" target="_blank">'
 		        . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > IPN History Page', 'event-tickets' )
 		        . '</a>';
@@ -52,7 +52,7 @@ class Tribe__Tickets__Commerce__PayPal__Links {
 		);
 
 		$tag = '<a href="'
-		       . esc_attr( $link )
+		       . esc_url( $link )
 		       . '" target="_blank">' . esc_html__( 'Profile and Settings > My selling tools > Instant Payment Notification > Update', 'event-tickets' )
 		       . '</a>';
 
@@ -81,7 +81,7 @@ class Tribe__Tickets__Commerce__PayPal__Links {
 
 		$link = Tribe__Tickets__Commerce__PayPal__Order::get_order_link( $order_id );
 		$tag  = '<a href="'
-		        . esc_attr( $link )
+		        . esc_url( $link )
 		        . '" target="_blank">' . esc_html__( $text )
 		        . '</a>';
 

--- a/src/Tribe/Commerce/PayPal/Notices.php
+++ b/src/Tribe/Commerce/PayPal/Notices.php
@@ -41,7 +41,7 @@ class Tribe__Tickets__Commerce__PayPal__Notices {
 			$this->slug( 'pdt-missing-identity-token' ),
 			sprintf( '%s, <a href="%s" target="_blank">%s</a>.',
 				esc_html__( 'PayPal is using PDT data but you have not set the PDT identity token', 'event-tickets' ),
-				esc_attr( admin_url() . '?page=tribe-common&tab=event-tickets#tribe-field-ticket-paypal-identity-token' ),
+				esc_url( admin_url() . '?page=tribe-common&tab=event-tickets#tribe-field-ticket-paypal-identity-token' ),
 				esc_html__( 'set it here', 'event-tickets' )
 			)
 		);

--- a/src/Tribe/Commerce/PayPal/Order.php
+++ b/src/Tribe/Commerce/PayPal/Order.php
@@ -884,4 +884,17 @@ class Tribe__Tickets__Commerce__PayPal__Order {
 	public function get_post_id() {
 		return $this->post_id;
 	}
+
+	/**
+	 * Returns the link to an Order (aka "transaction") link on PayPal.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $paypal_order_id The Order PayPal ID (hash).
+	 */
+	public static function get_order_link( $paypal_order_id ) {
+		/** @var Tribe__Tickets__Commerce__PayPal__Gateway $gateway */
+		$gateway = tribe( 'tickets.commerce.paypal.gateway' );
+		return $gateway->get_transaction_url( $paypal_order_id );
+	}
 }

--- a/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
@@ -92,7 +92,7 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 			)
 		);
 
-		tribe_transient_notice( $this->notice_slug(), $output, 'dismiss=1&type=warning' );
+		tribe_transient_notice( $this->notice_slug(), $output, 'type=warning' );
 
 		return $modified;
 	}

--- a/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
@@ -50,47 +50,22 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 	public function modify_quantity( $qty, $inventory ) {
 		$modified = $this->policy->modify_quantity( $qty, $inventory );
 
-		$output = sprintf(
-			'<p>%s</p>',
-			sprintf(
-				esc_html__(
-					'PayPal Order %1$s caused a possible oversell of tickets: %2$d available, %3$d requested; oversell policy is %4$s.',
-					'event-tickets'
-				),
-				$this->get_order_id(),
-				$inventory,
-				$qty,
-				strtolower( $this->policy->get_name() )
-			)
-		);
+		$output = $this->style();
+		$output .= $this->header_html( $qty, $inventory );
 
-		$sell_all_link = sprintf(
-			'<a href="%s">%s</a>',
-			$this->oversell_url( 'sell-all' ),
-			__( 'generate all requested attendees and oversell', 'event-tickets' )
-		);
+		/**
+		 * Filters the default policy that should be used to handle overselling.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $default
+		 * @param int    $post_id   The post ID
+		 * @param int    $ticket_id The ticket post ID
+		 * @param string $order_id  The Order PayPal ID (hash)
+		 */
+		$default = apply_filters( 'tribe_tickets_commerce_paypal_oversell_default_policy', 'sell-all', $this->get_post_id(), $this->get_ticket_id(), $this->get_order_id() );
 
-		$sell_available_link = sprintf(
-			'<a href="%s">%s</a>',
-			$this->oversell_url( 'sell-available' ),
-			__( 'generate attendees only for available tickets and not oversell', 'event-tickets' )
-		);
-
-		$no_oversell_link = sprintf(
-			'<a href="%s">%s</a>',
-			$this->oversell_url( 'no-oversell' ),
-			__( 'delete generated attendees and send no emails', 'event-tickets' )
-		);
-
-		$output           .= sprintf(
-			'<p>%s</p>',
-			sprintf(
-				esc_html__( 'You can %s, %s, or %s.', 'event-tickets' ),
-				$sell_all_link,
-				$sell_available_link,
-				$no_oversell_link
-			)
-		);
+		$output .= $this->options_html( $default );
 
 		tribe_transient_notice( $this->notice_slug(), $output, 'type=warning' );
 
@@ -98,14 +73,89 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 	}
 
 	/**
-	 * Returns the policy PayPal Order ID (hash).
+	 * Returns the embedded styles for the notice.
 	 *
 	 * @since TBD
 	 *
 	 * @return string
 	 */
-	public function get_order_id() {
-		return $this->policy->get_order_id();
+	protected function style() {
+		return '<style>
+			.tribe-tickets-paypal-oversell-radio + .tribe-tickets-paypal-oversell-radio {
+				margin-top: .25em;
+			}
+			.tribe-tickets-paypal-oversell-submit {
+				margin: .5em auto;
+				padding-bottom: 2px;
+			}
+		}</style>';
+	}
+
+	/**
+	 * Returns the notice header HTML.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $qty
+	 * @param int $inventory
+	 *
+	 * @return string
+	 */
+	protected function header_html( $qty, $inventory ) {
+		$post_id         = $this->get_post_id();
+		$post            = get_post( $post_id );
+		$post_type       = ! empty( $post ) ? get_post_type_object( $post->post_type ) : null;
+		$post_type_label = null !== $post_type
+			? strtolower( $post_type->labels->singular_name )
+			: _x( 'event', 'a generic name used to indicate any post type that has tickets assigned', 'event-tickets' );
+
+		if ( ! empty( $post ) ) {
+			$edit_link  = $this->get_user_insensible_edit_link( $post_type, $post_id );
+			$post_title = sprintf(
+				__(
+					'%s "%s" (ID %d)',
+					'event-tickets' ),
+				ucwords( $post_type_label ),
+				sprintf(
+					'<a href="%s">%s</a>',
+					esc_attr( $edit_link ),
+					apply_filters( 'the_title', $post->post_title, $post_id )
+				),
+				$post_id
+			);
+		} else {
+			$post_title = __( 'An event', 'event-tickets' );
+		}
+
+		/** @var Tribe__Tickets__Commerce__PayPal__Links $links */
+		$links             = tribe( 'tickets.commerce.paypal.links' );
+		$order_paypal_link = $links->order_link( 'tag', $this->get_order_id(), __( 'in your PayPal account', 'event-tickets' ) );
+
+		$lines   = array();
+		$lines[] = esc_html__(
+			'%1$s  is oversold: there are more tickets sold than the available %2$s capacity. This can occur when PayPal does not complete transactions immediately, delaying the decrease in %2$s capacity.',
+			'event-tickets'
+		);
+		$lines[] = esc_html__(
+			'Order %3$s includes %4$s ticket(s). There are only %5$s ticket(s) left for this %2$s. Ticket emails have not yet been sent for this order. Choose how to process this order from the options below. You may also want to adjust or refund the order %6$s.',
+			'event-tickets'
+		);
+
+		$qty       = esc_html( $qty );
+		$inventory = esc_html( $inventory );
+
+		return sprintf(
+			'<p class="tribe-tickets-paypal-oversell-header">%s</p>',
+			sprintf(
+				implode( "\n", $lines ),
+				$post_title,
+				$post_type_label,
+				$this->get_order_id(),
+				"<strong>{$qty}</strong>",
+				"<strong>{$inventory}</strong>",
+				$order_paypal_link
+			)
+		);
 	}
 
 	/**
@@ -120,14 +170,31 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 	}
 
 	/**
-	 * Returns the policy nice name.
+	 * Returns the post edit link skipping the `current_user_can` check.
+	 *
+	 * This might happen in the context of a PayPal request handling and the
+	 * current user will be set to `0`.
+	 *
+	 * @param object $post_type
+	 * @param int    $post_id
+	 *
+	 * @return string
+	 */
+	protected function get_user_insensible_edit_link( $post_type, $post_id ) {
+		$action = '&amp;action=edit';
+
+		return admin_url( sprintf( $post_type->_edit_link . $action, $post_id ) );
+	}
+
+	/**
+	 * Returns the policy PayPal Order ID (hash).
 	 *
 	 * @since TBD
 	 *
 	 * @return string
 	 */
-	public function get_name() {
-		return $this->policy->get_name();
+	public function get_order_id() {
+		return $this->policy->get_order_id();
 	}
 
 	/**
@@ -142,26 +209,54 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 	}
 
 	/**
-	 * Returns the URL that will be used to trigger an oversell for the Order from the admin UI.
+	 * Returns the notice options HTML.
 	 *
-	 * Note there is no nonce as the order might be generated during a POST request where the user
-	 * is `0`.
+	 * @since TBD
 	 *
-	 * @param string $policy
+	 * @param string $default The default oversell policy that should be used.
 	 *
 	 * @return string
 	 */
-	protected function oversell_url( $policy ) {
-		$order_id = $this->get_order_id();
+	protected function options_html( $default ) {
+		$form_inside = '';
 
-		return add_query_arg(
-			array(
-				'tpp_action'   => Tribe__Tickets__Commerce__PayPal__Oversell__Request::$oversell_action,
-				'tpp_policy'   => $policy,
-				'tpp_order_id' => $order_id,
-				'tpp_slug'     => $this->notice_slug(),
-			),
-			admin_url()
+		$hidden_inputs = array(
+			'tpp_action'   => Tribe__Tickets__Commerce__PayPal__Oversell__Request::$oversell_action,
+			'tpp_order_id' => $this->get_order_id(),
+			'tpp_slug'     => $this->notice_slug(),
+		);
+
+		foreach ( $hidden_inputs as $name => $value ) {
+			$form_inside .= sprintf( '<input type="hidden" name="%s" value="%s">', esc_attr( $name ), esc_attr( $value ) );
+		}
+
+		$options = array(
+			'sell-all'       => __( 'Confirm attendee records and send emails for all tickets in this order (overselling the event)', 'event-tickets' ),
+			'sell-available' => __( 'Confirm attendee records and send emails for some tickets in this order without overselling the event', 'event-tickets' ),
+			'no-oversell'    => __( 'Delete all attendees for this order and do not send any email', 'event-tickets' ),
+		);
+
+		foreach ( $options as $policy => $label ) {
+			$form_inside .= sprintf(
+				'<div class="tribe-tickets-paypal-oversell-radio"><input type="radio" radiogroup="order-%1$s-actions" value="%2$s" name="tpp_policy" '
+				. checked( $default, $policy, false )
+				. '><label >%3$s</label></div>',
+
+				$this->get_order_id(),
+				$policy,
+				$label
+			);
+		}
+
+		$form_inside .= sprintf(
+			'<div class="tribe-tickets-paypal-oversell-submit"><input type="submit" value="%s" class="button button-secondary"></div>',
+			__( 'Process order', 'event-tickets' )
+		);
+
+		return sprintf(
+			'<div class="tribe-tickets-paypal-oversell-form"><form action="%s" method="get">%s</form></div>',
+			$this->oversell_url(),
+			$form_inside
 		);
 	}
 
@@ -174,6 +269,29 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 	 */
 	protected function notice_slug() {
 		return "tickets-paypal-oversell-{$this->get_order_id()}-{$this->get_post_id()}";
+	}
+
+	/**
+	 * Returns the URL that will be used to trigger an oversell for the Order from the admin UI.
+	 *
+	 * Note there is no nonce as the order might be generated during a POST request where the user
+	 * is `0`.
+	 *
+	 * @return string
+	 */
+	protected function oversell_url() {
+		return admin_url();
+	}
+
+	/**
+	 * Returns the policy nice name.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return $this->policy->get_name();
 	}
 
 	/**

--- a/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Admin_Notice_Decorator.php
@@ -118,7 +118,7 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 				ucwords( $post_type_label ),
 				sprintf(
 					'<a href="%s">%s</a>',
-					esc_attr( $edit_link ),
+					esc_url( $edit_link ),
 					apply_filters( 'the_title', $post->post_title, $post_id )
 				),
 				$post_id
@@ -241,7 +241,6 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Admin_Notice_Decorator impleme
 				'<div class="tribe-tickets-paypal-oversell-radio"><input type="radio" radiogroup="order-%1$s-actions" value="%2$s" name="tpp_policy" '
 				. checked( $default, $policy, false )
 				. '><label >%3$s</label></div>',
-
 				$this->get_order_id(),
 				$policy,
 				$label

--- a/src/Tribe/Commerce/PayPal/Oversell/Policy.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Policy.php
@@ -56,7 +56,7 @@ abstract class Tribe__Tickets__Commerce__PayPal__Oversell__Policy {
 	 * @return int
 	 */
 	public function get_ticket_id() {
-		return $this->ticket_id_id;
+		return $this->ticket_id;
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
@@ -54,15 +54,23 @@ class LinksTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertMatchesSnapshot( $links->ipn_notification_settings( 'tag' ), self::$driver );
 	}
 
+	public function order_link_inputs() {
+		return [
+			[ 'bar', 'foo-bar-some' ],
+			[ 'link', 'foo-bar-some' ],
+			[ 'tag', 'foo-bar-some' ],
+			[ 'tag', 'foo-bar-some', 'See Order' ],
+		];
+	}
+
 	/**
 	 * Test order_link snapshot
+	 *
+	 * @dataProvider order_link_inputs
 	 */
-	public function test_order_link_snapshot() {
+	public function test_order_link_snapshot( $what, $order_id, $text = null ) {
 		$links = $this->make_instance();
-		$this->assertEmpty( $links->order_link( 'bar', 'foo-bar-some' ) );
-		$this->assertMatchesSnapshot( $links->order_link( 'link', 'foo-bar-some' ), self::$driver );
-		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some' ), self::$driver );
-		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some', 'See Order' ), self::$driver );
+		$this->assertMatchesSnapshot( $links->order_link( $what, $order_id, $text ), self::$driver );
 	}
 
 }

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
@@ -53,4 +53,16 @@ class LinksTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertMatchesSnapshot( $links->ipn_notification_settings( 'link' ), self::$driver );
 		$this->assertMatchesSnapshot( $links->ipn_notification_settings( 'tag' ), self::$driver );
 	}
+
+	/**
+	 * Test order_link snapshot
+	 */
+	public function test_order_link_snapshot() {
+		$links = $this->make_instance();
+		$this->assertEmpty( $links->order_link( 'bar' ) );
+		$this->assertMatchesSnapshot( $links->order_link( 'link', 'foo-bar-some' ), self::$driver );
+		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some' ), self::$driver );
+		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some', 'See Order' ), self::$driver );
+	}
+
 }

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
@@ -59,7 +59,7 @@ class LinksTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function test_order_link_snapshot() {
 		$links = $this->make_instance();
-		$this->assertEmpty( $links->order_link( 'bar' ) );
+		$this->assertEmpty( $links->order_link( 'bar', 'foo-bar-some' ) );
 		$this->assertMatchesSnapshot( $links->order_link( 'link', 'foo-bar-some' ), self::$driver );
 		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some' ), self::$driver );
 		$this->assertMatchesSnapshot( $links->order_link( 'tag', 'foo-bar-some', 'See Order' ), self::$driver );

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #0__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #0__1.php
@@ -1,0 +1,1 @@
+<?php return '';

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #1__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #1__1.php
@@ -1,0 +1,1 @@
+<?php return 'https://www.paypal.com/activity/payment/foo-bar-some';

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #2__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #2__1.php
@@ -1,0 +1,1 @@
+<?php return '<a href="https://www.paypal.com/activity/payment/foo-bar-some" target="_blank">foo-bar-some</a>';

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #3__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/__snapshots__/LinksTest__test_order_link_snapshot with data set #3__1.php
@@ -1,0 +1,1 @@
+<?php return '<a href="https://www.paypal.com/activity/payment/foo-bar-some" target="_blank">See Order</a>';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98563#note-8

This PR:
* remakes the oversell notice look and behaviour to make it (kinda) stick to the mock (https://cl.ly/14383c1B2x34)
* fixes a bug that would prevent oversell

Note: the notice contains HTML and CSS code; the former generated by a number of `sprintf` and the latter as there is no good place to style it.
As for the inline CSS:
1. it would be custom to the notice
2.  the notice might/should display *anywhere* in the admin area and I did not want to burde the common-admin file with its style; think React