### PR TITLE
Feature/119946 rsvp block ux improvement

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,12 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [TBD] =
+
+* Feature - Improve the UX for RSVPs with required login [119946]
+* Updated views: /views/blocks/rsvp/content.php, /views/blocks/rsvp/form.php, /views/blocks/rsvp/form/form.php, /views/blocks/rsvp/form/submit-login.php, /views/blocks/rsvp/form/submit.php, /views/blocks/rsvp/status.php, /views/blocks/rsvp/status/going.php, /views/blocks/rsvp/status/not-going.php
+* Fix - ensure that the RSVP login link redirects the user back to the event page post-login [120365]
+
 = [4.9.3] 2018-12-18 =
 
 * Fix - Only show "Log in before purchasing" when login is required for Tribe Commerce tickets [118977]

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,6 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
-<<<<<<< HEAD
 = [TBD] =
 
 * Feature - Improve the UX for RSVPs with required login [119946]
@@ -130,9 +129,6 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - ensure that the RSVP login link redirects the user back to the event page post-login [120365]
 
 = [4.9.3] 2018-12-18 =
-=======
-= [4.9.3] 2018-12-19 =
->>>>>>> release/M19.01
 
 * Fix - Only show "Log in before purchasing" when login is required for Tribe Commerce tickets [118977]
 * Fix - Set custom date format for date pickers used on tickets [119356]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2068,10 +2068,15 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		/**
 		 * Provides a URL that can be used to direct users to the login form.
 		 *
+		 * @param int $post_id - the ID of the post to redirect to
+		 *
 		 * @return string
 		 */
