### PR TITLE
#121519 - prevent PDF tickets from running if ET is on PDC and TEC is…

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -196,6 +196,7 @@ class Tribe__Tickets__Main {
 		) {
 			add_action( 'admin_notices', array( $this, 'tec_compatibility_notice' ) );
 			add_action( 'network_admin_notices', array( $this, 'tec_compatibility_notice' ) );
+			add_action( 'tribe_plugins_loaded', array( $this, 'remove_pdf_tickets_ext' ), 0 );
 
 			return;
 		}
@@ -333,6 +334,21 @@ class Tribe__Tickets__Main {
 		$output .= '</div>';
 
 		echo $output;
+	}
+
+	/**
+	 * Prevents PDF Tickets Ext from Running if TEC is on an Older Version
+	 *
+	 * @since TBD
+	 *
+	 */
+	public function remove_pdf_tickets_ext() {
+
+		if ( ! class_exists( 'Tribe__Extension__PDF_Tickets' ) ) {
+			return;
+		}
+
+		remove_action( 'tribe_plugins_loaded', array( Tribe__Extension__PDF_Tickets::instance(), 'register' ) );
 	}
 
 	/**


### PR DESCRIPTION
… older due to the add legacy plugins method


_Ref:_ [C#121519](https://central.tri.be/issues/121519)

If an older version of TEC Common loads because ET shuts down, then the dependency class has a method to add legacy plugins, which goes in and gets ET and adds it as an active plugin, because technically it finds the Main ET Class, which does load as it is the class that initializes the plugin. 

Since it adds it as an active plugin when the PDF ext loads it finds it in the list and continues to the fatal error. 

My solution is to prevent it from running if ET shuts down. 

It is in the main class because otherwise you would have to manually load another file to use it as the autoloader is not available. 