### PR TITLE
fallback on the site timezone if the post does not define one

### DIFF
--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -362,6 +362,14 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				}
 			}
 
+			if ( null === $this->event_timezone ) {
+				$wp_timezone = Tribe__Timezones::wp_timezone_string();
+				if ( Tribe__Timezones::is_utc_offset( $wp_timezone ) ) {
+					$wp_timezone = Tribe__Timezones::generate_timezone_string_from_utc_offset( $wp_timezone );
+				}
+				$this->event_timezone = new DateTimeZone( $wp_timezone );
+			}
+
 			return $this->event_timezone;
 		}
 


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/103787

This PR fixes an issue that would prevent post, not events, with assigned tickets from correctly rendering of the site front-end