### PR TITLE
Fix back-compat with out of date ET+ plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "homepage": "http://tri.be/shop/wordpress-events-calendar/",
   "license": "GPL-2.0",
   "require-dev": {
-    "lucatume/wp-browser": "^1.22.7",
+    "lucatume/wp-browser": "^2.0",
     "lucatume/function-mocker": "^1.0",
     "vlucas/phpdotenv": "^2.4",
     "lucatume/function-mocker-le": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c95e03eadeb872145dc93f32527c068",
+    "content-hash": "85391c8bc40264218d990fe82424b6ca",
     "packages": [],
     "packages-dev": [
         {
@@ -1410,16 +1410,16 @@
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "1.22.7",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "1a0d9ad12548dcda63aeb51796552429feae6595"
+                "reference": "cc7f6ae6cd404ec909ba93fcc00f929a3dd68fb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/1a0d9ad12548dcda63aeb51796552429feae6595",
-                "reference": "1a0d9ad12548dcda63aeb51796552429feae6595",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/cc7f6ae6cd404ec909ba93fcc00f929a3dd68fb2",
+                "reference": "cc7f6ae6cd404ec909ba93fcc00f929a3dd68fb2",
                 "shasum": ""
             },
             "require": {
@@ -1429,7 +1429,8 @@
                 "gumlet/php-image-resize": "^1.6",
                 "lucatume/codeception-setup-local": "~1.0",
                 "lucatume/wp-browser-commons": "^1.2.5",
-                "symfony/process": ">=2.7 <5.0",
+                "php": "^7.0",
+                "symfony/process": ">=2.7 <5.0, !=3.4.5",
                 "wp-cli/wp-cli": "^1.1"
             },
             "require-dev": {
@@ -1449,8 +1450,7 @@
                     "tad\\": "src\\tad"
                 },
                 "files": [
-                    "src/tad/WPBrowser/functions.php",
-                    "shims.php"
+                    "src/tad/WPBrowser/functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1471,7 +1471,7 @@
                 "codeception",
                 "wordpress"
             ],
-            "time": "2018-02-27T14:27:56+00:00"
+            "time": "2018-03-03T13:10:39+00:00"
         },
         {
             "name": "lucatume/wp-browser-commons",

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2549,4 +2549,19 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		}
 		tribe_exit();
 	}
+
+    /**
+     * Generates the validation code that will be printed in the ticket.
+     *
+     * Its purpose is to be used to validate the ticket at the door of an event.
+     *
+     * @since TBD
+     *
+     * @param int $attendee_id
+     *
+     * @return string
+     */
+    private function generate_security_code( $attendee_id ) {
+        return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
+    }
 }

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1451,7 +1451,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 *
 	 * @return bool
 	 */
-	public function checkin( $attendee_id, $qr = null ) {
+	public function checkin( $attendee_id ) {
 		$qr = null;
 
 		if ( ! tribe( 'tickets.attendees' )->user_can_manage_attendees() ) {

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1905,4 +1905,19 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		return (int) $_POST[ "quantity_{$product_id}" ];
 	}
+
+	/**
+	 * Generates the validation code that will be printed in the ticket.
+	 *
+	 * Its purpose is to be used to validate the ticket at the door of an event.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $attendee_id
+	 *
+	 * @return string
+	 */
+	private function generate_security_code( $attendee_id ) {
+		return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
+	}
 }

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1938,18 +1938,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
-		 * Generates the validation code that will be printed in the ticket.
-		 * It purpose is to be used to validate the ticket at the door of an event.
-		 *
-		 * @param int $attendee_id
-		 *
-		 * @return string
-		 */
-		public function generate_security_code( $attendee_id ) {
-			return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
-		}
-
-		/**
 		 * @param bool $operation_did_complete
 		 */
 		protected function maybe_update_attendees_cache( $operation_did_complete ) {

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -213,12 +213,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @var string
 		 */
 		public $attendee_user_id = '_tribe_tickets_attendee_user_id';
-		/**
-		 * Name of the CPT that holds Attendees (tickets holders).
-		 *
-		 * @var string
-		 */
-		public $attendee_object = '';
 
 		/**
 		 * Name of the CPT that holds Orders
@@ -226,25 +220,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		public $order_object = '';
 
 		/**
-		 * Meta key that relates Attendees and Events.
-		 *
-		 * @var string
-		 */
-		public $attendee_event_key = '';
-
-		/**
 		 * Meta key that relates Attendees and Products.
 		 *
 		 * @var string
 		 */
 		public $attendee_product_key = '';
-
-		/**
-		 * Currently unused for this provider, but defined per the Tribe__Tickets__Tickets spec.
-		 *
-		 * @var string
-		 */
-		public $attendee_order_key = '';
 
 		/**
 		 * Indicates if a ticket for this attendee was sent out via email.

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -674,10 +674,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param $qr true if from QR checkin process
 		 * @return mixed
 		 */
-		public function checkin( $attendee_id, $qr = false ) {
+		public function checkin( $attendee_id ) {
 			update_post_meta( $attendee_id, $this->checkin_key, 1 );
 
-			if ( $qr ) {
+			$args = func_get_args();
+			$qr = null;
+
+			if ( isset( $args[1] ) && $qr = (bool) $args[1] ) {
 				update_post_meta( $attendee_id, '_tribe_qr_status', 1 );
 			}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/100879

This PR modifies the code of the `Tickets` class to make sure extending classes defined  in ET+ (Woo, EDD) that might still be one version behind will not generate fatals or warnings. 
This **does** create duplicate code (the `generate_security_code` method is now defined in all classes) and makes the inheritance tree a little less "stable" but avoids issues during upgrades.