### PR TITLE
Set a datepicker format when using ET as standalone.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Display RSVP/Tickets unavailability message on the position selected over the Settings. Thanks @liblogger for flagging this! [113161]
 * Fix - Remove the "Not Going" RSVPs from the attendee count on the events list. Props to @mirre1 for flagging this! [111104]
 * Fix - Ensured that the TribeCommerce ticket start and end sale date respect the event timezone. Thanks Ryan and Georges for flagging this! [109510]
+* Fix - Fixed datepicker format related problems when using Event Tickets as standalone [111817]
 * Tweak - Fix some internal documentation of shortcode templates to ensure filenames are accurate [112360]
 * Tweak - Prevent RSVP form from submitting when the quantity is 0 or if blank [113989]
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -37,6 +37,11 @@ class Tribe__Tickets__Assets {
 			'remove_ticket_nonce' => wp_create_nonce( 'remove_ticket_nonce' ),
 		);
 
+		$datepicker_formats = array(
+			'datepicker_format'       => Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) ),
+			'datepicker_format_index' => tribe_get_option( 'datepickerFormat' ),
+		);
+
 		$locale  = localeconv();
 		$decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
 
@@ -93,6 +98,10 @@ class Tribe__Tickets__Assets {
 						'data' => array(
 							'nav_away_msg' => __( 'It looks like you have modified your shared capacity setting but have not saved or updated the post.', 'event-tickets' ),
 						),
+					),
+					array(
+						'name' => 'tribe_dynamic_help_text',
+						'data' => $datepicker_formats,
 					),
 					array(
 						'name' => 'price_format',


### PR DESCRIPTION
🎫 https://central.tri.be/issues/111817

When using ET without TEC the datepicker format wasn't getting there, so it was defaulting to the first one on the list.