### PR TITLE
Add initial architecture

### DIFF
--- a/src/Tribe/Attendee_Info.php
+++ b/src/Tribe/Attendee_Info.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Class Tribe__Tickets__Attendee_Info
+ */
+class Tribe__Tickets__Attendee_Info {
+
+	public function hook() {
+		// Attendee Info rewrites
+		add_action( 'plugins_loaded', array( Tribe__Tickets__Rewrite::instance(), 'hooks' ) );
+		add_action( 'template_redirect', array( $this, 'display_attendee_info_page' ) );
+	}
+
+	public function display_attendee_info_page() {
+		global $wp_query;
+
+		if ( empty( $wp_query->query_vars['attendeeInfo'] ) ) {
+			return;
+		}
+
+		// @todo: get actual tickets here from the various carts
+		$tickets = array();
+
+		/** @var Tribe__Tickets__Attendee_Info_View $view */
+		$view = tribe( 'tickets.attendees.view' );
+		$view->template( 'content', array( 'tickets' => $tickets ) );
+		die();
+	}
+
+}

--- a/src/Tribe/Attendee_Info_View.php
+++ b/src/Tribe/Attendee_Info_View.php
@@ -1,15 +1,11 @@
 <?php
 
 /**
- * Class Tribe__Tickets_Plus__Commerce__PayPal__Views
- *
- * @since 4.7
+ * Class Tribe__Tickets__Attendee_Info_View
  */
 class Tribe__Tickets__Attendee_Info_View extends Tribe__Template {
 	/**
-	 * Tribe__Tickets_Plus__Commerce__PayPal__Views constructor.
-	 *
-	 * @since 4.7
+	 * Tribe__Tickets__Attendee_Info_View constructor.
 	 */
 	public function __construct() {
 		$this->set_template_origin( Tribe__Tickets__Main::instance() );

--- a/src/Tribe/Attendee_Info_View.php
+++ b/src/Tribe/Attendee_Info_View.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class Tribe__Tickets_Plus__Commerce__PayPal__Views
+ *
+ * @since 4.7
+ */
+class Tribe__Tickets__Attendee_Info_View extends Tribe__Template {
+	/**
+	 * Tribe__Tickets_Plus__Commerce__PayPal__Views constructor.
+	 *
+	 * @since 4.7
+	 */
+	public function __construct() {
+		$this->set_template_origin( Tribe__Tickets__Main::instance() );
+		$this->set_template_folder( 'src/views/registration/attendees' );
+		$this->set_template_context_extract( true );
+	}
+}

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -134,8 +134,8 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_primary_info( array $item ) {
-		$purchaser_name  = empty( $item[ 'purchaser_name' ] ) ? '' : esc_html( $item[ 'purchaser_name' ] );
-		$purchaser_email = empty( $item[ 'purchaser_email' ] ) ? '' : esc_html( $item[ 'purchaser_email' ] );
+		$purchaser_name  = empty( $item['holder_name'] ) ? ( empty( $item[ 'purchaser_name' ] ) ? '' : esc_html( $item[ 'purchaser_name' ] ) ) : $item['holder_name'];
+		$purchaser_email = empty( $item['holder_email'] ) ? ( empty( $item[ 'purchaser_email' ] ) ? '' : esc_html( $item[ 'purchaser_email' ] ) ) : $item['holder_email'];
 
 		$output = "
 			<div class='purchaser_name'>{$purchaser_name}</div>

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2540,8 +2540,8 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 			// Fields for Email Tickets
 			'event_id'      => get_post_meta( $attendee->ID, $this->attendee_event_key, true ),
 			'ticket_name'   => ! empty( $product ) ? $product->post_title : false,
-			'holder_name'   => get_post_meta( $attendee->ID, $this->full_name, true ),
-			'holder_email'  => get_post_meta( $attendee->ID, $this->email, true ),
+			'holder_name'   => $this->get_holder_name( $attendee ),
+			'holder_email'  => $this->get_holder_email( $attendee ),
 			'order_id'      => $attendee->ID,
 			'ticket_id'     => $ticket_unique_id,
 			'qr_ticket_id'  => $attendee->ID,
@@ -2564,6 +2564,26 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		$attendee_data = apply_filters( 'tribe_tickets_attendee_data', $attendee_data, 'tpp', $attendee );
 
 		return $attendee_data;
+	}
+
+	protected function get_holder_name( $attendee ) {
+		$saved_name = $this->get_attendee_name( $attendee );
+
+		if ( ! empty( $saved_name ) ) {
+			return $saved_name;
+		}
+
+		return get_post_meta( $attendee->ID, $this->full_name, true );
+	}
+
+	protected function get_holder_email( $attendee ) {
+		$saved_email = $this->get_attendee_email( $attendee );
+
+		if ( ! empty( $saved_email ) ) {
+			return $saved_email;
+		}
+
+		return get_post_meta( $attendee->ID, $this->email, true );
 	}
 
 	/**

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2566,6 +2566,13 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		return $attendee_data;
 	}
 
+	/**
+	 * Get the Holder's Name; from the stored meta first if available, then from the attendee meta.
+	 *
+	 * @param $attendee
+	 *
+	 * @return string
+	 */
 	protected function get_holder_name( $attendee ) {
 		$saved_name = $this->get_attendee_name( $attendee );
 
@@ -2576,6 +2583,13 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		return get_post_meta( $attendee->ID, $this->full_name, true );
 	}
 
+	/**
+	 * Get the Holder email; from the stored meta first if available, then from the attendee meta.
+	 *
+	 * @param $attendee
+	 *
+	 * @return string
+	 */
 	protected function get_holder_email( $attendee ) {
 		$saved_email = $this->get_attendee_email( $attendee );
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -188,7 +188,7 @@ class Tribe__Tickets__Main {
 
 		tribe( 'tickets.privacy' );
 
-        tribe( 'tickets.attendees.info' );
+		tribe( 'tickets.attendees.info' );
 
 		/**
 		 * Fires once Event Tickets has completed basic setup.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -352,6 +352,9 @@ class Tribe__Tickets__Main {
 		// Attendee screen enhancements
 		add_action( 'tribe_events_tickets_attendees_event_details_top', array( $this, 'setup_attendance_totals' ), 20 );
 
+		// Attendee Info rewrites
+        add_action( 'plugins_loaded', array( Tribe__Tickets__Rewrite::instance(), 'hooks' ) );
+
 		// CSV Import options
 		if ( class_exists( 'Tribe__Events__Main' ) ) {
 			add_filter( 'tribe_events_import_options_rows', array( Tribe__Tickets__CSV_Importer__Rows::instance(), 'filter_import_options_rows' ) );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -188,6 +188,8 @@ class Tribe__Tickets__Main {
 
 		tribe( 'tickets.privacy' );
 
+        tribe( 'tickets.attendees.info' );
+
 		/**
 		 * Fires once Event Tickets has completed basic setup.
 		 */
@@ -205,6 +207,10 @@ class Tribe__Tickets__Main {
 		tribe_singleton( 'tickets.commerce.currency', 'Tribe__Tickets__Commerce__Currency', array( 'hook' ) );
 		tribe_singleton( 'tickets.commerce.paypal', new Tribe__Tickets__Commerce__PayPal__Main );
 		tribe_singleton( 'tickets.redirections', 'Tribe__Tickets__Redirections' );
+
+		// Attendee Info
+		tribe_singleton( 'tickets.attendees.info', 'Tribe__Tickets__Attendee_Info', array( 'hook' ) );
+		tribe_singleton( 'tickets.attendees.view', 'Tribe__Tickets__Attendee_Info_View' );
 
 		// REST API v1
 		tribe_register_provider( 'Tribe__Tickets__REST__V1__Service_Provider' );
@@ -348,12 +354,6 @@ class Tribe__Tickets__Main {
 		// Hook to oembeds
 		add_action( 'tribe_events_embed_after_the_cost_value', array( $this, 'inject_buy_button_into_oembed' ) );
 		add_action( 'embed_head', array( $this, 'embed_head' ) );
-
-		// Attendee screen enhancements
-		add_action( 'tribe_events_tickets_attendees_event_details_top', array( $this, 'setup_attendance_totals' ), 20 );
-
-		// Attendee Info rewrites
-        add_action( 'plugins_loaded', array( Tribe__Tickets__Rewrite::instance(), 'hooks' ) );
 
 		// CSV Import options
 		if ( class_exists( 'Tribe__Events__Main' ) ) {

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -76,6 +76,10 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 		$rewrite->add( array( '{{ attendee-info }}' ), array( 'attendeeInfo' => 1 ) );
 	}
 
+	public function add_rewrite_tags() {
+		add_rewrite_tag('%attendeeInfo%', '([^&]+)');
+	}
+
 	/**
 	 * Get the base slugs for the Plugin Rewrite rules
 	 *
@@ -111,9 +115,6 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 
 		// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)
 		$bases = array_map( 'array_unique', $bases );
-
-		// By default we always have `en_US` to avoid 404 with older URLs
-		$languages = apply_filters( 'tribe_tickets_rewrite_i18n_languages', array_unique( array( 'en_US', get_locale() ) ) );
 
 		// By default we load the Default and our plugin domains
 		$domains = apply_filters( 'tribe_tickets_rewrite_i18n_domains', array(
@@ -160,5 +161,6 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 	protected function add_hooks() {
 		parent::add_hooks();
 		add_action( 'tribe_tickets_pre_rewrite', array( $this, 'generate_core_rules' ) );
+		add_action( 'init', array( $this, 'add_rewrite_tags' ) );
 	}
 }

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -1,0 +1,164 @@
+<?php
+// Don't load directly
+defined( 'WPINC' ) or die;
+
+/**
+ * Rewrite Configuration Class
+ * Permalinks magic Happens over here!
+ */
+class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
+
+	/**
+	 * Tribe__Tickets__Rewrite constructor.
+	 *
+	 * @param WP_Rewrite|null $wp_rewrite
+	 */
+	public function __construct( WP_Rewrite $wp_rewrite = null ) {
+		$this->rewrite = $wp_rewrite;
+	}
+
+	/**
+	 * Static Singleton Factory Method
+	 *
+	 * @return Tribe__Tickets__Rewrite
+	 */
+	public static function instance( $wp_rewrite = null ) {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self( $wp_rewrite );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Generate the Rewrite Rules
+	 *
+	 * @param  WP_Rewrite $wp_rewrite WordPress Rewrite that will be modified, pass it by reference (&$wp_rewrite)
+	 */
+	public function filter_generate( WP_Rewrite $wp_rewrite ) {
+		$this->setup( $wp_rewrite );
+
+		/**
+		 * Use this to change the Tribe__Tickets__Rewrite instance before new rules
+		 * are committed.
+		 *
+		 * Should be used when you want to add more rewrite rules without having to
+		 * deal with the array merge, noting that rules for The Events Calendar are
+		 * themselves added via this hook (default priority).
+		 *
+		 * @var Tribe__Tickets__Rewrite $rewrite
+		 */
+		do_action( 'tribe_tickets_pre_rewrite', $this );
+
+		/**
+		 * Provides an opportunity to modify The Events Calendar's rewrite rules before they
+		 * are merged in to WP's own rewrite rules.
+		 *
+		 * @param array $events_rewrite_rules
+		 * @param Tribe__Tickets__Rewrite $tribe_rewrite
+		 * @param WP_Rewrite $wp_rewrite WordPress Rewrite that will be modified.
+		 */
+		$this->rules = apply_filters( 'tribe_tickets_rewrite_rules_custom', $this->rules, $this, $wp_rewrite );
+
+		$wp_rewrite->rules = $this->rules + $wp_rewrite->rules;
+	}
+
+	/**
+	 * Sets up the rules required by The Events Calendar.
+	 *
+	 * This should be called during tribe_tickets_pre_rewrite, which means other plugins needing to add rules
+	 * of their own can do so on the same hook at a lower or higher priority, according to how specific
+	 * those rules are.
+	 *
+	 * @param Tribe__Tickets__Rewrite $rewrite
+	 */
+	public function generate_core_rules( Tribe__Tickets__Rewrite $rewrite ) {
+		$rewrite->add( array( '{{ attendee-info }}' ), array( 'attendeeInfo' => 1 ) );
+	}
+
+	/**
+	 * Get the base slugs for the Plugin Rewrite rules
+	 *
+	 * WARNING: Don't mess with the filters below if you don't know what you are doing
+	 *
+	 * @param  string $method Use "regex" to return a Regular Expression with the possible Base Slugs using l10n
+	 * @return object         Return Base Slugs with l10n variations
+	 */
+	public function get_bases( $method = 'regex' ) {
+		$tec = Tribe__Events__Main::instance();
+
+		/**
+		 * If you want to modify the base slugs before the i18n happens filter this use this filter
+		 * All the bases need to have a key and a value, they might be the same or not.
+		 *
+		 * Each value is an array of possible slugs: to improve robustness the "original" English
+		 * slug is supported in addition to translated forms for month, list, today and day: this
+		 * way if the forms are altered (whether through i18n or other custom mods) *after* links
+		 * have already been promulgated, there will be less chance of visitors hitting 404s.
+		 *
+		 * The term "original" here for:
+		 * - events
+		 * - event
+		 *
+		 * Means that is a value that can be overwritten and relies on the user value entered on the
+		 * options page.
+		 *
+		 * @var array $bases
+		 */
+		$bases = apply_filters( 'tribe_tickets_rewrite_base_slugs', array(
+			'attendee-info' => array( Tribe__Settings_Manager::get_option( 'attendeeInfoSlug', 'attendee-info' ) ),
+		) );
+
+		// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)
+		$bases = array_map( 'array_unique', $bases );
+
+		// By default we always have `en_US` to avoid 404 with older URLs
+		$languages = apply_filters( 'tribe_tickets_rewrite_i18n_languages', array_unique( array( 'en_US', get_locale() ) ) );
+
+		// By default we load the Default and our plugin domains
+		$domains = apply_filters( 'tribe_tickets_rewrite_i18n_domains', array(
+			'default'             => true, // Default doesn't need file path
+			'the-events-calendar' => $tec->plugin_dir . 'lang/',
+		) );
+
+		/**
+		 * Use `tribe_tickets_rewrite_i18n_slugs_raw` to modify the raw version of the l10n slugs bases.
+		 *
+		 * This is useful to modify the bases before the method is taken into account.
+		 *
+		 * @param array  $bases   An array of rewrite bases that have been generated.
+		 * @param string $method  The method that's being used to generate the bases; defaults to `regex`.
+		 * @param array  $domains An associative array of language domains to use; these would be plugin or themes language
+		 *                        domains with a `'plugin-slug' => '/absolute/path/to/lang/dir'`
+		 */
+		$bases = apply_filters( 'tribe_tickets_rewrite_i18n_slugs_raw', $bases, $method, $domains );
+
+		if ( 'regex' === $method ) {
+			foreach ( $bases as $type => $base ) {
+				// Escape all the Bases
+				$base = array_map( 'preg_quote', $base );
+
+				// Create the Regular Expression
+				$bases[ $type ] = '(?:' . implode( '|', $base ) . ')';
+			}
+		}
+
+		/**
+		 * Use `tribe_tickets_rewrite_i18n_slugs` to modify the final version of the l10n slugs bases
+		 *
+		 * At this stage the method has been applied already and this filter will work with the
+		 * finalized version of the bases.
+		 *
+		 * @param array  $bases   An array of rewrite bases that have been generated.
+		 * @param string $method  The method that's being used to generate the bases; defaults to `regex`.
+		 * @param array  $domains An associative array of language domains to use; these would be plugin or themes language
+		 *                        domains with a `'plugin-slug' => '/absolute/path/to/lang/dir'`
+		 */
+		return (object) apply_filters( 'tribe_tickets_rewrite_i18n_slugs', $bases, $method, $domains );
+	}
+
+	protected function add_hooks() {
+		parent::add_hooks();
+		add_action( 'tribe_tickets_pre_rewrite', array( $this, 'generate_core_rules' ) );
+	}
+}

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -106,7 +106,7 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 		 * @var array $bases
 		 */
 		$bases = apply_filters( 'tribe_tickets_rewrite_base_slugs', array(
-			'attendee-info' => array( Tribe__Settings_Manager::get_option( 'attendeeInfoSlug', 'attendee-info' ) ),
+			'attendee-info' => array( Tribe__Settings_Manager::get_option( 'ticket-attendee-info-slug', 'attendee-info' ) ),
 		) );
 
 		// Remove duplicates (no need to have 'month' twice if no translations are in effect, etc)

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -43,7 +43,7 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 		 * are committed.
 		 *
 		 * Should be used when you want to add more rewrite rules without having to
-		 * deal with the array merge, noting that rules for The Events Calendar are
+		 * deal with the array merge, noting that rules for Event Tickets are
 		 * themselves added via this hook (default priority).
 		 *
 		 * @var Tribe__Tickets__Rewrite $rewrite
@@ -51,7 +51,7 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 		do_action( 'tribe_tickets_pre_rewrite', $this );
 
 		/**
-		 * Provides an opportunity to modify The Events Calendar's rewrite rules before they
+		 * Provides an opportunity to modify Event Tickets' rewrite rules before they
 		 * are merged in to WP's own rewrite rules.
 		 *
 		 * @param array $events_rewrite_rules
@@ -64,7 +64,7 @@ class Tribe__Tickets__Rewrite extends Tribe__Rewrite {
 	}
 
 	/**
-	 * Sets up the rules required by The Events Calendar.
+	 * Sets up the rules required by Event Tickets.
 	 *
 	 * This should be called during tribe_tickets_pre_rewrite, which means other plugins needing to add rules
 	 * of their own can do so on the same hook at a lower or higher priority, according to how specific

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -252,6 +252,27 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		public $attendee_optout_key = '';
 
 		/**
+		 * Meta key to store the attendee's first name if provided.
+		 *
+		 * @var string
+		 */
+		const ATTENDEE_FIRST_NAME = '_tribe_attendee_first_name';
+
+		/**
+		 * Meta key to store the attendee's last name if provided.
+		 *
+		 * @var string
+		 */
+		const ATTENDEE_LAST_NAME = '_tribe_attendee_last_name';
+
+		/**
+		 * Meta key to store the attendee's email if provided.
+		 *
+		 * @var string
+		 */
+		const ATTENDEE_EMAIL = '_tribe_attendee_email';
+
+		/**
 		 * Returns link to the report interface for sales for an event or
 		 * null if the provider doesn't have reporting capabilities.
 		 *
@@ -698,6 +719,31 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return mixed
 		 */
 		protected function get_attendees( $attendees_query, $post_id ) {}
+
+		/**
+		 * @param \WP_Post $attendee
+		 *
+		 * @return string
+		 */
+		protected function get_attendee_name( $attendee ) {
+			$fname = get_post_meta( $attendee->ID, self::ATTENDEE_FIRST_NAME, true );
+			$lname = get_post_meta( $attendee->ID, self::ATTENDEE_LAST_NAME, true );
+
+			if ( empty( $fname ) && empty( $lname ) ) {
+				return '';
+			}
+
+			return sprintf( '%1s %2s', $fname, $lname );
+		}
+
+		/**
+		 * @param \WP_Post $attendee
+		 *
+		 * @return mixed
+		 */
+		protected function get_attendee_email( $attendee ) {
+			return get_post_meta( $attendee->ID, self::ATTENDEE_EMAIL, true );
+		}
 
 		/**
 		 * Mark an attendee as checked in

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -65,6 +65,22 @@ $tickets_fields = array(
 );
 
 /**
+ * Add in option to define slug for attendee info page
+ */
+$tickets_fields = array_merge( $tickets_fields, array(
+		'ticket-attendee-info-slug' => array(
+			'type'                => 'text',
+			'label'               => esc_html__( 'Attendee Info URL slug', 'event-tickets' ),
+			'tooltip'             => esc_html__( 'The slug used for building the URL for the Attendee Info page.', 'event-tickets' ),
+			'size'                => 'medium',
+			'default'             => 'attendee-info',
+			'validation_callback' => 'is_string',
+			'validation_type'     => 'textarea',
+		),
+	)
+);
+
+/**
  * If  The Events Calendar is active let's add an option to control the position
  * of the ticket forms in the events view.
  */

--- a/src/views/registration/attendees/content.php
+++ b/src/views/registration/attendees/content.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * This template renders the registration/purchase attendee fields
+ *
+ * @version TBD
+ *
+ */
+?>
+<div
+	class="tribe-block__tickets__item__attendee__fields"
+>
+	<?php foreach ( $tickets as $key => $ticket ) : ?>
+		<?php $this->template( 'fields', array( 'ticket' => $ticket, 'key' => $key ) ); ?>
+	<?php endforeach; ?>
+</div>
+

--- a/src/views/registration/attendees/fields.php
+++ b/src/views/registration/attendees/fields.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This template renders a the fields for a ticket
+ *
+ * @version TBD
+ *
+ */
+
+$ticket = $this->get( 'ticket' );
+
+$meta   = Tribe__Tickets_Plus__Main::instance()->meta();
+$fields = $meta->get_meta_fields_by_ticket( $ticket->ID );
+
+?>
+<?php foreach ( $fields as $field ) : ?>
+	<?php $this->template( 'fields/' . $field->type  , array( 'ticket' => $ticket, 'field' => $field ) ); ?>
+<?php endforeach; ?>

--- a/src/views/registration/attendees/fields/checkbox.php
+++ b/src/views/registration/attendees/fields/checkbox.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This template renders the Checkbox
+ *
+ * @version TBD
+ *
+ */
+$required      = isset( $field->required ) && 'on' === $field->required ? true : false;
+$field         = (array) $field;
+$attendee_id   = null;
+$value         = '';
+$is_restricted = false;
+$options       = null;
+
+if ( isset( $field['extra'] ) && ! empty( $field['extra']['options'] ) ) {
+	$options = $field['extra']['options'];
+}
+
+if ( ! is_array( $value ) ) {
+	$value = array();
+}
+
+if ( ! $options ) {
+	return;
+}
+?>
+<div
+	class="tribe-field tribe-block__tickets__item__attendee__field__checkbox <?php echo $required ? 'tribe-tickets-meta-required' : ''; ?>"
+>
+	<header class="tribe-tickets-meta-label">
+		<h3><?php echo wp_kses_post( $field['label'] ); ?></h3>
+	</header>
+	<div class="tribe-options">
+		<?php
+		foreach ( $options as $option ) {
+			$option_slug = sanitize_title( $option );
+			$field_slug  = $field['slug'];
+			$option_id   = "tribe-tickets-meta_{$field_slug}" . ( $attendee_id ? '_' . $attendee_id : '' ) . "_{$option_slug}";
+			$slug        = $field_slug . '_' . $option_slug;
+			?>
+			<label for="<?php echo esc_attr( $option_id ); ?>" class="tribe-tickets-meta-field-header">
+				<input
+					type="checkbox"
+					id="<?php echo esc_attr( $option_id ); ?>"
+					class="ticket-meta"
+					name="tribe-tickets-meta[<?php echo $attendee_id ?>][<?php echo esc_attr( $slug ); ?>]"
+					value="<?php echo esc_attr( $option ); ?>"
+					<?php checked( true, in_array( $slug, $value ) ); ?>
+					<?php disabled( $is_restricted ); ?>
+				>
+				<span class="tribe-tickets-meta-option-label">
+					<?php echo wp_kses_post( $option ); ?>
+				</span>
+			</label>
+			<?php
+		}
+		?>
+	</div>
+</div>

--- a/src/views/registration/attendees/fields/radio.php
+++ b/src/views/registration/attendees/fields/radio.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This template renders a Single Ticket content
+ * composed by Title and Description currently
+ *
+ * @version TBD
+ *
+ */
+$field         = $this->get( 'field' );
+$required      = isset( $field->required ) && 'on' === $field->required ? true : false;
+$field         = (array) $field;
+
+$options = null;
+
+if ( isset( $field['extra'] ) && ! empty( $field['extra']['options'] ) ) {
+	$options = $field['extra']['options'];
+}
+
+if ( ! $options ) {
+	return;
+}
+
+$attendee_id   = null;
+$value         = '';
+$is_restricted = false;
+$slug          = $field['slug'];
+?>
+<div
+	class="tribe-field tribe-block__tickets__item__attendee__field__radio <?php echo $required ? 'tribe-tickets-meta-required' : ''; ?>"
+>
+	<header class="tribe-tickets-meta-label">
+		<h3><?php echo wp_kses_post( $field['label'] ); ?></h3>
+	</header>
+
+	<div class="tribe-options">
+		<?php
+		foreach ( $options as $option ) {
+			$option_slug = sanitize_title( $option );
+			$option_id = "tribe-tickets-meta_{$slug}" . ( $attendee_id ? '_' . $attendee_id : '' ) . "_{$option_slug}" ;
+			?>
+			<label for="<?php echo esc_attr( $option_id ); ?>" class="tribe-tickets-meta-field-header">
+				<input
+					type="radio"
+					id="<?php echo esc_attr( $option_id ); ?>"
+					class="ticket-meta"
+					name="tribe-tickets-meta[<?php echo $attendee_id ?>][<?php echo esc_attr( $slug ); ?>]"
+					value="<?php echo esc_attr( $option ); ?>"
+					<?php checked( $option, $value ); ?>
+					<?php disabled( $is_restricted ); ?>
+				>
+				<span class="tribe-tickets-meta-option-label">
+					<?php echo wp_kses_post( $option ); ?>
+				</span>
+			</label>
+			<?php
+		}
+		?>
+	</div>
+</div>

--- a/src/views/registration/attendees/fields/select.php
+++ b/src/views/registration/attendees/fields/select.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Descriptio
+ *
+ * @version TBD
+ *
+ */
+$required      = isset( $field->required ) && 'on' === $field->required ? true : false;
+$field         = (array) $field;
+$attendee_id   = null;
+$value         = '';
+$is_restricted = false;
+$slug          = $field['slug'];
+$options       = null;
+$field_name    = 'tribe-tickets-meta[' . $attendee_id . '][' .esc_attr( $slug ) . ']';
+
+if ( isset( $field['extra'] ) && ! empty( $field['extra']['options'] ) ) {
+	$options = $field['extra']['options'];
+}
+
+if ( ! $options ) {
+	return;
+}
+
+$option_id = "tribe-tickets-meta_{$slug}" . ( $attendee_id ? '_' . $attendee_id : '' );
+?>
+<div
+	class="tribe-field tribe-block__tickets__item__attendee__field__select <?php echo $required ? 'tribe-tickets-meta-required' : ''; ?>"
+>
+	<label for="<?php echo esc_attr( $option_id ); ?>"><?php echo wp_kses_post( $field['label'] ); ?></label>
+	<select	<?php disabled( $is_restricted ); ?>
+		id="<?php echo esc_attr( $option_id ); ?>"
+		class="ticket-meta"
+		name="<?php echo $field_name; ?>"
+		<?php echo $required ? 'required' : ''; ?>
+	>
+		<option><?php esc_html_e( 'Select an option', 'events-gutenberg' ); ?></option>
+		<?php foreach ( $options as $option ) : ?>
+			<option <?php selected( $option, $value ); ?>><?php echo esc_html( $option ); ?></option>
+		<?php endforeach; ?>
+	</select>
+</div>

--- a/src/views/registration/attendees/fields/text.php
+++ b/src/views/registration/attendees/fields/text.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This template renders a Single Ticket content
+ * composed by Title and Description currently
+ *
+ * @version TBD
+ *
+ */
+$attendee_id   = null;
+$required      = isset( $field->required ) && 'on' === $field->required ? true : false;
+$option_id     = "tribe-tickets-meta_{$field->slug}" . ( $attendee_id ? '_' . $attendee_id : '' );
+$field         = (array) $field;
+$multiline     = isset( $field['extra'] ) && isset( $field['extra']['multiline'] ) ? $field['extra']['multiline'] : '';
+$value         = '';
+$is_restricted = false;
+$field_name    = 'tribe-tickets-meta[' . $attendee_id . '][' . esc_attr( $field['slug'] ) . ']';
+?>
+<div
+	class="tribe-field tribe-block__tickets__item__attendee__field__text <?php echo $required ? 'tribe-tickets-meta-required' : ''; ?>"
+>
+	<label for="<?php echo esc_attr( $option_id ); ?>"><?php echo wp_kses_post( $field['label'] ); ?></label>
+	<?php if ( $multiline ) : ?>
+		<textarea
+			id="<?php echo esc_attr( $option_id ); ?>"
+			name="<?php echo $field_name; ?>"
+			<?php echo $required ? 'required' : ''; ?>
+			<?php disabled( $is_restricted ); ?>
+		><?php echo esc_textarea( $value ); ?></textarea>
+	<?php else : ?>
+		<input
+			type="text"
+			id="<?php echo esc_attr( $option_id ); ?>"
+			name="<?php echo $field_name; ?>"
+			value="<?php echo esc_attr( $value ); ?>"
+			<?php echo $required ? 'required' : ''; ?>
+			<?php disabled( $is_restricted ); ?>
+		>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
This adds in the initial architecture, including:

- Registering the settings field for the Attendee Info Slug
- Registering the rewrites for loading the Attendee Info page
- Registering the Views to actually display the Attendee info view templates
- Adding in the view templates (sourced from the events-gutenberg plugin and the work juanfra did)
- Adding in methods to retrieve the holder info from the stored meta instead of the full name data (in preparation for BE work)