### PR TITLE
Prevent fatal errors if `get_current_screen` is null

### DIFF
--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -39,10 +39,12 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		$this->per_page_option = Tribe__Tickets__Admin__Screen_Options__Attendees::$per_page_user_option;
 
-		$screen->add_option( 'per_page', array(
-			'label'  => __( 'Number of attendees per page:', 'event-tickets' ),
-			'option' => $this->per_page_option,
-		) );
+		if ( ! is_null( $screen ) ) {
+			$screen->add_option( 'per_page', array(
+				'label'  => __( 'Number of attendees per page:', 'event-tickets' ),
+				'option' => $this->per_page_option,
+			) );
+		}
 
 		// Fetch the event Object
 		if ( ! empty( $_GET['event_id'] ) ) {


### PR DESCRIPTION
*Ticket*: https://central.tri.be/issues/101217