### PR TITLE
Feature/119049 ticket block default sale

### DIFF
--- a/src/modules/data/blocks/rsvp/__tests__/__snapshots__/sagas.test.js.snap
+++ b/src/modules/data/blocks/rsvp/__tests__/__snapshots__/sagas.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RSVP block sagas createWPEditorSavingChannel should create channel 1`] = `
-Object {
-  "close": [Function],
-  "flush": [Function],
-  "take": [Function],
-}
-`;
-
 exports[`RSVP block sagas initializeRSVP should initialize state from datetime block 1`] = `
 Object {
   "@@redux-saga/IO": true,
@@ -44,36 +36,6 @@ Object {
       "January 4, 2018",
     ],
     "context": null,
-    "fn": [Function],
-  },
-}
-`;
-
-exports[`RSVP block sagas isTribeEventPostType should be event 1`] = `
-Object {
-  "@@redux-saga/IO": true,
-  "CALL": Object {
-    "args": Array [
-      "type",
-    ],
-    "context": Object {
-      "getEditedPostAttribute": [Function],
-    },
-    "fn": [Function],
-  },
-}
-`;
-
-exports[`RSVP block sagas isTribeEventPostType should not be event 1`] = `
-Object {
-  "@@redux-saga/IO": true,
-  "CALL": Object {
-    "args": Array [
-      "type",
-    ],
-    "context": Object {
-      "getEditedPostAttribute": [Function],
-    },
     "fn": [Function],
   },
 }

--- a/src/modules/data/blocks/rsvp/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/rsvp/__tests__/sagas.test.js
@@ -24,7 +24,7 @@ import watchers, * as sagas from '../sagas';
 import { MOVE_TICKET_SUCCESS } from '@moderntribe/tickets/data/shared/move/types';
 import { moment as momentUtil, time as timeUtil, globals } from '@moderntribe/common/utils';
 import * as moveSelectors from '@moderntribe/tickets/data/shared/move/selectors';
-import { isTribeEventPostType, createWPEditorSavingChannel } from '@moderntribe/tickets/data/shared/sagas';
+import { isTribeEventPostType, createWPEditorSavingChannel, createDates } from '@moderntribe/tickets/data/shared/sagas';
 
 function mock() {
 	return {
@@ -261,68 +261,6 @@ describe( 'RSVP block sagas', () => {
 		} );
 	} );
 
