### PR TITLE
Fixes glitch with Event Tickets + Enfold + WooCommerce

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,8 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 
 = [4.6.4] TBD =
 
+* Fix - Fixes a glitch, where adding an RSVP results in "NaN" in the counter when using Event Tickets, Enfold and WooCommerce. (Thanks to @tbo24 for the contribution.) [93027]
+
 = [4.6.3] 2018-01-10 =
 
 * Fix - Ensured that only users of the editor or administrator roles can delete, check-in, and undo check-ins on tickets (props to @skamath for reporting this!) [68831]

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -79,6 +79,7 @@ $now = current_time( 'timestamp' );
 						<input
 							type="number"
 							class="tribe-ticket-quantity"
+						        step="1"
 							min="0"
 							<?php if ( -1 !== $remaining ) : ?>
 								max="<?php echo esc_attr( $remaining ); ?>"


### PR DESCRIPTION
Ticket #93027
https://central.tri.be/issues/93027
Fixes a glitch, where adding an RSVP results in "NaN" in the counter when using ET, Enfold and WooCommerce.