### PR TITLE
#122368 - update release date and prevent most extensions from running

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
-= [4.10.0.1] 2019-02-06 =
+= [4.10.0.1] 2019-02-07 =
 
 * Fix - Modify extension dependency checking with new system to determine if it can load [122368]
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -196,7 +196,7 @@ class Tribe__Tickets__Main {
 		) {
 			add_action( 'admin_notices', array( $this, 'tec_compatibility_notice' ) );
 			add_action( 'network_admin_notices', array( $this, 'tec_compatibility_notice' ) );
-			add_action( 'tribe_plugins_loaded', array( $this, 'remove_pdf_tickets_ext' ), 0 );
+			add_action( 'tribe_plugins_loaded', array( $this, 'remove_exts' ), 0 );
 
 			return;
 		}
@@ -337,18 +337,15 @@ class Tribe__Tickets__Main {
 	}
 
 	/**
-	 * Prevents PDF Tickets Ext from Running if TEC is on an Older Version
+	 * Prevents Extensions from running if ET is on an Older Version
 	 *
-	 * @since 4.10
+	 * @since 4.10.0.1
 	 *
 	 */
-	public function remove_pdf_tickets_ext() {
+	public function remove_exts() {
 
-		if ( ! class_exists( 'Tribe__Extension__PDF_Tickets' ) ) {
-			return;
-		}
+		remove_all_actions( 'tribe_plugins_loaded', 10 );
 
-		remove_action( 'tribe_plugins_loaded', array( Tribe__Extension__PDF_Tickets::instance(), 'register' ) );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -337,7 +337,7 @@ class Tribe__Tickets__Main {
 	}
 
 	/**
-	 * Prevents Extensions from running if ET is on an Older Version
+	 * Prevents Extensions from running if TEC is on an Older Version
 	 *
 	 * @since 4.10.0.1
 	 *


### PR DESCRIPTION
_Ref:_ [C#122368](https://central.tri.be/issues/122368)

Prevents all extensions from loading on action tribe_plugins_loaded priority 10 if TEC on an older version. 