### PR TITLE
Make it easier to set Tribe Commerce as default module

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -250,6 +250,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Fixes the missing notification on the email and removes the notification when there's none [99979]
 * Fix - The redirection to the correct post type URL when site has a plain permalink structure on the buy ticket form [96640]
 * Tweak - Change Event tickets slug from 3 different types into 2 variants for post types and events types [88569]
+* Tweak - Made it easier to set Tribe Commerce as the default ticket module (when multiple ticketing modules are active) [96538]
 
 = [4.7] 2018-03-13 =
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -309,6 +309,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		add_action( 'tribe_events_tickets_metabox_edit_advanced', array( $this, 'do_metabox_advanced_options' ), 10, 2 );
 		add_filter( 'tribe_tickets_stock_message_available_quantity', tribe_callback( 'tickets.commerce.paypal.orders.sales', 'filter_available' ), 10, 4 );
 		add_action( 'admin_init', tribe_callback( 'tickets.commerce.paypal.oversell.request', 'handle' ) );
+		add_filter( 'tribe_tickets_get_default_module', array( $this, 'deprioritize_module' ), 5, 2 );
 	}
 
 	/**
@@ -2569,4 +2570,30 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
     public function generate_security_code( $attendee_id ) {
         return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
     }
+
+	/**
+	 * If other modules are active, we should deprioritize this one (we want other commerce
+	 * modules to take priority over this one).
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $default_module
+	 * @param string[] $available_modules
+	 *
+	 * @return string
+	 */
+	public function deprioritize_module( $default_module, array $available_modules ) {
+		$tribe_commerce_module = get_class( $this );
+
+		// If this isn't the default (or if there isn't a choice), no need to deprioritize
+		if (
+			$default_module !== $tribe_commerce_module
+			|| count( $available_modules ) < 2
+			|| reset( $available_modules ) !== $tribe_commerce_module
+		) {
+			return $default_module;
+		}
+
+		return next( $available_modules );
+	}
 }

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1239,8 +1239,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			} else {
 				// Remove RSVP and PayPal tickets for this part
 				unset(
-					$modules[ array_search( 'Tribe__Tickets__RSVP', $modules ) ],
-					$modules[ array_search( 'Tribe__Tickets__Commerce__PayPal__Main', $modules ) ]
+					$modules[ array_search( 'Tribe__Tickets__RSVP', $modules ) ]
 				);
 
 				if ( ! empty( $modules ) ) {


### PR DESCRIPTION
Ensures Tribe Commerce does not take priority over other ticketing modules, and makes it readily possible to set it as the default via the `tribe_tickets_get_default_module` hook.

:ticket: [♯96538](https://central.tri.be/issues/96538)