### PR TITLE
Fix the display and calculation of sales for oversold orders

### DIFF
--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -783,7 +783,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 
 				// check if we already have an attendee or not
 				$post_title        = $attendee_full_name . ' | ' . ( $i + 1 );
-				$criteria          = array( 'post_title' => $post_title, 'ticket_id' => $product_id, 'event_id' => $post_id );
+				$criteria          = array( 'post_title' => $post_title, 'product_id' => $product_id, 'event_id' => $post_id );
 				$existing_attendee = wp_list_filter( $existing_attendees, $criteria );
 
 				if ( ! empty( $existing_attendee ) ) {

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -747,7 +747,8 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 					$qty = $oversell_policy->modify_quantity( $qty, $inventory );
 
 					if ( ! $oversell_policy->allows_overselling() ) {
-						$oversell_policy->handle_oversold_attendees( $this->get_attendees_by_order_id( $order_id ) );
+						$oversold_attendees = $this->get_attendees_by_order_id( $order_id );
+						$oversell_policy->handle_oversold_attendees( $oversold_attendees );
 						$this->redirect_after_error( 102, $redirect, $post_id );
 						return;
 					}

--- a/src/Tribe/Commerce/PayPal/Orders/Report.php
+++ b/src/Tribe/Commerce/PayPal/Orders/Report.php
@@ -253,8 +253,8 @@ class Tribe__Tickets__Commerce__PayPal__Orders__Report {
 		$attendees    = $paypal->get_attendees_by_id( $post_id );
 		$tickets_sold = $sales->filter_sold_tickets( $paypal_tickets );
 
-		$post_revenue        = $sales->get_revenue_for_attendees( $attendees );
-		$total_sold          = $sales->get_sales_for_attendees( $attendees );
+		$post_revenue        = $sales->get_revenue_for_tickets( $tickets_sold );
+		$total_sold          = $sales->get_sales_for_tickets( $tickets );
 		$total_completed     = count( $sales->filter_completed( $attendees ) );
 		$total_not_completed = count( $sales->filter_not_completed( $attendees ) );
 

--- a/src/Tribe/Commerce/PayPal/Orders/Sales.php
+++ b/src/Tribe/Commerce/PayPal/Orders/Sales.php
@@ -24,61 +24,39 @@ class Tribe__Tickets__Commerce__PayPal__Orders__Sales {
 	}
 
 	/**
-	 * Returns the revenue for a single attendee.
+	 * Returns the revenue for a single ticket.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $attendee The attendee details.
+	 * @param Tribe__Tickets__Ticket_Object $ticket The ticket object.
 	 *
 	 * @return int
 	 */
-	public function get_revenue_for_attendee( array $attendee ) {
-		$revenue = $this->get_unfiltered_revenue_for_attendee( $attendee );
+	public function get_revenue_for_ticket( Tribe__Tickets__Ticket_Object $ticket ) {
+		$revenue = $this->get_unfiltered_revenue_for_ticket( $ticket );
 
 		/**
-		 * Filters the revenue for a specific attendee.
+		 * Filters the revenue for a specific ticket.
 		 *
 		 * @since TBD
 		 *
-		 * @param int   $revenue  The revenue for this attendee.
-		 * @param array $attendee The attendee details.
+		 * @param int                           $revenue The revenue for this ticket.
+		 * @param Tribe__Tickets__Ticket_Object $ticket  The ticket object.
 		 */
-		return apply_filters( 'tribe_tickets_commerce_paypal_attendee_revenue', $revenue, $attendee );
+		return apply_filters( 'tribe_tickets_commerce_paypal_attendee_revenue', $revenue, $ticket );
 	}
 
 	/**
-	 * Returns the unfiltered revenue for an attendee.
+	 * Returns the unfiltered revenue for an ticket.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $attendee
+	 * @param Tribe__Tickets__Ticket_Object $ticket
 	 *
 	 * @return int
 	 */
-	protected function get_unfiltered_revenue_for_attendee( $attendee ) {
-		$product_id = Tribe__Utils__Array::get( $attendee, 'product_id', false );
-
-		if ( ! filter_var( $product_id, FILTER_VALIDATE_INT ) ) {
-			return 0;
-		}
-
-		$cached = $this->cache[ $product_id ];
-
-		if ( false !== $cached ) {
-			return $cached;
-		}
-
-		if ( ! $this->is_order_completed( $attendee ) ) {
-			return 0;
-		}
-
-		$revenue = get_post_meta( $product_id, '_price', true );
-
-		if ( ! filter_var( $revenue, FILTER_VALIDATE_INT ) ) {
-			return 0;
-		}
-
-		return (int) $revenue;
+	protected function get_unfiltered_revenue_for_ticket( Tribe__Tickets__Ticket_Object $ticket ) {
+		return (int) $ticket->price * $ticket->qty_sold();
 	}
 
 	/**
@@ -123,73 +101,73 @@ class Tribe__Tickets__Commerce__PayPal__Orders__Sales {
 	}
 
 	/**
-	 * Returns the total revenue provided a list of attendees.
+	 * Returns the total revenue provided a list of tickets.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $attendees
+	 * @param array $tickets An array of ticket objects
 	 *
 	 * @return int
 	 */
-	public function get_revenue_for_attendees( array $attendees ) {
-		$revenue = array_sum( array_map( array( $this, 'get_revenue_for_attendee' ), $attendees ) );
+	public function get_revenue_for_tickets( array $tickets ) {
+		$revenue = array_sum( array_map( array( $this, 'get_revenue_for_ticket' ), $tickets ) );
 
 		/**
-		 * Filters the revenue for a list of attendees.
+		 * Filters the revenue for a list of tickets.
 		 *
 		 * @since TBD
 		 *
-		 * @param int   $revenue   The revenue for these attendees.
-		 * @param array $attendees The attendees details.
+		 * @param int   $revenue The revenue for these tickets.
+		 * @param array $tickets The tickets objects.
 		 */
-		return apply_filters( 'tribe_tickets_commerce_paypal_attendees_revenue', $revenue, $attendees );
+		return apply_filters( 'tribe_tickets_commerce_paypal_tickets_revenue', $revenue, $tickets );
 	}
 
 	/**
-	 * Returns the amount this attendee represents in sales terms.
+	 * Returns the amount this ticket represents in sales terms.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $attendee
+	 * @param Tribe__Tickets__Ticket_Object $ticket
 	 *
 	 * @return int
 	 */
-	public function get_sale_for_attendee( array $attendee ) {
-		$sales_count = $this->is_order_completed( $attendee ) ? 1 : 0;
+	public function get_sale_for_ticket( Tribe__Tickets__Ticket_Object $ticket ) {
+		$sales_count = $ticket->qty_sold();
 
 		/**
-		 * Filters the sales count for an attendee.
+		 * Filters the sales count for an ticket.
 		 *
 		 * @since TBD
 		 *
-		 * @param int   $sales_count The sales count for this attendee; defaults to `1` per attendee
+		 * @param int   $sales_count The sales count for this ticket; defaults to `1` per ticket
 		 *                           with a sales generating order status.
-		 * @param array $attendee    The attendee details.
+		 * @param Tribe__Tickets__Ticket_Object $ticket    The ticket object.
 		 */
-		return apply_filters( 'tribe_tickets_commerce_paypal_attendee_sales_count', $sales_count, $attendee );
+		return apply_filters( 'tribe_tickets_commerce_paypal_ticket_sales_count', $sales_count, $ticket );
 	}
 
 	/**
-	 * Returns the amount of sales for a list of attendees.
+	 * Returns the amount of sales for a list of tickets.
 	 *
 	 * @since TBD
 	 *
-	 * @param array $attendees
+	 * @param array $tickets
 	 *
 	 * @return int
 	 */
-	public function get_sales_for_attendees( $attendees ) {
-		$sales = array_sum( array_map( array( $this, 'get_sale_for_attendee' ), $attendees ) );
+	public function get_sales_for_tickets( $tickets ) {
+		$sales = array_sum( array_map( array( $this, 'get_sale_for_ticket' ), $tickets ) );
 
 		/**
-		 * Filters the sales for a list of attendees.
+		 * Filters the sales for a list of tickets.
 		 *
 		 * @since TBD
 		 *
-		 * @param int   $sales     The sales for these attendees.
-		 * @param array $attendees The attendees details.
+		 * @param int   $sales   The sales for these tickets.
+		 * @param array $tickets The tickets objects.
 		 */
-		return apply_filters( 'tribe_tickets_commerce_paypal_attendees_sales', $sales, $attendees );
+		return apply_filters( 'tribe_tickets_commerce_paypal_tickets_sales', $sales, $tickets );
 	}
 
 	/**

--- a/src/Tribe/Commerce/PayPal/Oversell/Attendee_Handling_Decorator.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Attendee_Handling_Decorator.php
@@ -107,11 +107,19 @@ class Tribe__Tickets__Commerce__PayPal__Oversell__Attendee_Handling_Decorator im
 		$paypal = tribe( 'tickets.commerce.paypal' );
 
 		foreach ( $oversold_attendees as $attendee ) {
-			if ( empty( $attendee['attendee_id'] ) ) {
-				continue;
+			$attendee_id = Tribe__Utils__Array::get( $attendee, 'attendee_id', false );
+			$event_id    = Tribe__Utils__Array::get( $attendee, 'event_id', false );
+
+			if ( $attendee_id && $event_id ) {
+				$paypal->delete_ticket( $event_id, $attendee_id );
 			}
 
-			$paypal->delete_ticket( $attendee['event_id'], $attendee['attendee_id'] );
+			// any oversold attendee, whether deleted or not, is a sale
+			$product_id = Tribe__Utils__Array::get( $attendee, 'product_id', false );
+
+			if ( false !== $product_id ) {
+				$paypal->increase_ticket_sales_by( $product_id, 1 );
+			}
 		}
 	}
 }

--- a/src/Tribe/Commerce/PayPal/Oversell/No_Oversell.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/No_Oversell.php
@@ -7,9 +7,7 @@
  *
  * @since TBD
  */
-class Tribe__Tickets__Commerce__PayPal__Oversell__No_Oversell
-	extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy
-	implements Tribe__Tickets__Commerce__PayPal__Oversell__Policy_Interface {
+class Tribe__Tickets__Commerce__PayPal__Oversell__No_Oversell extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy {
 
 	/**
 	 * Whether this policy allows overselling or not.

--- a/src/Tribe/Commerce/PayPal/Oversell/Policy.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Policy.php
@@ -5,7 +5,7 @@
  *
  * @since TBD
  */
-abstract class Tribe__Tickets__Commerce__PayPal__Oversell__Policy {
+abstract class Tribe__Tickets__Commerce__PayPal__Oversell__Policy implements Tribe__Tickets__Commerce__PayPal__Oversell__Policy_Interface {
 
 	/**
 	 * @var int

--- a/src/Tribe/Commerce/PayPal/Oversell/Sell_All.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Sell_All.php
@@ -7,9 +7,7 @@
  *
  * @since TBD
  */
-class Tribe__Tickets__Commerce__PayPal__Oversell__Sell_All
-	extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy
-	implements Tribe__Tickets__Commerce__PayPal__Oversell__Policy_Interface {
+class Tribe__Tickets__Commerce__PayPal__Oversell__Sell_All extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy {
 
 	/**
 	 * Whether this policy allows overselling or not.

--- a/src/Tribe/Commerce/PayPal/Oversell/Sell_Available.php
+++ b/src/Tribe/Commerce/PayPal/Oversell/Sell_Available.php
@@ -8,9 +8,7 @@
  *
  * @since TBD
  */
-class Tribe__Tickets__Commerce__PayPal__Oversell__Sell_Available
-	extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy
-	implements Tribe__Tickets__Commerce__PayPal__Oversell__Policy_Interface {
+class Tribe__Tickets__Commerce__PayPal__Oversell__Sell_Available extends Tribe__Tickets__Commerce__PayPal__Oversell__Policy {
 
 	/**
 	 * Whether this policy allows overselling or not.

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/Frontend/__snapshots__/Tickets_FormTest__test_render_snapshot_with_available_tickets__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/Frontend/__snapshots__/Tickets_FormTest__test_render_snapshot_with_available_tickets__1.php
@@ -19,70 +19,70 @@
 
 	<table class="tribe-events-tickets tribe-events-tickets-tpp">
 					<tr>
-				<td class="tribe-ticket quantity" data-product-id="9">
-					<input type="hidden" name="product_id[]" value="9">
+				<td class="tribe-ticket quantity" data-product-id="4">
+					<input type="hidden" name="product_id[]" value="4">
 											<input
 							type="number"
 							class="tribe-ticket-quantity qty"
 							min="0"
-							max="100"							name="quantity_9"
+							max="100"							name="quantity_4"
 							value="0"
 													>
 													<span class="tribe-tickets-remaining">
-							<span class="available-stock" data-product-id="9">100</span> available							</span>
+							<span class="available-stock" data-product-id="4">100</span> available							</span>
 															</td>
 				<td class="tickets_name">
-					Test Ticket for 8				</td>
+					Test Ticket for 3				</td>
 				<td class="tickets_price">
-					<span class="tribe-tickets-price-amount amount">&#x24;1</span>				</td>
+					<span class="tribe-tickets-price-amount amount">&#x24;1.00</span>				</td>
 				<td class="tickets_description" colspan="2">
-					Ticket for 8				</td>
+					Ticket for 3				</td>
 				<td class="tickets_submit">
 											<button type="submit" class="tpp-submit tribe-button">Buy now</button>
 									</td>
 			</tr>
 						<tr>
-				<td class="tribe-ticket quantity" data-product-id="10">
-					<input type="hidden" name="product_id[]" value="10">
+				<td class="tribe-ticket quantity" data-product-id="5">
+					<input type="hidden" name="product_id[]" value="5">
 											<input
 							type="number"
 							class="tribe-ticket-quantity qty"
 							min="0"
-							max="100"							name="quantity_10"
+							max="100"							name="quantity_5"
 							value="0"
 													>
 													<span class="tribe-tickets-remaining">
-							<span class="available-stock" data-product-id="10">100</span> available							</span>
+							<span class="available-stock" data-product-id="5">100</span> available							</span>
 															</td>
 				<td class="tickets_name">
-					Test Ticket for 8				</td>
+					Test Ticket for 3				</td>
 				<td class="tickets_price">
-					<span class="tribe-tickets-price-amount amount">&#x24;1</span>				</td>
+					<span class="tribe-tickets-price-amount amount">&#x24;1.00</span>				</td>
 				<td class="tickets_description" colspan="2">
-					Ticket for 8				</td>
+					Ticket for 3				</td>
 				<td class="tickets_submit">
 											<button type="submit" class="tpp-submit tribe-button">Buy now</button>
 									</td>
 			</tr>
 						<tr>
-				<td class="tribe-ticket quantity" data-product-id="11">
-					<input type="hidden" name="product_id[]" value="11">
+				<td class="tribe-ticket quantity" data-product-id="6">
+					<input type="hidden" name="product_id[]" value="6">
 											<input
 							type="number"
 							class="tribe-ticket-quantity qty"
 							min="0"
-							max="100"							name="quantity_11"
+							max="100"							name="quantity_6"
 							value="0"
 													>
 													<span class="tribe-tickets-remaining">
-							<span class="available-stock" data-product-id="11">100</span> available							</span>
+							<span class="available-stock" data-product-id="6">100</span> available							</span>
 															</td>
 				<td class="tickets_name">
-					Test Ticket for 8				</td>
+					Test Ticket for 3				</td>
 				<td class="tickets_price">
-					<span class="tribe-tickets-price-amount amount">&#x24;1</span>				</td>
+					<span class="tribe-tickets-price-amount amount">&#x24;1.00</span>				</td>
 				<td class="tickets_description" colspan="2">
-					Ticket for 8				</td>
+					Ticket for 3				</td>
 				<td class="tickets_submit">
 											<button type="submit" class="tpp-submit tribe-button">Buy now</button>
 									</td>
@@ -91,7 +91,7 @@
 					<tr>
 				<td colspan="5" class="tpp-add">
 																
-	<a href="http://commerce.dev/wp-login.php?redirect_to=http://commerce.dev/?p=8">Log in before purchasing</a>
+	<a href="http://commerce.dev/wp-login.php?redirect_to=http://commerce.dev/?p=3">Log in before purchasing</a>
 
 										</td>
 			</tr>


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98563

This PR fixes the sales reoport numbers when choosing one oversell option or the other.