### PR TITLE
Spotfix/108436 paypal purchase record

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Make sure the ticket creation is compatible with object cache. Thanks @zanart, @bethanymrac, @vividimage and others for flagging this! [105802]
 * Fix - Display a notice if the user accesses the tickets page and doesn't have tickets [89201]
 * Fix - If the ticket is a WooCommerce product and has a featured image, display it in the email [79877]
+* Fix - Make sure the Paypal orders are being recorded. Thanks @burlingtonbytes for flagging this! [108436]
 * Tweak - Added new action, `tribe_tickets_ticket_email_ticket_top`, to the tickets email template [79878]
 * Tweak - Changed `tribe_tickets_email_include_event_date` filter default value to true. Now event date shows by default in RSVP ticket emails. Thanks @melvidge for the feedback [102309]
 * Tweak - Replaced start date in the RSVP non-attendace email template with full event schedule details [87686]

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -58,7 +58,7 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 		}
 
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
-		if ( 'false' === strpos( $encoded, '{' ) && 'false' === strpos( $encoded, '}' ) ) {
+		if ( false === strpos( $encoded, '{' ) && false === strpos( $encoded, '}' ) ) {
 			// we create the json from that string
 			$encoded = explode( ',', $encoded );
 

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -79,7 +79,7 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 
 
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
-		if ( false === json_decode( $encoded ) ) {
+		if ( false === $decoded = json_decode( urldecode_deep( $encoded ), $assoc_array ) ) {
 			// we create an array that string
 			$encoded = explode( ',', $encoded );
 
@@ -89,8 +89,6 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 			// we convert it into a json
 			$encoded = json_encode( $encoded );
 		}
-
-		$decoded = json_decode( urldecode_deep( $encoded ), $assoc_array );
 
 		if ( null === $decoded ) {
 			return $assoc_array ? array() : new stdClass();

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -77,13 +77,15 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 			$encoded = str_replace( '\"', '"', $encoded );
 		}
 
+
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
-		if ( false === strpos( $encoded, '{' ) && false === strpos( $encoded, '}' ) ) {
+		if ( false === json_decode( $encoded ) ) {
+			echo $encoded;
 			// we create an array that string
 			$encoded = explode( ',', $encoded );
 
 			// Set the proper keys and values for the new array
-			$encoded = array_reduce( $encoded, 'self::array_fix_keys', array() );
+			$encoded = array_reduce( array( __CLASS__, 'array_fix_keys' ), array() );
 
 			// we convert it into a json
 			$encoded = json_encode( $encoded );

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -38,6 +38,22 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 		return $encoded;
 	}
 
+
+	/**
+	 * Fix array keys when the value is key:value
+	 *
+	 * @see Tribe__Tickets__Commerce__PayPal__Custom_Argument:decode()
+	 *
+	 * @since TBD
+	 * @return array $array
+	 *
+	*/
+	private static function array_fix_keys( $array, $item ) {
+		list( $key, $value ) = explode( ':', $item );
+		$array[ $key ] = $value;
+		return $array;
+	}
+
 	/**
 	 * Decodes an array of arguments encoded using the `encode` method.
 	 *
@@ -59,15 +75,13 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
 		if ( false === strpos( $encoded, '{' ) && false === strpos( $encoded, '}' ) ) {
-			// we create the json from that string
+			// we create an array that string
 			$encoded = explode( ',', $encoded );
 
-			$encoded = array_reduce( $encoded, function ( $array, $item ) {
-				list( $key, $value ) = explode( ':', $item );
-				$array[ $key ] = $value;
-				return $array;
-			}, array() );
+			// Set the proper keys and values for the new array
+			$encoded = array_reduce( $encoded, 'self::array_fix_keys', array() );
 
+			// we convert it into a json
 			$encoded = json_encode( $encoded );
 		}
 

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -80,7 +80,6 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
 		if ( false === json_decode( $encoded ) ) {
-			echo $encoded;
 			// we create an array that string
 			$encoded = explode( ',', $encoded );
 

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -57,6 +57,20 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 			$encoded = str_replace( '\"', '"', $encoded );
 		}
 
+		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
+		if ( ! strpos( $encoded, '{' ) && ! strpos( $encoded, '}' ) ) {
+			// we create the json from that string
+			$encoded = explode( ',', $encoded );
+
+			$encoded = array_reduce( $encoded, function ( $array, $item ) {
+				list( $key, $value ) = explode( ':' , $item );
+				$array[$key] = $value;
+				return $array;
+			}, array() );
+
+			$encoded = json_encode( $encoded );
+		}
+
 		$decoded = json_decode( urldecode_deep( $encoded ), $assoc_array );
 
 		if ( null === $decoded ) {

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -63,8 +63,8 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 			$encoded = explode( ',', $encoded );
 
 			$encoded = array_reduce( $encoded, function ( $array, $item ) {
-				list( $key, $value ) = explode( ':' , $item );
-				$array[$key] = $value;
+				list( $key, $value ) = explode( ':', $item );
+				$array[ $key ] = $value;
 				return $array;
 			}, array() );
 

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -49,6 +49,10 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 	 *
 	*/
 	private static function array_fix_keys( $array, $item ) {
+		if ( false === strpos( $item, ':' ) ) {
+			return;
+		}
+
 		list( $key, $value ) = explode( ':', $item );
 		$array[ $key ] = $value;
 		return $array;

--- a/src/Tribe/Commerce/PayPal/Custom_Argument.php
+++ b/src/Tribe/Commerce/PayPal/Custom_Argument.php
@@ -58,7 +58,7 @@ class Tribe__Tickets__Commerce__PayPal__Custom_Argument {
 		}
 
 		// in case we receive the param in non json 'user_id:0,tribe_handler:tpp,pid:4' format
-		if ( ! strpos( $encoded, '{' ) && ! strpos( $encoded, '}' ) ) {
+		if ( 'false' === strpos( $encoded, '{' ) && 'false' === strpos( $encoded, '}' ) ) {
 			// we create the json from that string
 			$encoded = explode( ',', $encoded );
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/108436

Some PayPal orders were not being recorded because we were receiving the custom parameter in the following format instead of a JSON: `user_id:N,tribe_handler:tpp,pid:N`