### PR TITLE
Overwrite initial localized data if more tickets are present

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1104,12 +1104,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			if ( ! self::$frontend_script_enqueued ) {
 				$url = Tribe__Tickets__Main::instance()->plugin_url . 'src/resources/js/frontend-ticket-form.js';
 				$url = Tribe__Template_Factory::getMinFile( $url, true );
-
 				wp_enqueue_script( 'tribe_tickets_frontend_tickets', $url, array( 'jquery' ), Tribe__Tickets__Main::VERSION, true );
-				add_action( 'wp_footer', array( __CLASS__, 'enqueue_frontend_stock_data' ), 1 );
 			}
 
-			self::$frontend_ticket_data += $tickets;
+			self::$frontend_ticket_data = array_filter( array_merge( self::$frontend_ticket_data, $tickets ) );
+			add_action( 'wp_footer', array( __CLASS__, 'enqueue_frontend_stock_data' ) );
 		}
 
 		/**

--- a/src/resources/js/frontend-ticket-form.js
+++ b/src/resources/js/frontend-ticket-form.js
@@ -11,7 +11,7 @@ var tribe_tickets_ticket_form = {};
 
 	my.init = function() {
 		$tickets_lists = $( '.tribe-events-tickets, .tribe-events-tickets-tpp' );
-		$quantity_fields = $tickets_lists.find( '.quantity' ).find( '.qty' );
+		$quantity_fields = $tickets_lists.find( '.quantity' ).find( '.qty, .edd-input' );
 		$quantity_fields.on( 'change', my.on_quantity_change );
 	};
 
@@ -30,7 +30,8 @@ var tribe_tickets_ticket_form = {};
 			my.normal_stock_quantity_changed( $this, ticket_id );
 		}
 
-		var new_quantity = $this.val();
+		var new_quantity = parseInt( $this.val(), 10 );
+		new_quantity = isNaN( new_quantity ) ? 0 : new_quantity;
 		var $form = $this.closest( 'form' );
 
 		if ( new_quantity > 0 ) {


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/102497

Make sure next calls that are tickets to the FE overwrite the initial data
localized to have all tickets on the page on the FE.