### PR TITLE
Fix Issues with calculating and displaying ticketed events on the admin list

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,10 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [4.7.5] TBD =
+
+* Fix - Issues with calculating and displaying ticketed events on the admin list [71122]
+
 = [4.7.4.1] 2018-06-22 =
 
 * Fix - Sending the ticket email when WooCommerce is active and purchasing another ticket type [109102]

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -54,6 +54,8 @@ class Tribe__Tickets__Query {
 		$cache      = tribe( 'tickets.cache' );
 		$post_types = (array) $query->get( 'post_type', array( 'post' ) );
 
+		$cache->include_past( true );
+
 		$ids = $has_tickets ? $cache->posts_with_ticket_types( $post_types ) : $cache->posts_without_ticket_types( $post_types );
 
 		$post__in = $query->get( 'post__in' );
@@ -67,5 +69,7 @@ class Tribe__Tickets__Query {
 
 		$query->set( 'post__in', $in );
 		$query->query_vars['post__in'] = $in;
+
+		$cache->include_past( false );
 	}
 }


### PR DESCRIPTION
🎫 https://central.tri.be/issues/71122

Figured out that the "ticketed events" list was sometimes not including the "past" events.