### PR TITLE
Purge attendees transient on checkin/uncheckin

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,8 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.7.4] TBD =
 
+* Fix - Properly update attendee's transient when checkin/unchekin an attendee, in order to see changes immediately [73272]
+
 = [4.7.3] 2018-05-29 =
 
 * Fix - Display the correct number of attendees on the events list in the admin section (props to @vbt, @xen and others for flagging this!) [102128]

--- a/readme.txt
+++ b/readme.txt
@@ -123,7 +123,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.7.4] TBD =
 
-* Fix - Properly update attendee's transient when checkin/unchekin an attendee, in order to see changes immediately [73272]
+* Fix - Properly update attendee's transient when checkin/unchekin an attendee, in order to see changes immediately. Thanks to @newcollegeofflorida and @gschnoor for flagging this! [73272]
 
 = [4.7.3] 2018-05-29 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,7 +123,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.7.4] TBD =
 
-* Fix - Properly update attendee's transient when checkin/unchekin an attendee, in order to see changes immediately. Thanks to @newcollegeofflorida and @gschnoor for flagging this! [73272]
+* Fix - Properly update attendees transient when checkin/unchekin an attendee, in order to see changes immediately. Thanks to @newcollegeofflorida and @gschnoor for flagging this! [73272]
 
 = [4.7.3] 2018-05-29 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -817,7 +817,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		}
 
 		/**
-		 * Remove the Post Transients when a Ticket change its state
+		 * Remove the attendees transient when a Ticket change its state
 		 *
 		 * @since TBD
 		 *

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -819,6 +819,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		/**
 		 * Remove the Post Transients when a Ticket change its state
 		 *
+		 * @since TBD
+		 *
 		 * @param  int $attendee_id
 		 * @return void
 		 */

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -811,6 +811,24 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			// Ensure ticket prices and event costs are linked
 			add_filter( 'tribe_events_event_costs', array( $this, 'get_ticket_prices' ), 10, 2 );
+
+			add_action( 'event_tickets_checkin',   array( $this, 'purge_attendees_transient' ) );
+			add_action( 'event_tickets_uncheckin', array( $this, 'purge_attendees_transient' ) );
+		}
+
+		/**
+		 * Remove the Post Transients when a Ticket change its state
+		 *
+		 * @param  int $attendee_id
+		 * @return void
+		 */
+		public function purge_attendees_transient( $attendee_id ) {
+
+			$event_id = $this->get_event_id_from_attendee_id( $attendee_id );
+
+			if ( $event_id ) {
+				tribe( 'post-transient' )->delete( $event_id, Tribe__Tickets__Tickets::ATTENDEES_CACHE );
+			}
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -812,7 +812,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			// Ensure ticket prices and event costs are linked
 			add_filter( 'tribe_events_event_costs', array( $this, 'get_ticket_prices' ), 10, 2 );
 
-			add_action( 'event_tickets_checkin',   array( $this, 'purge_attendees_transient' ) );
+			add_action( 'event_tickets_checkin', array( $this, 'purge_attendees_transient' ) );
 			add_action( 'event_tickets_uncheckin', array( $this, 'purge_attendees_transient' ) );
 		}
 
@@ -827,7 +827,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$event_id = $this->get_event_id_from_attendee_id( $attendee_id );
 
 			if ( $event_id ) {
-				tribe( 'post-transient' )->delete( $event_id, Tribe__Tickets__Tickets::ATTENDEES_CACHE );
+				tribe( 'post-transient' )->delete( $event_id, self::ATTENDEES_CACHE );
 			}
 		}
 


### PR DESCRIPTION
https://central.tri.be/issues/73272

https://central.tri.be/issues/104355

Purge attendees transient when checkin or uncheckin is performed. By having this in the main events, will be compatible with the different e-commerce tickets.