### PR TITLE
Fixes glitch with Event Tickets + Enfold + WooCommerce 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -250,6 +250,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Fixes the missing notification on the email and removes the notification when there's none [99979]
 * Fix - Prevent overwriting the start date of a ticket if it was already set [99601]
 * Fix - The redirection to the correct post type URL when site has a plain permalink structure on the buy ticket form [96640]
+* Fix - Fixes a glitch, where adding an RSVP results in "NaN" in the counter when using Event Tickets, Enfold and WooCommerce. (Thanks to @tbo24 for the contribution.) [93027]
 * Tweak - Change Event tickets slug from 3 different types into 2 variants for post types and events types [88569]
 * Tweak - Made it easier to set Tribe Commerce as the default ticket module (when multiple ticketing modules are active) [96538]
 

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -80,6 +80,7 @@ $now = current_time( 'timestamp' );
 						<input
 							type="number"
 							class="tribe-ticket-quantity"
+						        step="1"
 							min="0"
 							<?php if ( -1 !== $remaining ) : ?>
 								max="<?php echo esc_attr( $remaining ); ?>"


### PR DESCRIPTION
Ticket #93027
https://central.tri.be/issues/93027
Fixes a glitch, where adding an RSVP results in "NaN" in the counter when using ET, Enfold and WooCommerce.