### PR TITLE
Stop showing posts with "pending review" status in the blog page.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Fixed the "Show description" setting for Tribe Commerce tickets in the backend and frontend [100524]
 * Fix - Added required post ID parameter to `the_title` filter in Tribe Commerce [109592]
 * Fix - Stop showing tickets for past events with no end sale date. Thanks to @thesinglegourmet for flagging this! [107121]
+* Fix - Stop showing posts with "pending review" status in the blog page. Thanks Jansen, Antonio and others for reporting this issue! [102184]
 * Tweak - Made the attendees list html title translatable. Thanks @websource for pointing this out [109595]
 
 = [4.7.5.1] 2018-07-10 =

--- a/src/Tribe/Commerce/PayPal/Stati.php
+++ b/src/Tribe/Commerce/PayPal/Stati.php
@@ -19,7 +19,7 @@ class Tribe__Tickets__Commerce__PayPal__Stati {
 	 *
 	 * @var string
 	 */
-	public static $pending = 'pending';
+	public static $pending = 'pending-payment';
 
 	/**
 	 * The string representing the slug for a denied payment status.


### PR DESCRIPTION
🎫 https://central.tri.be/issues/102184

I was hesitant at first about how to fix this one, and I ended up deciding to change the wording. The pending post status is reserved and we shouldn't mess with that. It's better to change it now and provide a snippet in case somebody has an issue with their paypal orders where the status was pending.

