### PR TITLE
RSVP block shouldn't use Tickets as context variable

### DIFF
--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -57,7 +57,7 @@ extends Tribe__Editor__Blocks__Abstract {
 		$template           = tribe( 'tickets.editor.template' );
 		$args['post_id']    = $post_id = $template->get( 'post_id', null, false );
 		$args['attributes'] = $this->attributes( $attributes );
-		$args['tickets']    = $this->get_tickets( $post_id );
+		$args['rsvp']    = $this->get_tickets( $post_id );
 
 		// Add the rendering attributes into global context
 		$template->add_template_globals( $args );

--- a/src/views/blocks/rsvp.php
+++ b/src/views/blocks/rsvp.php
@@ -14,7 +14,7 @@
  */
 
 $event_id = $this->get( 'post_id' );
-$tickets  = $this->get( 'tickets' );
+$items = $this->get( 'rsvp' );
 
 ?>
 
@@ -22,13 +22,13 @@ $tickets  = $this->get( 'tickets' );
 
 <div class="tribe-block tribe-block__rsvp">
 
-	<?php foreach ( $tickets as $ticket ) : ?>
+	<?php foreach ( $items as $item ) : ?>
 
-		<div class="tribe-block__rsvp__ticket" data-rsvp-id="<?php echo absint( $ticket->ID ); ?>">
+		<div class="tribe-block__rsvp__ticket" data-rsvp-id="<?php echo absint( $item->ID ); ?>">
 
 			<?php $this->template( 'blocks/rsvp/icon' ); ?>
 
-			<?php $this->template( 'blocks/rsvp/content', array( 'ticket' => $ticket ) ); ?>
+			<?php $this->template( 'blocks/rsvp/content', array( 'ticket' => $item ) ); ?>
 
 			<?php $this->template( 'blocks/rsvp/loader' ); ?>
 


### PR DESCRIPTION
When debugging a problem with @mitogh we found that tickets and RSVP blocks are sharing a variable, which in the current state of how we do blocks is bad because they share the template context, on release 19.1 I will fix this template context sharing, but for now, we are changing the variable

_Ref:_ [C#119726](http://central.tri.be/issues/119726)
---
