### PR TITLE
Check for empty string too to find capacity

### DIFF
--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -961,7 +961,7 @@ class Tribe__Tickets__Tickets_Handler {
 
 			$capacity = $ticket->capacity();
 
-			if ( -1 === $capacity ) {
+			if ( -1 === $capacity || '' === $capacity ) {
 				$total = -1;
 				break;
 			}


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/99380

Unlimited capacity might be represented, in the db, by an empty string (`''`) or by  a `-1`; the casting that would happen later than this added check (line 969) would cast en empty string to a `0` thus incorrectly marking the ticket as without capacity.
This fixes it.