### PR TITLE
Fix auto-return issues

### DIFF
--- a/src/Tribe/Commerce/PayPal/Endpoints.php
+++ b/src/Tribe/Commerce/PayPal/Endpoints.php
@@ -32,7 +32,9 @@ class Tribe__Tickets__Commerce__PayPal__Endpoints {
 			return;
 		}
 
-		wp_safe_redirect( $this->success_url( $_GET['tx'] ) );
+		$post_id = Tribe__Utils__Array::get( $custom_data, 'pid', null );
+
+		wp_safe_redirect( $this->success_url( $_GET['tx'], $post_id ) );
 	}
 
 	/**

--- a/src/Tribe/Commerce/PayPal/Endpoints.php
+++ b/src/Tribe/Commerce/PayPal/Endpoints.php
@@ -55,8 +55,8 @@ class Tribe__Tickets__Commerce__PayPal__Endpoints {
 		if ( ! empty( $page ) && 'page' === $page->post_type ) {
 			$url = add_query_arg( array( 'p' => $success_page_id, 'tribe-tpp-order' => $order ), home_url() );
 		} else {
-			// use the post single page
-			$url = add_query_arg( array( 'tribe-tpp-order' => $order ), get_permalink( $post_id ) );
+			// use the post single page; see `Tribe__Tickets__Commerce__PayPal__Errors` for the message code
+			$url = add_query_arg( array( 'tribe-tpp-order' => $order, 'tpp_message' => 201 ), get_permalink( $post_id ) );
 		}
 
 		return $url;

--- a/src/Tribe/Commerce/PayPal/Endpoints.php
+++ b/src/Tribe/Commerce/PayPal/Endpoints.php
@@ -35,6 +35,7 @@ class Tribe__Tickets__Commerce__PayPal__Endpoints {
 		$post_id = Tribe__Utils__Array::get( $custom_data, 'pid', null );
 
 		wp_safe_redirect( $this->success_url( $_GET['tx'], $post_id ) );
+		tribe_exit();
 	}
 
 	/**

--- a/src/Tribe/Commerce/PayPal/Errors.php
+++ b/src/Tribe/Commerce/PayPal/Errors.php
@@ -29,6 +29,9 @@ class Tribe__Tickets__Commerce__PayPal__Errors {
 			'101' => __( 'In order to purchase tickets, you must enter your name and a valid email address.', 'event-tickets' ),
 			'102' => __( 'You can\'t add more tickets than the total remaining tickets.', 'event-tickets' ),
 			'103' => __( 'You should add at least one ticket.', 'event-tickets' ),
+
+			// a numeric namespace reserved for front-end messages
+			'201' => __( "Your order is currently processing. Once completed, you'll receive your ticket(s) in an email.", 'event-tickets' ),
 		);
 
 		/**

--- a/src/Tribe/Commerce/PayPal/Frontend/Tickets_Form.php
+++ b/src/Tribe/Commerce/PayPal/Frontend/Tickets_Form.php
@@ -75,6 +75,12 @@ class Tribe__Tickets__Commerce__PayPal__Frontend__Tickets_Form {
 			$this->main->add_message( Tribe__Tickets__Commerce__PayPal__Errors::error_code_to_message( $ticket_error ), 'error' );
 		}
 
+		$ticket_message = empty( $_GET['tpp_message'] ) ? false : (int) $_GET['tpp_message'];
+
+		if ( $ticket_message ) {
+			$this->main->add_message( Tribe__Tickets__Commerce__PayPal__Errors::error_code_to_message( $ticket_message ), 'update' );
+		}
+
 		$must_login = ! is_user_logged_in() && $this->main->login_required();
 		$can_login  = true;
 

--- a/src/Tribe/Commerce/PayPal/Gateway.php
+++ b/src/Tribe/Commerce/PayPal/Gateway.php
@@ -114,7 +114,7 @@ class Tribe__Tickets__Commerce__PayPal__Gateway {
 		 */
 		$notify_url = apply_filters( 'tribe_tickets_commerce_paypal_notify_url', $notify_url, $post, $product_ids );
 
-		$custom_args = array( 'user_id' => get_current_user_id(), 'tribe_handler' => 'tpp' );
+		$custom_args = array( 'user_id' => get_current_user_id(), 'tribe_handler' => 'tpp', 'pid' => $post->ID );
 
 		/**
 		 * Filters the custom arguments that will be sent ot PayPal.

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1203,7 +1203,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				);
 
 				if ( $ticket->managing_stock() ) {
-					$ticket_data['stock'] = $ticket->stock();
+					$ticket_data['stock'] = $ticket->available();
 				}
 
 				$data['events'][ $post_id ] = array(

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -164,7 +164,7 @@ if ( ! empty( $pages ) ) {
 }
 
 // add an empty entry at the start
-$pages = array_merge( array( 0 => '' ), $pages );
+$pages = array( 0 => '' ) + $pages;
 $default_page = reset( $pages );
 
 $tpp_success_shortcode = 'tribe-tpp-success';


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/100461
Also: https://central.tri.be/issues/100254

This PR fixes three auto-return issues:
1. the `select` in the ticket settings was being populated with an `array_merge`, the keys (the page IDs) would be lost thus making the ID to title relation totally inaccurate
2. when no success page is selected the user would be returned to the wrong post
3. when finally returned to the correct post no message would indicate to the user that she came back after a purchase
4. fixes an issue where the ticket front-end form would display the wrong number of remaining tickets