### PR TITLE
Render <TicketsDashboard> only if has providers

### DIFF
--- a/src/Tribe/REST/V1/Endpoints/Base.php
+++ b/src/Tribe/REST/V1/Endpoints/Base.php
@@ -295,6 +295,9 @@ abstract class Tribe__Tickets__REST__V1__Endpoints__Base {
 		}
 
 		$ticket_post_type_object = get_post_type_object( $ticket_post->post_type );
+		if ( null === $ticket_post_type_object ) {
+			return new WP_Error( 'ticket-provider-not-found', $this->messages->get_message( 'ticket-provider-not-found' ), array( 'status' => 500 ) );
+		}
 		$read_cap                = $ticket_post_type_object->cap->read_post;
 
 		if ( ! ( 'publish' === $ticket_post->post_status || current_user_can( $read_cap, $ticket_id ) ) ) {

--- a/src/modules/blocks/tickets/container.js
+++ b/src/modules/blocks/tickets/container.js
@@ -18,6 +18,7 @@ const mapStateToProps = ( state ) => {
 		isSettingsOpen: selectors.getTicketsIsSettingsOpen( state ),
 		provider: selectors.getTicketsProvider( state ),
 		sharedCapacity: selectors.getTicketsSharedCapacity( state ),
+		hasProviders: selectors.hasTicketProviders(),
 	};
 };
 

--- a/src/modules/blocks/tickets/template.js
+++ b/src/modules/blocks/tickets/template.js
@@ -16,6 +16,7 @@ import './style.pcss';
 class Tickets extends PureComponent {
 	static propTypes = {
 		isSelected: PropTypes.bool,
+		hasProviders: PropTypes.bool,
 		isSettingsOpen: PropTypes.bool,
 		clientId: PropTypes.string,
 		header: PropTypes.string,
@@ -24,6 +25,7 @@ class Tickets extends PureComponent {
 	render() {
 		const {
 			isSelected,
+			hasProviders,
 			isSettingsOpen,
 			clientId,
 		} = this.props;
@@ -37,7 +39,7 @@ class Tickets extends PureComponent {
 				) }
 			>
 				<TicketsContainer isSelected={ isSelected } />
-				<TicketsDashboard isSelected={ isSelected } clientId={ clientId } />
+				{ hasProviders && <TicketsDashboard isSelected={ isSelected } clientId={ clientId } /> }
 				<TicketControls />
 			</div>
 		);


### PR DESCRIPTION
Prevent to render the `<TicketsDashboard />` if there are no providers
active.

Ticket: https://central.tri.be/issues/119340