### PR TITLE
Make sure function exists before call it.

### DIFF
--- a/src/Tribe/Commerce/Currency.php
+++ b/src/Tribe/Commerce/Currency.php
@@ -438,7 +438,7 @@ class Tribe__Tickets__Commerce__Currency {
 				: 'postfix';
 		}
 
-		if ( 'Tribe__Tickets_Plus__Commerce__EDD__Main' === $provider ) {
+		if ( 'Tribe__Tickets_Plus__Commerce__EDD__Main' === $provider && function_exists( 'edd_get_option' ) ) {
 			$position = edd_get_option( 'currency_position', 'before' );
 
 			return 'before' === $position ? 'prefix' : 'postfix';


### PR DESCRIPTION
There a very edge scenario if an event is created with EDD as the
provider and then the plugin is disabled when calling `edd_get_option`
will trigger an error.

In order to prevent this we need to make sure the function does exists
before use it.