### PR TITLE
Switch to DateTime::ATOM for truly ISO8601 compliant datetimes | #43349

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -244,6 +244,7 @@ The plugin is produced by [Modern Tribe Inc](http://m.tri.be/18uc).
 * Fix - Prevent rendering of the RSVP form if Tickets is disabled for Event post type [66072]
 * Fix - Honor the Start of Week for the DatePickers of the Admin [75114]
 * Fix - Ensure exported Attendee Reports have user info in the "Primary Information" column [70453]
+* Fix - Corrected the datetime format used within our JSON LD output so that it follows the ISO8601 standard [43349]
 * Tweak - Added the `wp-background-processing` library by Ashley Rich (https://github.com/A5hleyRich/wp-background-processing) to `common` [102323]
 
 = [4.7.1] 2018-03-28 =

--- a/src/Tribe/JSON_LD/Order.php
+++ b/src/Tribe/JSON_LD/Order.php
@@ -146,11 +146,11 @@ class Tribe__Tickets__JSON_LD__Order {
 		);
 
 		if ( ! empty( $ticket->start_date ) ) {
-			$offer->validFrom = date( DateTime::ISO8601, strtotime( $ticket->start_date ) );
+			$offer->validFrom = date( DateTime::ATOM, strtotime( $ticket->start_date ) );
 		}
 
 		if ( ! empty( $ticket->end_date ) ) {
-			$offer->validThrough = date( DateTime::ISO8601, strtotime( $ticket->end_date ) );
+			$offer->validThrough = date( DateTime::ATOM, strtotime( $ticket->end_date ) );
 		}
 
 		/**


### PR DESCRIPTION
Use ISO8601-compliant datetime formatting as expected within our JSON LD feed (previously we used `DateTime::ISO8601` formatting which despite its name was not compliant). No customer props, this was an internal find.

:ticket: [♯43349](https://central.tri.be/issues/43349)