-	describe( 'createDates', () => {
-		const date = '2018-01-01 00:00:00';
-		it( 'should create dates when no format', () => {
-			const gen = sagas.createDates( date );
-
-			expect( gen.next().value ).toEqual(
-				call( [ globals, 'tecDateSettings' ] )
-			);
-
-			expect( gen.next( { datepickerFormat: false } ).value ).toEqual(
-				call( momentUtil.toMoment, date )
-			);
-
-			expect( gen.next( {} ).value ).toEqual(
-				call( momentUtil.toDate, {} )
-			);
-
-			expect( gen.next( {} ).value ).toEqual(
-				call( momentUtil.toDate, {} )
-			);
-
-			expect( gen.next( date ).value ).toEqual(
-				call( momentUtil.toDatabaseTime, {} )
-			);
-
-			expect( gen.next( date ).value ).toEqual(
-				call( momentUtil.toTime, {} )
-			);
-
-			expect( gen.next().done ).toEqual( true );
-		} );
-		it( 'should create dates with datepicker format', () => {
-			const gen = sagas.createDates( date );
-
-			expect( gen.next().value ).toEqual(
-				call( [ globals, 'tecDateSettings' ] )
-			);
-
-			expect( gen.next( { datepickerFormat: true } ).value ).toEqual(
-				call( momentUtil.toMoment, date )
-			);
-
-			expect( gen.next( {} ).value ).toEqual(
-				call( momentUtil.toDate, {} )
-			);
-
-			expect( gen.next( {} ).value ).toEqual(
-				call( momentUtil.toDate, {}, true )
-			);
-
-			expect( gen.next( date ).value ).toEqual(
-				call( momentUtil.toDatabaseTime, {} )
-			);
-
-			expect( gen.next( date ).value ).toEqual(
-				call( momentUtil.toTime, {} )
-			);
-
-			expect( gen.next().done ).toEqual( true );
-		} );
-	} );
-
 	describe( 'initializeRSVP', () => {
 		let state;
 		beforeEach( () => {
@@ -451,7 +389,7 @@ describe( 'RSVP block sagas', () => {
 				select( selectors.getRSVPEndDateMoment )
 			);
 			expect( gen.next( momentMock ).value ).toEqual(
-				call( sagas.createDates, prevDate )
+				call( createDates, prevDate )
 			);
 			expect( gen.next( { moment: momentMock } ).value ).toMatchSnapshot();
 			expect( gen.next( false ).value ).toMatchSnapshot();
@@ -468,7 +406,7 @@ describe( 'RSVP block sagas', () => {
 				select( selectors.getRSVPEndDateMoment )
 			);
 			expect( gen.next( momentMock ).value ).toEqual(
-				call( sagas.createDates, prevDate )
+				call( createDates, prevDate )
 			);
 			expect( gen.next( { moment: momentMock } ).value ).toMatchSnapshot();
 			expect( gen.next( true ).value ).toMatchSnapshot();
@@ -478,7 +416,7 @@ describe( 'RSVP block sagas', () => {
 				select( global.tribe.events.data.blocks.datetime.selectors.getStart )
 			);
 			expect( gen.next( '2018-02-02 02:00:00' ).value ).toEqual(
-				call( sagas.createDates, '2018-02-02 02:00:00' )
+				call( createDates, '2018-02-02 02:00:00' )
 			);
 
 			expect( gen.next( {
@@ -825,7 +763,7 @@ describe( 'RSVP block sagas', () => {
 				call( [ momentMock, 'add' ], 100, 'years' )
 			);
 			expect( gen.next( momentMock ).value ).toEqual(
-				call( sagas.createDates, momentMock.toDate() )
+				call( createDates, momentMock.toDate() )
 			);
 			expect( gen.next( {
 				date: '2018-01-01',

--- a/src/modules/data/blocks/rsvp/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/rsvp/__tests__/sagas.test.js
@@ -24,6 +24,7 @@ import watchers, * as sagas from '../sagas';
 import { MOVE_TICKET_SUCCESS } from '@moderntribe/tickets/data/shared/move/types';
 import { moment as momentUtil, time as timeUtil, globals } from '@moderntribe/common/utils';
 import * as moveSelectors from '@moderntribe/tickets/data/shared/move/selectors';
+import { isTribeEventPostType, createWPEditorSavingChannel } from '@moderntribe/tickets/data/shared/sagas';
 
 function mock() {
 	return {
@@ -322,19 +323,6 @@ describe( 'RSVP block sagas', () => {
 		} );
 	} );
 
-	describe( 'isTribeEventPostType', () => {
-		it( 'should be event', () => {
-			const gen = sagas.isTribeEventPostType();
-			expect( gen.next().value ).toMatchSnapshot();
-			expect( gen.next( 'tribe_events' ).value ).toEqual( true );
-		} );
-		it( 'should not be event', () => {
-			const gen = sagas.isTribeEventPostType();
-			expect( gen.next().value ).toMatchSnapshot();
-			expect( gen.next( 'no' ).value ).toEqual( false );
-		} );
-	} );
-
 	describe( 'initializeRSVP', () => {
 		let state;
 		beforeEach( () => {
@@ -390,7 +378,7 @@ describe( 'RSVP block sagas', () => {
 				] )
 			);
 			expect( gen.next().value ).toEqual(
-				call( sagas.isTribeEventPostType )
+				call( isTribeEventPostType )
 			);
 			expect( gen.next( true ).value ).toEqual(
 				select( global.tribe.events.data.blocks.datetime.selectors.getStart )
@@ -562,12 +550,6 @@ describe( 'RSVP block sagas', () => {
 		} );
 	} );
 
-	describe( 'createWPEditorSavingChannel', () => {
-		it( 'should create channel', () => {
-			expect( sagas.createWPEditorSavingChannel() ).toMatchSnapshot();
-		} );
-	} );
-
 	describe( 'saveRSVPWithPostSave', () => {
 		let channel;
 
@@ -583,7 +565,7 @@ describe( 'RSVP block sagas', () => {
 			);
 
 			expect( gen.next( true ).value ).toEqual(
-				call( sagas.createWPEditorSavingChannel )
+				call( createWPEditorSavingChannel )
 			);
 
 			expect( gen.next( channel ).value ).toEqual(
@@ -642,7 +624,7 @@ describe( 'RSVP block sagas', () => {
 			);
 
 			expect( gen.next().value ).toEqual(
-				call( sagas.isTribeEventPostType )
+				call( isTribeEventPostType )
 			);
 
 			expect( gen.next( true ).value ).toEqual(
@@ -813,7 +795,7 @@ describe( 'RSVP block sagas', () => {
 			);
 
 			expect( gen.next().value ).toEqual(
-				call( sagas.isTribeEventPostType )
+				call( isTribeEventPostType )
 			);
 
 			expect( gen.next( true ).done ).toEqual( true );
@@ -831,7 +813,7 @@ describe( 'RSVP block sagas', () => {
 				take( [ types.INITIALIZE_RSVP ] )
 			);
 			expect( gen.next().value ).toEqual(
-				call( sagas.isTribeEventPostType )
+				call( isTribeEventPostType )
 			);
 			expect( gen.next( false ).value ).toEqual(
 				select( selectors.getRSVPTempEndDateMoment )

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -3,10 +3,8 @@
 /**
  * External Dependencies
  */
-import { select as wpSelect, dispatch as wpDispatch, subscribe } from '@wordpress/data';
+import { select as wpSelect, dispatch as wpDispatch } from '@wordpress/data';
 import { put, call, all, select, takeEvery, take, fork, cancel } from 'redux-saga/effects';
-import { eventChannel } from 'redux-saga';
-import { some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,13 +13,11 @@ import * as types from './types';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import { updateRSVP } from './thunks';
-import { editor } from '@moderntribe/common/data';
 import { MOVE_TICKET_SUCCESS } from '@moderntribe/tickets/data/shared/move/types';
 import * as moveSelectors from '@moderntribe/tickets/data/shared/move/selectors';
-import { isTribeEventPostType, createWPEditorSavingChannel } from '@moderntribe/tickets/data/shared/sagas';
+import { isTribeEventPostType, createWPEditorSavingChannel, createDates } from '@moderntribe/tickets/data/shared/sagas';
 
 import {
-	globals,
 	moment as momentUtil,
 	time as timeUtil,
 } from '@moderntribe/common/utils';

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -112,32 +112,6 @@ export function* setRSVPTempDetails( action ) {
 	] );
 }
 
-/**
- * Create date objects used throughout sagas
- *
- * @export
- * @param {String} date datetime string
- * @returns {Object} Object of dates/moments
- */
-export function* createDates( date ) {
-	const { datepickerFormat } = yield call( [ globals, 'tecDateSettings' ] );
-	const moment = yield call( momentUtil.toMoment, date );
-	const currentDate = yield call( momentUtil.toDate, moment );
-	const dateInput = yield datepickerFormat
-		? call( momentUtil.toDate, moment, datepickerFormat )
-		: call( momentUtil.toDate, moment );
-	const time = yield call( momentUtil.toDatabaseTime, moment );
-	const timeInput = yield call( momentUtil.toTime, moment );
-
-	return {
-		moment,
-		date: currentDate,
-		dateInput,
-		time,
-		timeInput,
-	};
-}
-
 //
 // ─── INITIALIZE ─────────────────────────────────────────────────────────────────
 //

--- a/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
+++ b/src/modules/data/blocks/ticket/__tests__/__snapshots__/constants.test.js.snap
@@ -35,6 +35,8 @@ Array [
 ]
 `;
 
+exports[`Ticket Constants RSVP 1`] = `"rsvp"`;
+
 exports[`Ticket Constants SHARED 1`] = `"shared"`;
 
 exports[`Ticket Constants SUFFIX 1`] = `"suffix"`;

--- a/src/modules/data/blocks/ticket/__tests__/__snapshots__/sagas.test.js.snap
+++ b/src/modules/data/blocks/ticket/__tests__/__snapshots__/sagas.test.js.snap
@@ -1,0 +1,341 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ticket Block sagas handleEventStartDateChanges should handle start time changes 1`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "TAKE": Object {
+    "channel": Object {
+      "close": [MockFunction],
+      "name": "nodejs",
+      "take": [MockFunction],
+    },
+  },
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should not sync 1`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "ALL": Array [
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+  ],
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should not sync 2`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      Object {
+        "format": [MockFunction],
+        "isSame": [MockFunction],
+        "local": [MockFunction],
+      },
+      "minute",
+    ],
+    "context": Object {
+      "format": [MockFunction],
+      "isSame": [MockFunction],
+      "local": [MockFunction],
+    },
+    "fn": [MockFunction],
+  },
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should not sync 3`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      Object {
+        "format": [MockFunction],
+        "isSame": [MockFunction],
+        "local": [MockFunction],
+      },
+      "minute",
+    ],
+    "context": Object {
+      "format": [MockFunction],
+      "isSame": [MockFunction],
+      "local": [MockFunction],
+    },
+    "fn": [MockFunction],
+  },
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should sync 1`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "ALL": Array [
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "CALL": Object {
+        "args": Array [],
+        "context": Object {
+          "format": [MockFunction],
+          "isSame": [MockFunction],
+          "local": [MockFunction],
+        },
+        "fn": [MockFunction],
+      },
+    },
+  ],
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should sync 2`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      Object {
+        "format": [MockFunction],
+        "isSame": [MockFunction],
+        "local": [MockFunction],
+      },
+      "minute",
+    ],
+    "context": Object {
+      "format": [MockFunction],
+      "isSame": [MockFunction],
+      "local": [MockFunction],
+    },
+    "fn": [MockFunction],
+  },
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should sync 3`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      Object {
+        "format": [MockFunction],
+        "isSame": [MockFunction],
+        "local": [MockFunction],
+      },
+      "minute",
+    ],
+    "context": Object {
+      "format": [MockFunction],
+      "isSame": [MockFunction],
+      "local": [MockFunction],
+    },
+    "fn": [MockFunction],
+  },
+}
+`;
+
+exports[`Ticket Block sagas syncTicketSaleEndWithEventStart should sync 4`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "ALL": Array [
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDate": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_TEMP_END_DATE",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDateInput": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_TEMP_END_DATE_INPUT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDateMoment": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_TEMP_END_DATE_MOMENT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endTime": "02:00:00",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_TEMP_END_TIME",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endTimeInput": "02:00:00",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_TEMP_END_TIME_INPUT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDate": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_END_DATE",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDateInput": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_END_DATE_INPUT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endDateMoment": "2018-02-02",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_END_DATE_MOMENT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endTime": "02:00:00",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_END_TIME",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "endTimeInput": "02:00:00",
+          },
+          "type": "@@MT/TICKETS/SET_TICKET_END_TIME_INPUT",
+        },
+        "channel": null,
+      },
+    },
+    Object {
+      "@@redux-saga/IO": true,
+      "PUT": Object {
+        "action": Object {
+          "payload": Object {
+            "blockId": "blockId",
+            "hasChanges": true,
+          },
+          "type": "@@MT/TICKETS/SET_TICKETS_HAS_CHANGES",
+        },
+        "channel": null,
+      },
+    },
+  ],
+}
+`;

--- a/src/modules/data/blocks/ticket/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/ticket/__tests__/sagas.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { takeEvery, put, all, select, call } from 'redux-saga/effects';
+import { takeEvery, put, all, select, call, take, fork } from 'redux-saga/effects';
 import { cloneableGenerator } from 'redux-saga/utils';
 
 /**
@@ -28,6 +28,7 @@ import {
 	moment as momentUtil,
 	time as timeUtil,
 } from '@moderntribe/common/utils';
+import { isTribeEventPostType, createWPEditorSavingChannel, hasPostTypeChannel, createDates } from '@moderntribe/tickets/data/shared/sagas';
 
 const {
 	INDEPENDENT,
@@ -83,6 +84,9 @@ describe( 'Ticket Block sagas', () => {
 					types.HANDLE_TICKET_END_TIME,
 					MOVE_TICKET_SUCCESS,
 				], sagas.handler )
+			);
+			expect( gen.next().value ).toEqual(
+				fork( sagas.handleEventStartDateChanges )
 			);
 			expect( gen.next().done ).toEqual( true );
 		} );
@@ -1987,4 +1991,196 @@ describe( 'Ticket Block sagas', () => {
 			expect( clone2.next().done ).toEqual( true );
 		} );
 	} );
+
+	describe( 'syncTicketSaleEndWithEventStart', () => {
+		let prevDate, state, momentMock, blockId;
+		beforeEach( () => {
+			blockId = 'blockId';
+			prevDate = '2018-01-01 00:00:00';
+			state = {
+				startDate: 'January 1, 2018',
+				startTime: '12:34',
+				endDate: 'January 4, 2018',
+				endTime: '23:32',
+			};
+			global.tribe = {
+				events: {
+					data: {
+						blocks: {
+							datetime: {
+								selectors: {
+									getStart: jest.fn(),
+								},
+							},
+						},
+					},
+				},
+			};
+			momentMock = {
+				local: jest.fn(),
+				isSame: jest.fn(),
+				format: jest.fn(),
+			};
+		} );
+
+		afterEach( () => {
+			delete global.tribe;
+		} );
+
+		it( 'should not sync', () => {
+			const gen = sagas.syncTicketSaleEndWithEventStart( prevDate, blockId );
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketTempEndDateMoment, { blockId } )
+			);
+			expect( gen.next( momentMock ).value ).toEqual(
+				select( selectors.getTicketEndDateMoment, { blockId } )
+			);
+			expect( gen.next( momentMock ).value ).toEqual(
+				call( createDates, prevDate )
+			);
+			expect( gen.next( { moment: momentMock } ).value ).toMatchSnapshot();
+			expect( gen.next( false ).value ).toMatchSnapshot();
+			expect( gen.next( true ).value ).toMatchSnapshot();
+			expect( gen.next().done ).toEqual( true );
+		} );
+
+		it( 'should sync', () => {
+			const gen = sagas.syncTicketSaleEndWithEventStart( prevDate, blockId );
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketTempEndDateMoment, { blockId } )
+			);
+			expect( gen.next( momentMock ).value ).toEqual(
+				select( selectors.getTicketEndDateMoment, { blockId } )
+			);
+			expect( gen.next( momentMock ).value ).toEqual(
+				call( createDates, prevDate )
+			);
+			expect( gen.next( { moment: momentMock } ).value ).toMatchSnapshot();
+			expect( gen.next( true ).value ).toMatchSnapshot();
+			expect( gen.next( true ).value ).toMatchSnapshot();
+
+			expect( gen.next( true ).value ).toEqual(
+				select( global.tribe.events.data.blocks.datetime.selectors.getStart )
+			);
+			expect( gen.next( '2018-02-02 02:00:00' ).value ).toEqual(
+				call( createDates, '2018-02-02 02:00:00' )
+			);
+
+			expect( gen.next( {
+				moment: '2018-02-02',
+				date: '2018-02-02',
+				dateInput: '2018-02-02',
+				time: '02:00:00',
+				timeInput: '02:00:00',
+			} ).value ).toMatchSnapshot();
+
+			expect( gen.next().value ).toEqual(
+				fork( sagas.saveTicketWithPostSave, blockId )
+			);
+		} );
+	} );
+
+	describe( 'handleEventStartDateChanges', () => {
+		let channel;
+		beforeEach( () => {
+			global.tribe = {
+				events: {
+					data: {
+						blocks: {
+							datetime: {
+								selectors: {
+									getStart: jest.fn(),
+								},
+								types: {
+									SET_START_DATE_TIME: 'SET_START_DATE_TIME',
+									SET_START_TIME: 'SET_START_TIME',
+								},
+							},
+						},
+					},
+				},
+			};
+			channel = { name, take: jest.fn(), close: jest.fn() };
+		} );
+
+		afterEach( () => {
+			delete global.tribe;
+		} );
+
+		it( 'should handle start time changes', () => {
+			const gen = sagas.handleEventStartDateChanges();
+
+			expect(gen.next().value).toEqual(
+				call( hasPostTypeChannel )
+			);
+			expect(gen.next(channel).value).toMatchSnapshot();
+			expect(gen.next().value).toEqual(
+				call( [ channel, 'close' ] )
+			);
+
+			expect( gen.next().value ).toEqual(
+				call( isTribeEventPostType )
+			);
+
+			expect( gen.next( true ).value ).toEqual(
+				select( global.tribe.events.data.blocks.datetime.selectors.getStart )
+			);
+
+			expect( gen.next( '2018-01-01 12:00:00' ).value ).toEqual(
+				take( [ 'SET_START_DATE_TIME', 'SET_START_TIME' ] )
+			);
+
+			expect( gen.next().value ).toEqual(
+				fork( sagas.syncTicketsSaleEndWithEventStart, '2018-01-01 12:00:00' )
+			);
+
+			expect( gen.next().done ).toEqual( false );
+		} );
+	} );
+
+	describe( 'saveTicketWithPostSave', () => {
+		let channel, blockId;
+
+		beforeEach( () => {
+			channel = { name, take: jest.fn(), close: jest.fn() };
+			blockId = 'blockId';
+		} );
+
+		it( 'should update when channel saves', () => {
+			const gen = sagas.saveTicketWithPostSave( blockId );
+
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketHasBeenCreated, { blockId } )
+			);
+
+			expect( gen.next( true ).value ).toEqual(
+				call( createWPEditorSavingChannel )
+			);
+
+			expect( gen.next( channel ).value ).toEqual(
+				take( channel )
+			);
+
+			expect(gen.next().value).toEqual(
+				call( sagas.updateTicket, { payload: { blockId } } )
+			);
+
+			expect( gen.next().value ).toEqual(
+				call( [ channel, 'close' ] )
+			);
+
+			expect( gen.next().done ).toEqual( true );
+		} );
+		it( 'should do nothing', () => {
+			const gen = sagas.saveTicketWithPostSave( blockId );
+
+			expect( gen.next().value ).toEqual(
+				select( selectors.getTicketHasBeenCreated, { blockId } )
+			);
+
+			expect( gen.next( false ).done ).toEqual( true );
+		} );
+	} );
+
+
 } );

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -788,7 +788,7 @@ export function* syncTicketsSaleEndWithEventStart( prevStartDate ) {
  * @param {String} prevStartDate Previous start date before latest set date time changes
  * @export
  */
-export function* syncTicketSaleEndWithEventStart(prevStartDate, blockId){
+export function* syncTicketSaleEndWithEventStart( prevStartDate, blockId ){
 	try {
 		const tempEndMoment = yield select( selectors.getTicketTempEndDateMoment, { blockId } );
 		const endMoment = yield select( selectors.getTicketEndDateMoment, { blockId } );

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -816,8 +816,6 @@ export function* syncTicketSaleEndWithEventStart(prevStartDate, blockId){
 				timeInput: endTimeInput,
 			} = yield call( createDates, eventStart );
 
-			console.warn(endDate, endDateInput, endTime, endTimeInput);
-
 			yield all( [
 				put( actions.setTicketTempEndDate( blockId, endDate ) ),
 				put( actions.setTicketTempEndDateInput( blockId, endDateInput ) ),

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { put, all, select, takeEvery, call } from 'redux-saga/effects';
+import { put, all, select, takeEvery, call, fork, take, cancel } from 'redux-saga/effects';
 import { includes } from 'lodash';
 
 /**
@@ -34,6 +34,8 @@ import {
 } from '@moderntribe/common/utils';
 import { MOVE_TICKET_SUCCESS } from '@moderntribe/tickets/data/shared/move/types';
 import * as moveSelectors from '@moderntribe/tickets/data/shared/move/selectors';
+import { isTribeEventPostType, createWPEditorSavingChannel, hasPostTypeChannel, createDates } from '@moderntribe/tickets/data/shared/sagas';
+
 
 const {
 	UNLIMITED,
@@ -425,8 +427,8 @@ export function* updateTicket( action ) {
 
 	try {
 		const data = [];
-		for ( const pair of body.entries() ) {
-			data.push( `${ encodeURIComponent( pair[ 0 ] ) }=${ encodeURIComponent( pair[ 1 ] ) }` );
+		for ( const [ key, value ] of body.entries() ) {
+			data.push( `${ encodeURIComponent( key ) }=${ encodeURIComponent( value ) }` );
 		}
 
 		yield put( actions.setTicketIsLoading( blockId, true ) );
@@ -737,6 +739,148 @@ export function* setTicketTempDetails( action ) {
 	] );
 }
 
+/**
+ * Allows the Ticket to be saved at the same time a post is being saved.
+ * Avoids the user having to open up the Ticket block, and then click update again there, when changing the event start date.
+ *
+ * @export
+ */
+export function* saveTicketWithPostSave( blockId ) {
+	let saveChannel;
+	try {
+		// Do nothing when not already created
+		if ( yield select( selectors.getTicketHasBeenCreated, { blockId } ) ) {
+			// Create channel for use
+			saveChannel = yield call( createWPEditorSavingChannel );
+
+			// Wait for channel to save
+			yield take( saveChannel );
+
+			// Update when saving
+			yield call( updateTicket, { payload: { blockId } } );
+		}
+	} catch ( error ) {
+		console.error( error );
+	} finally {
+		// Close channel if exists
+		if ( saveChannel ) {
+			yield call( [ saveChannel, 'close' ] );
+		}
+	}
+}
+
+/**
+ * Will sync all tickets
+ * @param {String} prevStartDate Previous start date before latest set date time changes
+ * @export
+ */
+export function* syncTicketsSaleEndWithEventStart( prevStartDate ) {
+	const ticketIds = yield select( selectors.getAllTicketIds );
+	for (let index = 0; index < ticketIds.length; index++) {
+		const blockId = ticketIds[index];
+		yield call( syncTicketSaleEndWithEventStart, prevStartDate, blockId );
+	}
+}
+
+/**
+ * Will sync Tickets sale end to be the same as event start date and time, if field has not been manually edited
+ * @borrows TEC - Functionality requires TEC to be enabled
+ * @param {String} prevStartDate Previous start date before latest set date time changes
+ * @export
+ */
+export function* syncTicketSaleEndWithEventStart(prevStartDate, blockId){
+	try {
+		const tempEndMoment = yield select( selectors.getTicketTempEndDateMoment, { blockId } );
+		const endMoment = yield select( selectors.getTicketEndDateMoment, { blockId } );
+		const { moment: prevEventStartMoment } = yield call( createDates, prevStartDate );
+
+		// NOTE: Mutation
+		// Convert to use local timezone
+		yield all( [
+			call( [ tempEndMoment, 'local' ] ),
+			call( [ endMoment, 'local' ] ),
+			call( [ prevEventStartMoment, 'local' ] ),
+		] );
+
+		// If initial end and current end are the same, the RSVP has not been modified
+		const isNotManuallyEdited = yield call( [ tempEndMoment, 'isSame' ], endMoment, 'minute' );
+		const isSyncedToEventStart = yield call( [ tempEndMoment, 'isSame' ], prevEventStartMoment, 'minute' );
+
+		if ( isNotManuallyEdited && isSyncedToEventStart ) {
+			const eventStart = yield select( window.tribe.events.data.blocks.datetime.selectors.getStart );
+			const {
+				moment: endDateMoment,
+				date: endDate,
+				dateInput: endDateInput,
+				time: endTime,
+				timeInput: endTimeInput,
+			} = yield call( createDates, eventStart );
+
+			console.warn(endDate, endDateInput, endTime, endTimeInput);
+
+			yield all( [
+				put( actions.setTicketTempEndDate( blockId, endDate ) ),
+				put( actions.setTicketTempEndDateInput( blockId, endDateInput ) ),
+				put( actions.setTicketTempEndDateMoment( blockId, endDateMoment ) ),
+				put( actions.setTicketTempEndTime( blockId, endTime ) ),
+				put( actions.setTicketTempEndTimeInput( blockId, endTimeInput ) ),
+
+				// Sync Ticket end items as well so as not to make state 'manually edited'
+				put( actions.setTicketEndDate( blockId, endDate ) ),
+				put( actions.setTicketEndDateInput( blockId, endDateInput ) ),
+				put( actions.setTicketEndDateMoment( blockId, endDateMoment ) ),
+				put( actions.setTicketEndTime( blockId, endTime ) ),
+				put( actions.setTicketEndTimeInput( blockId, endTimeInput ) ),
+
+				// Trigger UI button
+				put( actions.setTicketHasChanges( blockId, true ) ),
+			] );
+
+			yield fork( saveTicketWithPostSave, blockId );
+		}
+	} catch ( error ) {
+		// ¯\_(ツ)_/¯
+		console.error( error );
+	}
+}
+
+/**
+ * Listens for event start date and time changes after RSVP block is loaded.
+ * @borrows TEC - Functionality requires TEC to be enabled and post type to be event
+ * @export
+ */
+export function* handleEventStartDateChanges() {
+	try {
+		// Ensure we have a postType set before proceeding
+		const postTypeChannel = yield call( hasPostTypeChannel );
+		yield take( postTypeChannel );
+		yield call( [ postTypeChannel, 'close' ] );
+
+		const isEvent = yield call( isTribeEventPostType );
+		if ( isEvent && window.tribe.events ) {
+			const { SET_START_DATE_TIME, SET_START_TIME } = window.tribe.events.data.blocks.datetime.types;
+
+			let syncTask;
+			while ( true ) {
+				// Cache current event start date for comparison
+				const eventStart = yield select( window.tribe.events.data.blocks.datetime.selectors.getStart );
+
+				// Wait til use changes date or time on TEC datetime block
+				yield take( [ SET_START_DATE_TIME, SET_START_TIME ] );
+
+				// Important to cancel any pre-existing forks to prevent bad data from being sent
+				if ( syncTask ) {
+					yield cancel( syncTask );
+				}
+				syncTask = yield fork( syncTicketsSaleEndWithEventStart, eventStart );
+			}
+		}
+	} catch ( error ) {
+		// ¯\_(ツ)_/¯
+		console.error( error );
+	}
+}
+
 export function* handleTicketStartDate( action ) {
 	const { blockId, date, dayPickerInput } = action.payload;
 	const startDateMoment = yield date ? call( momentUtil.toMoment, date ) : undefined;
@@ -890,4 +1034,6 @@ export default function* watchers() {
 		types.HANDLE_TICKET_END_TIME,
 		MOVE_TICKET_SUCCESS,
 	], handler );
+
+	yield fork( handleEventStartDateChanges );
 }

--- a/src/modules/data/shared/__tests__/__snapshots__/sagas.test.js.snap
+++ b/src/modules/data/shared/__tests__/__snapshots__/sagas.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Shared block sagas createWPEditorSavingChannel should create channel 1`] = `
+Object {
+  "close": [Function],
+  "flush": [Function],
+  "take": [Function],
+}
+`;
+
+exports[`Shared block sagas isTribeEventPostType should be event 1`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      "type",
+    ],
+    "context": Object {
+      "getEditedPostAttribute": [Function],
+    },
+    "fn": [Function],
+  },
+}
+`;
+
+exports[`Shared block sagas isTribeEventPostType should not be event 1`] = `
+Object {
+  "@@redux-saga/IO": true,
+  "CALL": Object {
+    "args": Array [
+      "type",
+    ],
+    "context": Object {
+      "getEditedPostAttribute": [Function],
+    },
+    "fn": [Function],
+  },
+}
+`;

--- a/src/modules/data/shared/__tests__/sagas.test.js
+++ b/src/modules/data/shared/__tests__/sagas.test.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { takeEvery, put, call, select, all, fork, take } from 'redux-saga/effects';
+import { cloneableGenerator, createMockTask } from 'redux-saga/utils';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	dispatch as wpDispatch,
+	select as wpSelect,
+} from '@wordpress/data';
+
+/**
+ * Internal Dependencies
+ */
+import * as sagas from '../sagas';
+
+function mock() {
+	return {
+		select: ( key ) => {
+			if ( key === 'core/editor' ) {
+				return {
+					getEditedPostAttribute: ( attr ) => {
+						if ( attr === 'date' ) {
+							return 'January 1, 2018';
+						}
+					},
+				};
+			}
+		},
+		subscribe: jest.fn( () => noop ),
+		dispatch: jest.fn( () => ( {
+			removeBlocks: noop,
+		} ) ),
+	};
+}
+jest.mock( '@wordpress/data', () => mock() );
+
+describe( 'Shared block sagas', () => {
+
+	describe( 'isTribeEventPostType', () => {
+		it( 'should be event', () => {
+			const gen = sagas.isTribeEventPostType();
+			expect( gen.next().value ).toMatchSnapshot();
+			expect( gen.next( 'tribe_events' ).value ).toEqual( true );
+		} );
+		it( 'should not be event', () => {
+			const gen = sagas.isTribeEventPostType();
+			expect( gen.next().value ).toMatchSnapshot();
+			expect( gen.next( 'no' ).value ).toEqual( false );
+		} );
+	} );
+
+	describe( 'createWPEditorSavingChannel', () => {
+		it( 'should create channel', () => {
+			expect( sagas.createWPEditorSavingChannel() ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/src/modules/data/shared/__tests__/sagas.test.js
+++ b/src/modules/data/shared/__tests__/sagas.test.js
@@ -2,10 +2,15 @@
  * External dependencies
  */
 import { noop } from 'lodash';
+import { call } from 'redux-saga/effects';
 
 /**
  * Internal Dependencies
  */
+import {
+	globals,
+	moment as momentUtil,
+} from '@moderntribe/common/utils';
 import * as sagas from '../sagas';
 
 function mock() {
@@ -30,7 +35,6 @@ function mock() {
 jest.mock( '@wordpress/data', () => mock() );
 
 describe( 'Shared block sagas', () => {
-
 	describe( 'isTribeEventPostType', () => {
 		it( 'should be event', () => {
 			const gen = sagas.isTribeEventPostType();
@@ -47,6 +51,68 @@ describe( 'Shared block sagas', () => {
 	describe( 'createWPEditorSavingChannel', () => {
 		it( 'should create channel', () => {
 			expect( sagas.createWPEditorSavingChannel() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'createDates', () => {
+		const date = '2018-01-01 00:00:00';
+		it( 'should create dates when no format', () => {
+			const gen = sagas.createDates( date );
+
+			expect( gen.next().value ).toEqual(
+				call( [ globals, 'tecDateSettings' ] )
+			);
+
+			expect( gen.next( { datepickerFormat: false } ).value ).toEqual(
+				call( momentUtil.toMoment, date )
+			);
+
+			expect( gen.next( {} ).value ).toEqual(
+				call( momentUtil.toDatabaseDate, {} )
+			);
+
+			expect( gen.next( {} ).value ).toEqual(
+				call( momentUtil.toDate, {} )
+			);
+
+			expect( gen.next( date ).value ).toEqual(
+				call( momentUtil.toDatabaseTime, {} )
+			);
+
+			expect( gen.next( date ).value ).toEqual(
+				call( momentUtil.toTime, {} )
+			);
+
+			expect( gen.next().done ).toEqual( true );
+		} );
+		it( 'should create dates with datepicker format', () => {
+			const gen = sagas.createDates( date );
+
+			expect( gen.next().value ).toEqual(
+				call( [ globals, 'tecDateSettings' ] )
+			);
+
+			expect( gen.next( { datepickerFormat: true } ).value ).toEqual(
+				call( momentUtil.toMoment, date )
+			);
+
+			expect( gen.next( {} ).value ).toEqual(
+				call( momentUtil.toDatabaseDate, {} )
+			);
+
+			expect( gen.next( {} ).value ).toEqual(
+				call( momentUtil.toDate, {}, true )
+			);
+
+			expect( gen.next( date ).value ).toEqual(
+				call( momentUtil.toDatabaseTime, {} )
+			);
+
+			expect( gen.next( date ).value ).toEqual(
+				call( momentUtil.toTime, {} )
+			);
+
+			expect( gen.next().done ).toEqual( true );
 		} );
 	} );
 } );

--- a/src/modules/data/shared/__tests__/sagas.test.js
+++ b/src/modules/data/shared/__tests__/sagas.test.js
@@ -1,17 +1,7 @@
 /**
  * External dependencies
  */
-import { takeEvery, put, call, select, all, fork, take } from 'redux-saga/effects';
-import { cloneableGenerator, createMockTask } from 'redux-saga/utils';
 import { noop } from 'lodash';
-
-/**
- * WordPress dependencies
- */
-import {
-	dispatch as wpDispatch,
-	select as wpSelect,
-} from '@wordpress/data';
 
 /**
  * Internal Dependencies

--- a/src/modules/data/shared/sagas.js
+++ b/src/modules/data/shared/sagas.js
@@ -12,6 +12,10 @@ import { some } from 'lodash';
  * Internal dependencies
  */
 import { editor } from '@moderntribe/common/data';
+import {
+	globals,
+	moment as momentUtil,
+} from '@moderntribe/common/utils';
 
 /*
  * Determines if current post is a tribe event
@@ -21,6 +25,30 @@ import { editor } from '@moderntribe/common/data';
 export function* isTribeEventPostType() {
 	const postType = yield call( [ wpSelect( 'core/editor' ), 'getEditedPostAttribute' ], 'type' );
 	return postType === editor.EVENT;
+}
+
+/**
+ * Creates event channel subscribing to WP editor state when post type is loaded.
+ * Used as post type is not available upon load in some cases, so some false negatives
+ *
+ * @returns {Function} Channel
+ */
+export function hasPostTypeChannel() {
+	return eventChannel( emit => {
+		const wpEditor = wpSelect( 'core/editor' );
+
+		const predicates = [
+			() => !! wpEditor.getEditedPostAttribute( 'type' ),
+		];
+
+		// Returns unsubscribe function
+		return subscribe( () => {
+			// Only emit when truthy
+			if ( some( predicates, fn => fn() ) ) {
+				emit( true ); // Emitted value is insignificant here, but cannot be left undefined
+			}
+		} );
+	} );
 }
 
 /**
@@ -44,4 +72,30 @@ export function createWPEditorSavingChannel() {
 			}
 		} );
 	} );
+}
+
+/**
+ * Create date objects used throughout sagas
+ *
+ * @export
+ * @param {String} date datetime string
+ * @returns {Object} Object of dates/moments
+ */
+export function* createDates( date ) {
+	const { datepickerFormat } = yield call( [ globals, 'tecDateSettings' ] );
+	const moment = yield call( momentUtil.toMoment, date );
+	const currentDate = yield call( momentUtil.toDatabaseDate, moment );
+	const dateInput = yield datepickerFormat
+		? call( momentUtil.toDate, moment, datepickerFormat )
+		: call( momentUtil.toDate, moment );
+	const time = yield call( momentUtil.toDatabaseTime, moment );
+	const timeInput = yield call( momentUtil.toTime, moment );
+
+	return {
+		moment,
+		date: currentDate,
+		dateInput,
+		time,
+		timeInput,
+	};
 }

--- a/src/modules/data/shared/sagas.js
+++ b/src/modules/data/shared/sagas.js
@@ -1,0 +1,47 @@
+/* eslint-disable max-len */
+
+/**
+ * External Dependencies
+ */
+import { select as wpSelect, subscribe } from '@wordpress/data';
+import { call } from 'redux-saga/effects';
+import { eventChannel } from 'redux-saga';
+import { some } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { editor } from '@moderntribe/common/data';
+
+/*
+ * Determines if current post is a tribe event
+ * @export
+ * @returns {Boolean} bool
+ */
+export function* isTribeEventPostType() {
+	const postType = yield call( [ wpSelect( 'core/editor' ), 'getEditedPostAttribute' ], 'type' );
+	return postType === editor.EVENT;
+}
+
+/**
+ * Creates event channel subscribing to WP editor state when saving post
+ *
+ * @returns {Function} Channel
+ */
+export function createWPEditorSavingChannel() {
+	return eventChannel( emit => {
+		const wpEditor = wpSelect( 'core/editor' );
+
+		const predicates = [
+			() => wpEditor.isSavingPost() && ! wpEditor.isAutosavingPost(),
+		];
+
+		// Returns unsubscribe function
+		return subscribe( () => {
+			// Only emit when truthy
+			if ( some( predicates, fn => fn() ) ) {
+				emit( true ); // Emitted value is insignificant here, but cannot be left undefined
+			}
+		} );
+	} );
+}


### PR DESCRIPTION
https://central.tri.be/issues/119049

Allows ticket sale end date to be synced with event start date. Adds ticket saving when sale end date is synced and post is updated.

Adding tests but can be reviewed