-		public static function get_login_url() {
-			$post_id   = get_the_ID();
+		public static function get_login_url( $post_id = null ) {
+			if ( is_null( $post_id ) ) {
+				$post_id   = get_the_ID();
+			}
+
 			$login_url = get_site_url( null, 'wp-login.php' );
 
 			if ( $post_id ) {

--- a/src/views/blocks/rsvp.php
+++ b/src/views/blocks/rsvp.php
@@ -24,7 +24,7 @@ $items = $this->get( 'rsvp' );
 
 	<?php foreach ( $items as $item ) : ?>
 
-		<div class="tribe-block__rsvp__ticket" data-rsvp-id="<?php echo absint( $item->ID ); ?>">
+		<div class="tribe-block__rsvp__ticket" data-rsvp-id="<?php echo absint( $item->ID ); ?>" id="tribe-block__rsvp__ticket-<?php echo absint( $item->ID ); ?>">
 
 			<?php $this->template( 'blocks/rsvp/icon' ); ?>
 

--- a/src/views/blocks/rsvp/content.php
+++ b/src/views/blocks/rsvp/content.php
@@ -13,7 +13,7 @@
  * @version 4.9
  *
  */
-$going = ! empty( $_GET[ 'going' ] ) ? $_GET[ 'going' ] : '';
+$going = ! empty( $_GET[ 'going' ] ) ? sanitize_text_field( $_GET[ 'going' ] ) : '';
 ?>
 <div class="tribe-block__rsvp__content">
 

--- a/src/views/blocks/rsvp/content.php
+++ b/src/views/blocks/rsvp/content.php
@@ -13,15 +13,15 @@
  * @version 4.9
  *
  */
-
+$going = ! empty( $_GET[ 'going' ] ) ? $_GET[ 'going' ] : '';
 ?>
 <div class="tribe-block__rsvp__content">
 
 	<div class="tribe-block__rsvp__details__status">
-		<?php $this->template( 'blocks/rsvp/details', array( 'ticket' => $ticket ) ); ?>
-		<?php $this->template( 'blocks/rsvp/status', array( 'ticket' => $ticket ) ); ?>
+		<?php $this->template( 'blocks/rsvp/details', array( 'ticket' => $ticket  ) ); ?>
+		<?php $this->template( 'blocks/rsvp/status', array( 'ticket' => $ticket, 'going' => $going  ) ); ?>
 	</div>
 
-	<?php $this->template( 'blocks/rsvp/form', array( 'ticket' => $ticket ) ); ?>
+	<?php $this->template( 'blocks/rsvp/form', array( 'ticket' => $ticket, 'going' => $going  ) ); ?>
 
 </div>

--- a/src/views/blocks/rsvp/content.php
+++ b/src/views/blocks/rsvp/content.php
@@ -18,10 +18,10 @@ $going = ! empty( $_GET[ 'going' ] ) ? $_GET[ 'going' ] : '';
 <div class="tribe-block__rsvp__content">
 
 	<div class="tribe-block__rsvp__details__status">
-		<?php $this->template( 'blocks/rsvp/details', array( 'ticket' => $ticket  ) ); ?>
-		<?php $this->template( 'blocks/rsvp/status', array( 'ticket' => $ticket, 'going' => $going  ) ); ?>
+		<?php $this->template( 'blocks/rsvp/details', array( 'ticket' => $ticket ) ); ?>
+		<?php $this->template( 'blocks/rsvp/status', array( 'ticket' => $ticket, 'going' => $going ) ); ?>
 	</div>
 
-	<?php $this->template( 'blocks/rsvp/form', array( 'ticket' => $ticket, 'going' => $going  ) ); ?>
+	<?php $this->template( 'blocks/rsvp/form', array( 'ticket' => $ticket, 'going' => $going ) ); ?>
 
 </div>

--- a/src/views/blocks/rsvp/form.php
+++ b/src/views/blocks/rsvp/form.php
@@ -20,7 +20,6 @@ $must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required()
 <!-- This div is where the AJAX returns the form -->
 <div class="tribe-block__rsvp__form">
 	<?php if ( ! empty( $going ) && ! $must_login ) :
-		error_log( $going );
 		$ticket = $this->get( 'ticket' );
 		$args = array(
 					'ticket_id' => $ticket->ID,
@@ -28,6 +27,7 @@ $must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required()
 					'going'     => esc_html( $going ),
 				);
 
+		// can't escape, contains html
 		echo tribe( 'tickets.editor.template' )->template( 'blocks/rsvp/form/form', $args, false );
 	endif; ?>
 </div>

--- a/src/views/blocks/rsvp/form.php
+++ b/src/views/blocks/rsvp/form.php
@@ -16,8 +16,6 @@
 
 $going      = $this->get( 'going' );
 $must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
-error_log( $going );
-error_log( $must_login );
 ?>
 <!-- This div is where the AJAX returns the form -->
 <div class="tribe-block__rsvp__form">

--- a/src/views/blocks/rsvp/form.php
+++ b/src/views/blocks/rsvp/form.php
@@ -14,6 +14,22 @@
  *
  */
 
+$going      = $this->get( 'going' );
+$must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
+error_log( $going );
+error_log( $must_login );
 ?>
 <!-- This div is where the AJAX returns the form -->
-<div class="tribe-block__rsvp__form"></div>
+<div class="tribe-block__rsvp__form">
+	<?php if ( ! empty( $going ) && ! $must_login ) :
+		error_log( $going );
+		$ticket = $this->get( 'ticket' );
+		$args = array(
+					'ticket_id' => $ticket->ID,
+					'ticket'    => tribe( 'tickets.rsvp' )->get_ticket( get_the_id(), $ticket->ID ),
+					'going'     => esc_html( $going ),
+				);
+
+		echo tribe( 'tickets.editor.template' )->template( 'blocks/rsvp/form/form', $args, false );
+	endif; ?>
+</div>

--- a/src/views/blocks/rsvp/form/form.php
+++ b/src/views/blocks/rsvp/form/form.php
@@ -13,8 +13,9 @@
  * @version 4.9
  *
  */
-$ticket_id = $this->get( 'ticket_id' );
-$going     = $this->get( 'going' );
+$ticket_id   = $this->get( 'ticket_id' );
+$going       = $this->get( 'going' );
+$must_login  = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
 ?>
 <form
 	name="tribe-rsvp-form"
@@ -25,17 +26,13 @@ $going     = $this->get( 'going' );
 	<!-- Maybe add nonce over here? Try to leave templates as clean as possible -->
 
 	<div class="tribe-left">
-		<?php $this->template( 'blocks/rsvp/form/quantity', array( 'ticket' => $ticket ) ); ?>
+		<?php if ( ! $must_login ) : ?>
+			<?php $this->template( 'blocks/rsvp/form/quantity', array( 'ticket' => $ticket ) ); ?>
+		<?php endif; ?>
 	</div>
 
 	<div class="tribe-right">
 		<?php $this->template( 'blocks/rsvp/form/error' ); ?>
-
-		<?php $this->template( 'blocks/rsvp/form/name', array( 'ticket' => $ticket ) ); ?>
-
-		<?php $this->template( 'blocks/rsvp/form/email', array( 'ticket' => $ticket ) ); ?>
-
-		<?php $this->template( 'blocks/rsvp/form/opt-out', array( 'ticket' => $ticket ) ); ?>
 
 		<?php $this->template( 'blocks/rsvp/form/submit', array( 'ticket' => $ticket ) ); ?>
 	</div>

--- a/src/views/blocks/rsvp/form/form.php
+++ b/src/views/blocks/rsvp/form/form.php
@@ -37,7 +37,7 @@ $must_login  = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required(
 		<?php $this->template( 'blocks/rsvp/form/error' ); ?>
 
 		<?php if ( $must_login ) : ?>
-			<?php $this->template( 'blocks/rsvp/form/submit-login', array( 'event_id' => $event_id, 'going' => $going ) ); ?>
+			<?php $this->template( 'blocks/rsvp/form/submit-login', array( 'event_id' => $event_id, 'going' => $going, 'ticket_id' => $ticket_id ) ); ?>
 		<?php else : ?>
 			<?php $this->template( 'blocks/rsvp/form/submit', array( 'ticket' => $ticket ) ); ?>
 		<?php endif; ?>

--- a/src/views/blocks/rsvp/form/form.php
+++ b/src/views/blocks/rsvp/form/form.php
@@ -15,6 +15,8 @@
  */
 $ticket_id   = $this->get( 'ticket_id' );
 $going       = $this->get( 'going' );
+$ticket_data = tribe( 'tickets.handler' )->get_object_connections( $ticket_id );
+$event_id    = $ticket_data->event;
 $must_login  = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
 ?>
 <form
@@ -34,7 +36,11 @@ $must_login  = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required(
 	<div class="tribe-right">
 		<?php $this->template( 'blocks/rsvp/form/error' ); ?>
 
-		<?php $this->template( 'blocks/rsvp/form/submit', array( 'ticket' => $ticket ) ); ?>
+		<?php if ( $must_login ) : ?>
+			<?php $this->template( 'blocks/rsvp/form/submit-login', array( 'event_id' => $event_id, 'going' => $going ) ); ?>
+		<?php else : ?>
+			<?php $this->template( 'blocks/rsvp/form/submit', array( 'ticket' => $ticket ) ); ?>
+		<?php endif; ?>
 	</div>
 
 </form>

--- a/src/views/blocks/rsvp/form/submit-login.php
+++ b/src/views/blocks/rsvp/form/submit-login.php
@@ -16,6 +16,7 @@
 $event_id  = $this->get( 'event_id' );
 $ticket_id = $this->get( 'ticket_id' );
 $going     = $this->get( 'going' );
+// Note: the anchor tag is urlencoded here ('%23tribe-block__rsvp__ticket-') so it passes through the login redirect
 ?>
 <a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) . '?going=' . $going . '%23tribe-block__rsvp__ticket-' . $ticket_id ); ?>">
 	<?php esc_html_e( 'Log in to RSVP', 'events-tickets' ); ?>

--- a/src/views/blocks/rsvp/form/submit-login.php
+++ b/src/views/blocks/rsvp/form/submit-login.php
@@ -13,8 +13,10 @@
  * @version 4.9.3
  *
  */
-
+$ticket   = $this->get( 'ticket' );
+$ticket_data = tribe( 'tickets.handler' )->get_object_connections( $ticket->ID );
+$event_id    = $ticket_data->event;
 ?>
-<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url() ); ?>">
+<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) ); ?>">
 	<?php esc_html_e( 'Login to RSVP', 'events-tickets' ); ?>
 </a>

