### PR TITLE
REST API > Make the currency values dependants on the ticket provider

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [4.8.3] TBD =
 
 * Fix - Ensure ticket start sale and end sale datepicker respects the WordPress Week Starts On Setting, thanks websource! [109729]
+* Tweak - Ensure the ticket currency and position returned by the REST API is based on the ticket provider [116352]
 
 = [4.8.2.1] 2018-10-10 =
 

--- a/src/Tribe/Commerce/Currency.php
+++ b/src/Tribe/Commerce/Currency.php
@@ -375,7 +375,7 @@ class Tribe__Tickets__Commerce__Currency {
 	 *
 	 * @return string
 	 */
-	protected function get_provider_symbol( $provider, $object_id ) {
+	public function get_provider_symbol( $provider, $object_id ) {
 		if ( ! class_exists( $provider ) ) {
 			return $this->get_currency_symbol( $object_id );
 		}
@@ -438,7 +438,7 @@ class Tribe__Tickets__Commerce__Currency {
 	 *
 	 * @return string
 	 */
-	protected function get_provider_symbol_position( $provider, $object_id ) {
+	public function get_provider_symbol_position( $provider, $object_id ) {
 		if ( ! class_exists( $provider ) ) {
 			return $this->get_currency_symbol_position( $object_id );
 		}

--- a/src/Tribe/REST/V1/Post_Repository.php
+++ b/src/Tribe/REST/V1/Post_Repository.php
@@ -606,11 +606,11 @@ class Tribe__Tickets__REST__V1__Post_Repository
 			return false;
 		}
 
-
 		/** @var Tribe__Tickets__Commerce__Currency $currency */
 		$currency = tribe( 'tickets.commerce.currency' );
 
 		$price = $ticket->price;
+		$provider = $ticket->provider_class;
 
 		if ( ! is_numeric( $price ) ) {
 			$price = 0; // free
@@ -623,8 +623,8 @@ class Tribe__Tickets__REST__V1__Post_Repository
 		}
 
 		$details = array(
-			'currency_symbol'   => html_entity_decode( $currency->get_currency_symbol( $ticket_id ) ),
-			'currency_position' => $currency->get_currency_symbol_position( $ticket_id ),
+			'currency_symbol'   => html_entity_decode( $currency->get_provider_symbol( $provider, $ticket_id ) ),
+			'currency_position' => $currency->get_provider_symbol_position( $provider, $ticket_id ),
 			'values'            => array( $price ),
 		);
 


### PR DESCRIPTION
🎫 https://central.tri.be/issues/116352

We need to return the currency symbol of the ticket, not the general.

So, if the currency symbol for WooCommerce is EUROS and we're checking a WooTicket, then we have to return EUROS. The same with the currency position.

This one is needed in order to fix this one: https://central.tri.be/issues/115649
