### PR TITLE
Add Block Ticket Item registration

### DIFF
--- a/src/Tribe/Editor/Blocks/Tickets.php
+++ b/src/Tribe/Editor/Blocks/Tickets.php
@@ -22,34 +22,6 @@ extends Tribe__Editor__Blocks__Abstract {
 	}
 
 	/**
-	 * Returns the Correct tickets for the Tickets block
-	 *
-	 * @since TBD
-	 *
-	 * @param  int   $post_id  Which Event or Post we are looking ticket in
-	 * @return array
-	 */
-	private function get_tickets( $post_id ) {
-		$unfiltered_tickets = Tribe__Tickets__Tickets::get_all_event_tickets( $post_id );
-		$tickets = array();
-
-		foreach ( $unfiltered_tickets as $key => $ticket ) {
-			// Skip RSVP items
-			if ( 'Tribe__Tickets__RSVP' === $ticket->provider_class ) {
-				continue;
-			}
-
-			if ( ! $ticket->date_in_range() ) {
-				continue;
-			}
-
-			$tickets[] = $ticket;
-		}
-
-		return $tickets;
-	}
-
-	/**
 	 * Since we are dealing with a Dynamic type of Block we need a PHP method to render it
 	 *
 	 * @since TBD
@@ -63,7 +35,6 @@ extends Tribe__Editor__Blocks__Abstract {
 		$template           = tribe( 'tickets.editor.template' );
 		$args['post_id']    = $post_id = $template->get( 'post_id', null, false );
 		$args['attributes'] = $this->attributes( $attributes );
-		$args['tickets']    = $this->get_tickets( $post_id );
 
 		// Prevent the render when the ID of the post has not being set to a correct value
 		if ( $args['post_id'] === null ) {

--- a/src/Tribe/Editor/Blocks/Tickets.php
+++ b/src/Tribe/Editor/Blocks/Tickets.php
@@ -8,8 +8,6 @@ extends Tribe__Editor__Blocks__Abstract {
 	public function hook() {
 		add_action( 'wp_ajax_ticket_availability_check', array( $this, 'ticket_availability' ) );
 		add_action( 'wp_ajax_nopriv_ticket_availability_check', array( $this, 'ticket_availability' ) );
-
-		add_shortcode( 'gutti_tickets_purchase', array( $this, 'render_shortcode_attendees' ) );
 	}
 
 	/**
@@ -126,51 +124,6 @@ extends Tribe__Editor__Blocks__Abstract {
 			array(),
 			null
 		);
-	}
-
-	/**
-	 * A nice shortcode to show the WIP for the
-	 * Registration intermediate page & styles.
-	 *
-	 * THIS IS A WIP AND THE PURPOSE IS ONLY TO SHOW THE
-	 * RESULTS
-	 *
-	 * USE THE SHORTCODE [gutti_tickets_purchase ticket="ID"]
-	 *
-	 * @since TBD
-	 *
-	 * @return string
-	 */
-	public function render_shortcode_attendees( $atts, $content = '' ) {
-
-		// Bail if we don't receive `ticket` with the ticket id as a param
-		if ( ! isset( $atts['ticket'] ) ) {
-			return $content;
-		}
-
-		$ticket_id = intval( $atts['ticket'] );
-		$ticket    = Tribe__Tickets__Tickets::load_ticket_object( $ticket_id );
-
-		// Initialize attributes, in case we need them for the WIP
-		$attributes = array(
-			'ticket_id' => $ticket_id,
-			'ticket'    => $ticket, // just in case, to test
-		);
-
-		// enqueue assets
-		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-tickets-style' );
-
-		// set arguments. Let's just use the ticket we receive as the shortcode argument
-		// to display the results
-		$args['tickets'][]  = $ticket;
-		$args['attributes'] = $this->attributes( $attributes );
-
-		// Add the rendering attributes into global context
-		tribe( 'tickets.editor.template' )->add_template_globals( $args );
-
-		$content = tribe( 'tickets.editor.template' )->template( 'blocks/tickets/registration/content', $args, false );
-
-		return $content;
 	}
 
 	/**

--- a/src/Tribe/Editor/Blocks/Tickets_Item.php
+++ b/src/Tribe/Editor/Blocks/Tickets_Item.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Tickets block Setup
+ */
+class Tribe__Tickets__Editor__Blocks__Tickets_Item extends Tribe__Editor__Blocks__Abstract {
+
+	/**
+	 * Which is the name/slug of this block
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function slug() {
+		return 'tickets-item';
+	}
+
+	/**
+	 * Since we are dealing with a Dynamic type of Block we need a PHP method to render it
+	 *
+	 * @since TBD
+	 *
+	 * @param  array $attributes
+	 *
+	 * @return string
+	 */
+	public function render( $attributes = array() ) {
+		/** @var Tribe__Tickets__Editor__Template $template */
+		$template = tribe( 'tickets.editor.template' );
+
+		if (
+			empty( $attributes['ticketId'] )
+			|| empty( $attributes['hasBeenCreated'] )
+			|| $attributes['hasBeenCreated'] === false
+		) {
+			return;
+		}
+
+		$ticket_post = get_post( $attributes['ticketId'] );
+		// Prevent to attach blocks with tickets removed or under trash
+		if ( ! $ticket_post instanceof WP_Post || 'publish' !== $ticket_post->post_status ) {
+			return;
+		}
+
+		$tickets = $template->get( 'tickets', array(), false );
+		$ticket  = Tribe__Tickets__Tickets::load_ticket_object( $attributes['ticketId'] );
+		$args    = array(
+			'tickets' => array_merge( $tickets, array( $ticket ) )
+		);
+
+		// Add the rendering attributes into global context
+		$template->add_template_globals( $args );
+	}
+}