--- a/src/views/blocks/rsvp/form/submit-login.php
+++ b/src/views/blocks/rsvp/form/submit-login.php
@@ -13,9 +13,10 @@
  * @version 4.9.3
  *
  */
-$event_id = $this->get( 'event_id' );
-$going    = $this->get( 'going' );
+$event_id  = $this->get( 'event_id' );
+$ticket_id = $this->get( 'ticket_id' );
+$going     = $this->get( 'going' );
 ?>
-<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) . '?going=' . $going ); ?>">
-	<?php esc_html_e( 'Login to RSVP', 'events-tickets' ); ?>
+<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) . '?going=' . $going . '%23tribe-block__rsvp__ticket-' . $ticket_id ); ?>">
+	<?php esc_html_e( 'Log in to RSVP', 'events-tickets' ); ?>
 </a>

--- a/src/views/blocks/rsvp/form/submit-login.php
+++ b/src/views/blocks/rsvp/form/submit-login.php
@@ -13,10 +13,9 @@
  * @version 4.9.3
  *
  */
-$ticket   = $this->get( 'ticket' );
-$ticket_data = tribe( 'tickets.handler' )->get_object_connections( $ticket->ID );
-$event_id    = $ticket_data->event;
+$event_id = $this->get( 'event_id' );
+$going    = $this->get( 'going' );
 ?>
-<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) ); ?>">
+<a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) . '?going=' . $going ); ?>">
 	<?php esc_html_e( 'Login to RSVP', 'events-tickets' ); ?>
 </a>

--- a/src/views/blocks/rsvp/form/submit.php
+++ b/src/views/blocks/rsvp/form/submit.php
@@ -13,12 +13,8 @@
  * @version 4.9
  *
  */
-
-$must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
 ?>
