### PR TITLE
#110248 - fix tribe_is_event fatal if the events calendar is not active

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Event Tickets
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 4.7.5
+Version: 4.7.5.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-tickets",
-  "version": "4.7.5",
+  "version": "4.7.5.1",
   "repository": "git@github.com:moderntribe/event-tickets.git",
   "_zipname": "event-tickets",
   "_zipfoldername": "event-tickets",

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,10 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [4.7.5.1] 2018-07-10 =
+
+* Fix - Fatal error on some product pages when The Events Calendar is not active [110248]
+
 = [4.7.5] 2018-07-09 =
 
 * Fix - Display unavailability message when tickets are not yet or no longer available [81334]

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, borkweb, bordoni, barry.hughes, aguseo, brianjessee, 
 Tags: RSVP, events, tickets, event management, calendar, ticket sales, community, registration, api, dates, date, posts, workshop, conference, meeting, seminar, concert, summit, ticket integration, event ticketing
 Requires at least: 4.5
 Tested up to: 4.9.6
-Stable tag: 4.7.5
+Stable tag: 4.7.5.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4,7 +4,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '4.7.5';
+	const VERSION = '4.7.5.1';
 
 	/**
 	 * Min required The Events Calendar version

--- a/src/Tribe/REST/V1/Headers/Base.php
+++ b/src/Tribe/REST/V1/Headers/Base.php
@@ -92,7 +92,7 @@ class Tribe__Tickets__REST__V1__Headers__Base implements Tribe__REST__Headers__B
 	 * @return string
 	 */
 	public function get_rest_url() {
-		if ( is_single() && tribe_is_event() ) {
+		if ( is_single() && is_singular( 'tribe_events' ) ) {
 			return tribe_tickets_rest_url( 'tickets/' . Tribe__Main::post_id_helper() );
 		}
 


### PR DESCRIPTION
This fatal occurs when The Events Calendar is not active.