### PR TITLE
Display the correct number of available tickets on list and day view

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Tweak - Changed validation on the option 'Post types that can have tickets' to allow empty value [105930]
 * Fix - Display the correct number of attendees on the events list in the admin section [102128]
+* Fix - Display the correct number of available tickets on list and day view [100340]
 
 = [4.7.2] 2018-04-18 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1200,9 +1200,44 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
 
 			$types['tickets']['available'] += $global_stock;
-			$types['tickets']['stock'] += $global_stock;
+
+			// If there's at least one ticket with shared capacity
+			if ( ! self::tickets_own_stock( $post_id ) ) {
+				$types['tickets']['stock'] += $global_stock;
+			}
 
 			return $types;
+		}
+
+		/**
+		 * Returns if the all the tickets for an event
+		 * have own stock
+		 *
+		 * @param int $post_id ID of parent "event" post
+		 * @return bool
+		 */
+		public static function tickets_own_stock( $post_id ) {
+			$tickets = self::get_all_event_tickets( $post_id );
+
+			// if no tickets or rsvp return false
+			if ( ! $tickets ) {
+				return false;
+			}
+
+			foreach ( $tickets as $ticket ) {
+
+				// if ticket and not RSVP
+				if ( 'Tribe__Tickets__RSVP' !== $ticket->provider_class ) {
+
+					$global_stock_mode = $ticket->global_stock_mode();
+
+					if ( Tribe__Tickets__Global_Stock::OWN_STOCK_MODE !== $global_stock_mode ) {
+						return false;
+					}
+				}
+			}
+
+			return true;
 		}
 
 		/**


### PR DESCRIPTION
https://central.tri.be/issues/100340

Couldn't find a more elegant way to fix this. Basically, the shared capacity was adding to the stock when an event had all tickets with their own stock. Added a helper function and modified the addition for that special case.