### PR TITLE
Correct shortcode reference (spotfix) | #111011

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Added parent post and order IDs as parameters to the Tribe Commerce email filters [104209]
 * Tweak - Made the attendees list html title translatable. Thanks @websource for pointing this out [109595]
 * Tweak - Added a new filter `tribe_tickets_email_ticket_image` for easier ticket image customization in the tickets email [79876]
+* Tweak - Corrected the reference to the [tribe-tpp-success] shortcode within the Tribe Commerce settings area [111011]
 * Feature - Include RSVP and Tribe Commerce tickets fields data in WP personal data eraser [108490]
 * Feature - Include TribeCommerce orders data in WP personal data exporter [108487]
 

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -277,7 +277,7 @@ $paypal_fields            = array(
 		'tooltip'         => esc_html(
 			                     sprintf(
 				                     __( 'After a successful PayPal order users will be redirected to this page; use the %s shortcode to display the order confirmation to the user in the page content.', 'event-tickets' ),
-				                     '[$tpp_success_shortcode]'
+				                     "[$tpp_success_shortcode]"
 			                     )
 		                     ),
 		'size'            => 'medium',


### PR DESCRIPTION
Fixes the Tribe Commerce settings area so we display the correct shortcode name.

:ticket: [#111011](https://central.tri.be/issues/111011)