-<?php if ( $must_login ) : ?>
-	<?php $this->template( 'blocks/rsvp/form/submit-login', array( 'ticket' => $ticket ) ); ?>
-<?php else : ?>
+
 	<?php $this->template( 'blocks/rsvp/form/name', array( 'ticket' => $ticket ) ); ?>
 
 	<?php $this->template( 'blocks/rsvp/form/email', array( 'ticket' => $ticket ) ); ?>
@@ -26,4 +22,3 @@ $must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required()
 	<?php $this->template( 'blocks/rsvp/form/opt-out', array( 'ticket' => $ticket ) ); ?>
 
 	<?php $this->template( 'blocks/rsvp/form/submit-button' ); ?>
-<?php endif; ?>

--- a/src/views/blocks/rsvp/form/submit.php
+++ b/src/views/blocks/rsvp/form/submit.php
@@ -17,7 +17,13 @@
 $must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
 ?>
 <?php if ( $must_login ) : ?>
-	<?php $this->template( 'blocks/rsvp/form/submit-login' ); ?>
+	<?php $this->template( 'blocks/rsvp/form/submit-login', array( 'ticket' => $ticket ) ); ?>
 <?php else : ?>
+	<?php $this->template( 'blocks/rsvp/form/name', array( 'ticket' => $ticket ) ); ?>
+
+	<?php $this->template( 'blocks/rsvp/form/email', array( 'ticket' => $ticket ) ); ?>
+
+	<?php $this->template( 'blocks/rsvp/form/opt-out', array( 'ticket' => $ticket ) ); ?>
+
 	<?php $this->template( 'blocks/rsvp/form/submit-button' ); ?>
 <?php endif; ?>

--- a/src/views/blocks/rsvp/status.php
+++ b/src/views/blocks/rsvp/status.php
@@ -13,13 +13,13 @@
  * @version 4.9
  *
  */
-
+$going = $this->get( 'going' );
 ?>
 <div class="tribe-block__rsvp__status">
 	<?php if ( $ticket->is_in_stock() ) : ?>
 
-		<?php $this->template( 'blocks/rsvp/status/going', array( 'ticket' => $ticket ) ); ?>
-		<?php $this->template( 'blocks/rsvp/status/not-going', array( 'ticket' => $ticket ) ); ?>
+		<?php $this->template( 'blocks/rsvp/status/going', array( 'ticket' => $ticket, 'going' => $going ) ); ?>
+		<?php $this->template( 'blocks/rsvp/status/not-going', array( 'ticket' => $ticket, 'going' => $going ) ); ?>
 
 	<?php else : ?>
 		<?php $this->template( 'blocks/rsvp/status/full', array( 'ticket' => $ticket ) ); ?>

--- a/src/views/blocks/rsvp/status/going.php
+++ b/src/views/blocks/rsvp/status/going.php
@@ -13,10 +13,14 @@
  * @version 4.9.3
  *
  */
-
+$must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
+$going = $must_login ? false : $this->get( 'going' );
 ?>
 <span>
-	<button class="tribe-block__rsvp__status-button tribe-block__rsvp__status-button--going">
+	<button
+	class="tribe-block__rsvp__status-button tribe-block__rsvp__status-button--going<?php if ( 'yes' === $going ) { echo ' tribe-active'; }?>"
+	<?php echo disabled( 'yes', $going, false ); ?>
+	>
 		<?php $this->template( 'blocks/rsvp/status/going-icon' ); ?>
 		<span><?php esc_html_e( 'Going', 'event-tickets' ); ?></span>
 	</button>

--- a/src/views/blocks/rsvp/status/not-going.php
+++ b/src/views/blocks/rsvp/status/not-going.php
@@ -31,9 +31,15 @@ $show_not_going = tribe_is_truthy(
 if ( ! $show_not_going ) {
     return;
 }
+
+$must_login = ! is_user_logged_in() && tribe( 'tickets.rsvp' )->login_required();
+$going = $must_login ? false : $this->get( 'going' );
 ?>
 <span>
-	<button class="tribe-block__rsvp__status-button tribe-block__rsvp__status-button--not-going">
+	<button
+		class="tribe-block__rsvp__status-button tribe-block__rsvp__status-button--not-going<?php if ( 'no' === $going ) { echo ' tribe-active'; }?>"
+		<?php echo disabled( 'no', $going, false ); ?>
+	>
 		<?php $this->template( 'blocks/rsvp/status/not-going-icon' ); ?>
 		<span><?php esc_html_e( 'Not going', 'event-tickets' ); ?></span>
 	</button>


### PR DESCRIPTION
🎟  https://central.tri.be/issues/119946 && https://central.tri.be/issues/120365

Edit templates to streamline the process when login is required for RSVPs.
Pass status through login into template and preload form if present.
Fix login url so it redirects correctly.