### PR TITLE
try to fetch the tickt provider from the new settings first'

### DIFF
--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -1151,7 +1151,10 @@ class Tribe__Tickets__Tickets_Handler {
 			return false;
 		}
 
-		$provider = tribe_get_request_var( 'ticket_provider', false );
+		$provider = tribe_get_request_var(
+			array( 'tribe-tickets', 'settings', 'default_provider' ),
+			tribe_get_request_var( 'ticket_provider', false )
+		);
 
 		if ( $provider && tribe( 'tickets.metabox' )->module_is_valid( $provider ) ) {
 			// Get the Provider


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/99616

This PR fixes the issue where an additional PayPal ticket, with empty details and thus unlimited in capacity, would be created when submitting a Community Event.