### PR TITLE
Make sure `Tribe__Events__Timezones` is present

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -350,7 +350,11 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 */
 		public function get_event_timezone() {
 
-			if ( ! is_null( $this->get_event_id() ) && is_null( $this->event_timezone ) ) {
+			if (
+				class_exists( 'Tribe__Events__Timezones' )
+				&& ! is_null( $this->get_event_id() )
+				&& is_null( $this->event_timezone )
+			) {
 				try {
 					$this->event_timezone = new DateTimeZone( Tribe__Events__Timezones::get_event_timezone_string( $this->get_event_id() ) );
 				} catch ( Exception $exception ) {


### PR DESCRIPTION
This is an edge case when TEC is disabled and a user visits the event
page with tickets.

As the Events post type will be disabled from the BE if the plugin is
disabled it might be worth to check before using
`Tribe__Events__Timezones`