### PR TITLE
Make sure `tribe_events_get_the_excerpt` is available

### DIFF
--- a/src/Tribe/JSON_LD/Type.php
+++ b/src/Tribe/JSON_LD/Type.php
@@ -113,7 +113,10 @@ class Tribe__Tickets__JSON_LD__Type extends Tribe__JSON_LD__Abstract {
 				continue;
 			}
 
-			$data = parent::get_data( $post, $args );
+			$data = array();
+			if ( function_exists( 'tribe_events_get_the_excerpt' ) ) {
+				$data = parent::get_data( $post, $args );
+			}
 
 			// If we have an Empty data we just skip
 			if ( empty( $data ) ) {


### PR DESCRIPTION
Before usage of the function make sure is available as it's called by
the parent class.