### PR TITLE
Make sure the Paypal orders are being recorded.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Make sure the ticket creation is compatible with object cache. Thanks @zanart, @bethanymrac, @vividimage and others for flagging this! [105802]
 * Fix - Display a notice if the user accesses the tickets page and doesn't have tickets [89201]
 * Fix - If the ticket is a WooCommerce product and has a featured image, display it in the email [79877]
+* Fix - Make sure the Paypal orders are being recorded. Thanks @burlingtonbytes for flagging this! [108436]
 * Tweak - Added new action, `tribe_tickets_ticket_email_ticket_top`, to the tickets email template [79878]
 * Tweak - Changed `tribe_tickets_email_include_event_date` filter default value to true. Now event date shows by default in RSVP ticket emails. Thanks @melvidge for the feedback [102309]
 * Tweak - Replaced start date in the RSVP non-attendace email template with full event schedule details [87686]

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -57,6 +57,20 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 			$encoded = str_replace( '\"', '"', $encoded );
 		}
 
+		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
+		if ( ! strpos( $encoded, '{' ) && ! strpos( $encoded, '}' ) ) {
+			// we create the json from that string
+			$encoded = explode( ',', $encoded );
+
+			$encoded = array_reduce( $encoded, function ( $array, $item ) {
+				list( $key, $value ) = explode( ':' , $item );
+				$array[$key] = $value;
+				return $array;
+			}, array() );
+
+			$encoded = json_encode( $encoded );
+		}
+
 		$decoded = json_decode( urldecode_deep( $encoded ), $assoc_array );
 
 		if ( null === $decoded ) {


### PR DESCRIPTION
🎫 https://central.tri.be/issues/108436

Some PayPal orders were not being recorded because we were receiving the custom parameter in the following format instead of a JSON: `user_id:N,tribe_handler:tpp,pid:N`