### PR TITLE
Fix the Orders and currency display

### DIFF
--- a/src/Tribe/Commerce/Currency.php
+++ b/src/Tribe/Commerce/Currency.php
@@ -25,7 +25,7 @@ class Tribe__Tickets__Commerce__Currency {
 	 * @since TBD
 	 */
 	public function hook(  ) {
-		add_filter( 'tribe_currency_symbol', array( $this, 'get_currency_symbol' ), 10, 2 );
+		add_filter( 'tribe_currency_symbol', array( $this, 'filter_currency_symbol' ), 10, 2 );
 		add_filter( 'tribe_reverse_currency_position', array( $this, 'reverse_currency_symbol_position' ), 10, 2 );
 		add_filter( 'get_post_metadata', array( $this, 'filter_cost_meta' ), 10, 4 );
 	}
@@ -48,7 +48,9 @@ class Tribe__Tickets__Commerce__Currency {
 	 * @return string
 	 */
 	public function filter_currency_symbol( $unused_currency_symbol, $post_id = null ) {
-		return $this->get_currency_symbol( $post_id );
+		$default_provider = Tribe__Tickets__Tickets::get_event_ticket_provider( $post_id );
+
+		return $this->get_provider_symbol( $default_provider, $post_id );
 	}
 
 	/**

--- a/src/admin-views/editor/button-view-orders.php
+++ b/src/admin-views/editor/button-view-orders.php
@@ -34,4 +34,4 @@ $url = apply_filters( 'tribe_filter_attendee_order_link', $url, $post->ID );
 	>
 		<?php esc_html_e( 'View Orders', 'event-tickets' ); ?>
 	</a>
-<?php endif; ?>
+<?php endif;

--- a/src/admin-views/editor/button-view-orders.php
+++ b/src/admin-views/editor/button-view-orders.php
@@ -26,9 +26,12 @@ $url = add_query_arg( $args, admin_url( 'edit.php' ) );
  */
 $url = apply_filters( 'tribe_filter_attendee_order_link', $url, $post->ID );
 ?>
-<a
-	href="<?php echo esc_url( $url ); ?>"
-	class="button-secondary"
->
-	<?php esc_html_e( 'View Orders', 'event-tickets' ); ?>
-</a>
+
+<?php if ( ! empty( $url ) ) : ?>
+	<a
+			href="<?php echo esc_url( $url ); ?>"
+			class="button-secondary"
+	>
+		<?php esc_html_e( 'View Orders', 'event-tickets' ); ?>
+	</a>
+<?php endif; ?>

--- a/src/admin-views/editor/button-view-orders.php
+++ b/src/admin-views/editor/button-view-orders.php
@@ -29,8 +29,8 @@ $url = apply_filters( 'tribe_filter_attendee_order_link', $url, $post->ID );
 
 <?php if ( ! empty( $url ) ) : ?>
 	<a
-			href="<?php echo esc_url( $url ); ?>"
-			class="button-secondary"
+		href="<?php echo esc_url( $url ); ?>"
+		class="button-secondary"
 	>
 		<?php esc_html_e( 'View Orders', 'event-tickets' ); ?>
 	</a>


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/70361

Related: https://github.com/moderntribe/event-tickets-plus/pull/497

This PR:
1. makes sure that the currency symbol will be provided by the ticket provider in the Orders report
2. removes (see ET+ PR) the Orders link for EDD tickets