### PR TITLE
Do not enable tickets on events by default when activating TEC

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [4.7.5] TBD =
 
 * Fix - Issues with calculating and displaying ticketed events on the admin list [71122]
+* Tweak - Do not enable tickets on events by default when The Events Calendar is installed [73599]
 
 = [4.7.4.1] 2018-06-22 =
 

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -55,9 +55,7 @@ $tickets_fields = array(
 	),
 	'ticket-enabled-post-types' => array(
 		'type'            => 'checkbox_list',
-		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
-		// only set the default to tribe_events if the ticket-endabled-post-types index has never been saved
-		'default'         => array_key_exists( 'ticket-enabled-post-types', $options ) ? false : 'tribe_events',
+		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),,
 		'options'         => $all_post_types,
 		'can_be_empty'    => true,
 		'validation_type' => 'options_multi',

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -55,7 +55,7 @@ $tickets_fields = array(
 	),
 	'ticket-enabled-post-types' => array(
 		'type'            => 'checkbox_list',
-		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),,
+		'label'           => esc_html__( 'Post types that can have tickets', 'event-tickets' ),
 		'options'         => $all_post_types,
 		'can_be_empty'    => true,
 		'validation_type' => 'options_multi',


### PR DESCRIPTION
🎫 https://central.tri.be/issues/73599

As requested on the ticket:

> The settings behavior should be consistent. Since the pages and posts options are not checked by default when you first activate Event Tickets by itself, the events option should also not be checked when The Events Calendar is first activated.