### PR TITLE
Add template chooser for attendee registration page

### DIFF
--- a/src/Tribe/Attendee_Registration/Template.php
+++ b/src/Tribe/Attendee_Registration/Template.php
@@ -99,12 +99,38 @@ class Tribe__Tickets__Attendee_Registration__Template extends Tribe__Templates {
 			return $template;
 		}
 
-		// get the page template
-		$template = get_page_template();
+		// Use the template option set in the admin
+		$event_template = tribe_get_option( 'tribeEventsTemplate' );
+		$template = tribe_get_option( 'ticket-attendee-info-template' );
 
-		// Fallback for themes that are missing page.php
 		if ( empty( $template ) ) {
-			$template = get_template_directory() . '/index.php';
+			// we should only get here if the value hasn't been set yet
+			$tempalte = 'default';
+		} elseif ( 'same' === $template ) {
+			//note this could be an empty string...because
+			$template = $event_template;
+		}
+
+		switch ( $template ) {
+			case '' :
+			case 'event' :
+				$template = Tribe__Events__Templates::getTemplateHierarchy( 'default-template' );
+				break;
+			case 'default' :
+				$template = get_template_directory() . '/page.php';
+				break;
+			default :
+				$template = get_template_directory() . '/' . $template;
+		}
+
+		// get the page template
+		if ( empty( $template ) ) {
+			$template = get_page_template();
+
+			// Fallback for themes that are missing page.php
+			if ( empty( $template ) ) {
+				$template = get_template_directory() . '/index.php';
+			}
 		}
 
 		/**

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -9,6 +9,17 @@ $post_types_to_ignore = apply_filters( 'tribe_tickets_settings_post_type_ignore_
 	'attachment',
 ) );
 
+$template_options = array(
+	'same'    => esc_html__( 'Same as Event Page Template', 'the-events-calendar' ),
+	'default' => esc_html__( 'Default Page Template', 'the-events-calendar' ),
+	'event'   => esc_html__( 'Default Events Template', 'the-events-calendar' ),
+);
+$templates        = get_page_templates();
+ksort( $templates );
+foreach ( array_keys( $templates ) as $template ) {
+	$template_options[ $templates[ $template ] ] = $template;
+}
+
 $all_post_type_objects = get_post_types( array( 'public' => true ), 'objects' );
 $all_post_types        = array();
 
@@ -77,6 +88,15 @@ $tickets_fields = array_merge( $tickets_fields, array(
 			'default'             => tribe( 'tickets.attendee_registration' )->get_slug(),
 			'validation_callback' => 'is_string',
 			'validation_type'     => 'slug',
+		),
+		'ticket-attendee-info-template' => array(
+			'type'            => 'dropdown',
+			'label'           => __( 'Attendee registration template', 'the-events-calendar' ),
+			'tooltip'         => __( 'Choose a page template to control the appearance of your attendee registration page.', 'event-tickets' ),
+			'validation_type' => 'options',
+			'size'            => 'large',
+			'default'         => 'default',
+			'options'         => $template_options,
 		),
 	)
 );

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -10,7 +10,7 @@ $post_types_to_ignore = apply_filters( 'tribe_tickets_settings_post_type_ignore_
 ) );
 
 $template_options = array(
-	'default' => esc_html__( 'Default Page Template', 'the-events-calendar' ),
+	'default' => esc_html__( 'Default Page Template', 'event-tickets' ),
 );
 
 if ( class_exists( 'Tribe__Events__Main' ) ) {

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -14,7 +14,7 @@ $template_options = array(
 );
 
 if ( class_exists( 'Tribe__Events__Main' ) ) {
-	$template_options['same']  = esc_html__( 'Same as Event Page Template', 'the-events-calendar' );
+	$template_options['same']  = esc_html__( 'Same as Event Page Template', 'event-tickets' );
 	$template_options['event'] = esc_html__( 'Default Events Template', 'the-events-calendar' );
 }
 

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -11,11 +11,11 @@ $post_types_to_ignore = apply_filters( 'tribe_tickets_settings_post_type_ignore_
 
 $template_options = array(
 	'default' => esc_html__( 'Default Page Template', 'the-events-calendar' ),
-	'event'   => esc_html__( 'Default Events Template', 'the-events-calendar' ),
 );
 
 if ( class_exists( 'Tribe__Events__Main' ) ) {
 	$template_options['same']  = esc_html__( 'Same as Event Page Template', 'the-events-calendar' );
+	$template_options['event'] = esc_html__( 'Default Events Template', 'the-events-calendar' );
 }
 
 $templates        = get_page_templates();

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -95,7 +95,7 @@ $tickets_fields = array_merge( $tickets_fields, array(
 		),
 		'ticket-attendee-info-template' => array(
 			'type'            => 'dropdown',
-			'label'           => __( 'Attendee Registration template', 'the-events-calendar' ),
+			'label'           => __( 'Attendee Registration template', 'event-tickets' ),
 			'tooltip'         => __( 'Choose a page template to control the appearance of your attendee registration page.', 'event-tickets' ),
 			'validation_type' => 'options',
 			'size'            => 'large',

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -10,10 +10,14 @@ $post_types_to_ignore = apply_filters( 'tribe_tickets_settings_post_type_ignore_
 ) );
 
 $template_options = array(
-	'same'    => esc_html__( 'Same as Event Page Template', 'the-events-calendar' ),
 	'default' => esc_html__( 'Default Page Template', 'the-events-calendar' ),
 	'event'   => esc_html__( 'Default Events Template', 'the-events-calendar' ),
 );
+
+if ( class_exists( 'Tribe__Events__Main' ) ) {
+	$template_options['same']  = esc_html__( 'Same as Event Page Template', 'the-events-calendar' );
+}
+
 $templates        = get_page_templates();
 ksort( $templates );
 foreach ( array_keys( $templates ) as $template ) {

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -95,7 +95,7 @@ $tickets_fields = array_merge( $tickets_fields, array(
 		),
 		'ticket-attendee-info-template' => array(
 			'type'            => 'dropdown',
-			'label'           => __( 'Attendee registration template', 'the-events-calendar' ),
+			'label'           => __( 'Attendee Registration template', 'the-events-calendar' ),
 			'tooltip'         => __( 'Choose a page template to control the appearance of your attendee registration page.', 'event-tickets' ),
 			'validation_type' => 'options',
 			'size'            => 'large',

--- a/src/admin-views/tribe-options-tickets.php
+++ b/src/admin-views/tribe-options-tickets.php
@@ -15,7 +15,7 @@ $template_options = array(
 
 if ( class_exists( 'Tribe__Events__Main' ) ) {
 	$template_options['same']  = esc_html__( 'Same as Event Page Template', 'event-tickets' );
-	$template_options['event'] = esc_html__( 'Default Events Template', 'the-events-calendar' );
+	$template_options['event'] = esc_html__( 'Default Events Template', 'event-tickets' );
 }
 
 $templates        = get_page_templates();


### PR DESCRIPTION
🎫 https://central.tri.be/issues/120195

Adds a dropdown to the admin Tickets tab to set a template for the AR page.

Chooses the template used based on that - falls back to `page.php` then to `index.php`

On hold for Strategy QA