### PR TITLE
Add query params as input values to the form

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -246,6 +246,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Add warning if a ticket has stock management turned off in the related WooCommerce product, but has capacity enabled for the ticket(thanks Isaiah Baker and others for highlighting this) [91471]
 * Fix - Make sure the correct menu parent is expanded on the admin when visiting the list of attendees [93057]
 * Fix - Fixes the missing notification on the email and removes the notification when there's none [99979]
+* Fix - The redirection to the correct post type URL when site has a plain permalink structure on the buy ticket form [96640]
 * Tweak - Change Event tickets slug from 3 different types into 2 variants for post types and events types [88569]
 * Feature - Add updater class to enable changes on future updates [84675]
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -238,8 +238,24 @@ if ( ! function_exists( 'tribe_tickets_buy_button' ) ) {
 					$button_anchor = '#buy-tickets';
 				}
 
-				$button = '<form method="get" action="' . esc_url( get_the_permalink( $event_id ) . $button_anchor ) . '">'
-					. '<button type="submit" name="tickets_process" class="tribe-button">' . $button_label . '</button>'
+				$permalink = get_the_permalink( $event_id );
+				$query_string = parse_url( $permalink, PHP_URL_QUERY );
+				$query_params = empty( $query_string ) ? array() : (array) explode( '&', $query_string );
+
+				$button = '<form method="get" action="' . esc_url( $permalink . $button_anchor ) . '">';
+
+				// Add any query attribute as a hidden input as the action of the form is GET
+				foreach ( $query_params as $param ) {
+					$parts = explode( '=', $param );
+					// a query string must be 2 parts only a name and a value
+					$number_of_parts = 2;
+					if ( is_array( $parts ) && $number_of_parts === count( $parts ) ) {
+						list( $name, $value ) = $parts;
+						$button .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '">';
+					}
+				}
+
+				$button	.= '<button type="submit" name="tickets_process" class="tribe-button">' . $button_label . '</button>'
 					. '</form>';
 
 				$parts[ $type . '-button' ] = $html['button'] = $button;

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -247,9 +247,9 @@ if ( ! function_exists( 'tribe_tickets_buy_button' ) ) {
 				// Add any query attribute as a hidden input as the action of the form is GET
 				foreach ( $query_params as $param ) {
 					$parts = explode( '=', $param );
+
 					// a query string must be 2 parts only a name and a value
-					$number_of_parts = 2;
-					if ( is_array( $parts ) && $number_of_parts === count( $parts ) ) {
+					if ( is_array( $parts ) && 2 === count( $parts ) ) {
 						list( $name, $value ) = $parts;
 						$button .= '<input type="hidden" name="' . esc_attr( $name ) . '" value="' . esc_attr( $value ) . '">';
 					}


### PR DESCRIPTION
**Ticket**: https://central.tri.be/issues/96640

In order to send the params as the type of Request is $_GET and all the
values that are on the permalink as $query params are not consider when
doing the request.