### PR TITLE
Fixed datepicker formats validation error on ticket start sale date

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,8 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.7.7] TBD =
 
+* Fix - Fixed datepicker formats YYYY.MM.DD, MM.DD.YYYY and DD.MM.YYYY validation error on ticket start sale date. Thanks @dmitry-zhuk, Albert and others for reporting this issue! [102815]
+
 = [4.7.6] 2018-08-01 =
 
 * Fix - Fixed the "Show description" setting for Tribe Commerce tickets in the backend and frontend [100524]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -14,7 +14,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Min required version of Tribe Common
 	 */
-	const MIN_COMMON_VERSION = '4.7.17';
+	const MIN_COMMON_VERSION = '4.7.19';
 
 	/**
 	 * Name of the provider


### PR DESCRIPTION
🎫 https://central.tri.be/issues/102815

The origin of the problem is in the validation script in common. Bumping version and adding readme entry to log that we solved this one.

Related: https://github.com/moderntribe/tribe-common/pull/750