### PR TITLE
Check for woo and edd functions existence before trying to use them

### DIFF
--- a/src/Tribe/Commerce/Currency.php
+++ b/src/Tribe/Commerce/Currency.php
@@ -372,11 +372,11 @@ class Tribe__Tickets__Commerce__Currency {
 			return $this->get_currency_symbol( $object_id );
 		}
 
-		if ( 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main' === $provider ) {
+		if ( 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main' === $provider && function_exists( 'get_woocommerce_currency_symbol' ) ) {
 			return get_woocommerce_currency_symbol();
 		}
 
-		if ( 'Tribe__Tickets_Plus__Commerce__EDD__Main' === $provider ) {
+		if ( 'Tribe__Tickets_Plus__Commerce__EDD__Main' === $provider && function_exists( 'edd_currency_symbol' ) ) {
 			return edd_currency_symbol();
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/100322

This PR adds a check in the Currency class to make sure that not only the commerce provider bridge (ET+) class exists but that the functions do too.