### PR TITLE
Update references to the correct class

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -233,6 +233,10 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 == Changelog ==
 
+= [4.6.4] TBD =
+
+* Fix - Remove PHP warnings during CSV generation of the attendees [94293]
+
 = [4.6.3] 2018-01-10 =
 
 * Fix - Ensured that only users of the editor or administrator roles can delete, check-in, and undo check-ins on tickets (props to @skamath for reporting this!) [68831]

--- a/readme.txt
+++ b/readme.txt
@@ -233,7 +233,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 == Changelog ==
 
-= [4.6.4] TBD =
+= [4.6.3.1] TBD =
 
 * Fix - Remove PHP warnings during CSV generation of the attendees [94293]
 

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -458,7 +458,7 @@ class Tribe__Tickets__Attendees {
 
 		//Add in Columns or get_column_headers() returns nothing
 		$filter_name = "manage_{$this->page_id}_columns";
-		add_filter( $filter_name, array( $this->page_id, 'get_columns' ), 15 );
+		add_filter( $filter_name, array( $this->attendees_table, 'get_columns' ), 15 );
 
 		$items = Tribe__Tickets__Tickets::get_event_attendees( $event_id );
 
@@ -466,7 +466,8 @@ class Tribe__Tickets__Attendees {
 		if ( ! is_admin() ) {
 			$columns = apply_filters( $filter_name, array() );
 		} else {
-			$columns = array_map( 'wp_strip_all_tags', get_column_headers( get_current_screen() ) );
+			$columns = array_filter( (array) get_column_headers( get_current_screen() ) );
+			$columns = array_map( 'wp_strip_all_tags', $columns  );
 		}
 
 		// We dont want HTML inputs, private data or other columns that are superfluous in a CSV export


### PR DESCRIPTION
**Ticket** https://central.tri.be/issues/94293

There was an error during migration of this class as `attendees_table` was
ot referenced correct, as `page_id` is a string reference when
`attendees_table` is a class reference.

It also makes sure the values used on `array_map` are the expected
values.