### PR TITLE
#121937 - remove PHP 7.0 type hinting for integers

### DIFF
--- a/src/Tribe/Status/Abstract.php
+++ b/src/Tribe/Status/Abstract.php
@@ -54,7 +54,7 @@ abstract class Tribe__Tickets__Status__Abstract {
 	 *
 	 * @param int $value
 	 */
-	public function add_qty( int $value ) {
+	public function add_qty( $value ) {
 		$this->qty += $value;
 	}
 
@@ -63,7 +63,7 @@ abstract class Tribe__Tickets__Status__Abstract {
 	 *
 	 * @param int $value
 	 */
-	public function remove_qty( int $value ) {
+	public function remove_qty( $value ) {
 		$this->qty -= $value;
 	}
 
@@ -81,7 +81,7 @@ abstract class Tribe__Tickets__Status__Abstract {
 	 *
 	 * @param int $value
 	 */
-	public function add_line_total( int $value ) {
+	public function add_line_total( $value ) {
 		$this->line_total += $value;
 	}
 
@@ -90,7 +90,7 @@ abstract class Tribe__Tickets__Status__Abstract {
 	 *
 	 * @param int $value
 	 */
-	public function remove_line_total( int $value ) {
+	public function remove_line_total( $value ) {
 		$this->line_total -= $value;
 	}
 

--- a/src/Tribe/Status/Abstract_Commerce.php
+++ b/src/Tribe/Status/Abstract_Commerce.php
@@ -76,7 +76,7 @@ class Tribe__Tickets__Status__Abstract_Commerce {
 	 *
 	 * @param int $value
 	 */
-	public function add_qty( int $value ) {
+	public function add_qty( $value ) {
 		$this->qty += $value;
 	}
 
@@ -87,7 +87,7 @@ class Tribe__Tickets__Status__Abstract_Commerce {
 	 *
 	 * @param int $value
 	 */
-	public function remove_qty( int $value ) {
+	public function remove_qty( $value ) {
 		$this->qty -= $value;
 	}
 
@@ -109,7 +109,7 @@ class Tribe__Tickets__Status__Abstract_Commerce {
 	 *
 	 * @param int $value
 	 */
-	public function add_line_total( int $value ) {
+	public function add_line_total( $value ) {
 		$this->line_total += $value;
 	}
 
@@ -120,7 +120,7 @@ class Tribe__Tickets__Status__Abstract_Commerce {
 	 *
 	 * @param int $value
 	 */
-	public function remove_line_total( int $value ) {
+	public function remove_line_total( $value ) {
 		$this->line_total -= $value;
 	}
 


### PR DESCRIPTION
_Ref:_ [C#121937](https://central.tri.be/issues/121937)

Remove int type hinting that is PHP 7.0... 