--- a/src/Tribe/Editor/Blocks/Tickets_Item.php
+++ b/src/Tribe/Editor/Blocks/Tickets_Item.php
@@ -46,7 +46,7 @@ class Tribe__Tickets__Editor__Blocks__Tickets_Item extends Tribe__Editor__Blocks
 		$tickets = $template->get( 'tickets', array(), false );
 		$ticket  = Tribe__Tickets__Tickets::load_ticket_object( $attributes['ticketId'] );
 		$args    = array(
-			'tickets' => array_merge( $tickets, array( $ticket ) )
+			'tickets' => array_merge( $tickets, array( $ticket ) ),
 		);
 
 		// Add the rendering attributes into global context

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -34,6 +34,7 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 		$this->container->singleton( 'tickets.editor.assets', 'Tribe__Tickets__Editor__Assets', array( 'register' ) );
 
 		$this->container->singleton( 'tickets.editor.blocks.tickets', 'Tribe__Tickets__Editor__Blocks__Tickets' );
+		$this->container->singleton( 'tickets.editor.blocks.tickets-item', 'Tribe__Tickets__Editor__Blocks__Tickets_Item' );
 		$this->container->singleton( 'tickets.editor.blocks.rsvp', 'Tribe__Tickets__Editor__Blocks__Rsvp' );
 		$this->container->singleton( 'tickets.editor.blocks.attendees', 'Tribe__Tickets__Editor__Blocks__Attendees' );
 
@@ -95,6 +96,11 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 		add_action(
 			'tribe_events_editor_register_blocks',
 			tribe_callback( 'tickets.editor.blocks.tickets', 'register' )
+		);
+
+		add_action(
+			'tribe_events_editor_register_blocks',
+			tribe_callback( 'tickets.editor.blocks.tickets-item', 'register' )
 		);
 
 		add_action(


### PR DESCRIPTION
Register the render mechanism for the Ticket Item, used to populate the
template argument "tickets" used to have access to the set of tickets used
to render the block.

So every ticket injected respects the order in which they are presented
into the BE.