### PR TITLE
Static call syntax 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -124,7 +124,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.9.0.1] 2018-11-30 =
 
-* Fix - Update common library to maximize compatibility with earlier PHP versions (our thanks to @megabit81 for highlighting this problem) [119073]
+* Fix - Adjustments for better compatibility with earlier PHP versions (our thanks to @megabit81 for highlighting this problem) [119073]
 * Fix - Update common library to ensure better compatibility with addons running inside multisite networks [119044]
 * Language - 0 new strings added, 1 updated, 0 fuzzied, and 0 obsoleted
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2299,7 +2299,9 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 			$_COOKIE, Tribe__Tickets__Commerce__PayPal__Gateway::$invoice_cookie_name,
 			false
 		);
-		return $cart->get_transient_name( $invoice );
+
+		$cart_class = get_class( $cart );
+		return call_user_func( array( $cart_class, 'get_transient_name' ), $invoice );
 	}
 
 	/**


### PR DESCRIPTION
Use `call_user_func()` to call static method of an object obtained via DI52.

Also adjusted the readme, since our PHP-compat fixes are no longer just inside of Common.

:ticket: [♯119073](https://central.tri.be/issues/119073)