### PR TITLE
Add filter to show email form for non-admins

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Indicate required fields in ticket block [122442]
 * Tweak - Add filter for attendee registration page template [121223]
 * Tweak - Add filter to manage attendees permissions [123070]
+* Tweak - Add filter to allow email form to be shown for non-admins [123070]
 * Fix - Only show attendee registration for RSVP if going [121026]
 * Fix - Fix broken ticket block sagas to allow syncing with event times [120736]
 * Fix - Only allow attendee move functionality in admin [87145]

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -540,9 +540,13 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		if ( $allow_fe && ! is_admin() ) {
 			$email_link = str_replace( '/wp-admin/', '/', $email_link );
-			$email_link = str_replace( 'page=tickets-attendees&', '', $email_link );
-
-			$email_link = substr( $email_link, 0, stripos( $email_link, '&post_type' ) );
+			$email_link = add_query_arg(
+				array(
+					'page' => null,
+					'post_type' => null,
+				),
+				$email_link
+			);
 		}
 
 		$nav = array(

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -559,7 +559,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 
 		// Only show the email button if the user is an admin, or we've enableds it via the filter.
 		if ( current_user_can( 'edit_posts' ) || $allow_fe ) {
-			$nav[ 'left' ][ 'email' ] = '<a class="email button action thickbox" href="' . esc_url( $email_link ) . '">' . esc_attr__( 'Email', 'event-tickets' ) . '</a>';
+			$nav['left']['email'] = sprintf( '<a class="email button action thickbox" href="%1$s">%2$s</a>', esc_url( $email_link ), esc_html__( 'Email', 'event-tickets' ) );
 		}
 
 		/**

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -525,7 +525,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$allow_fe = apply_filters( 'tribe_allow_admin_on_frontend', false );
 		if ( $allow_fe && ! is_admin() ) {
 			global $wp;
-			$parent = $wp->request . '/';
+			$parent = untrailingslashit( $wp->request ) . '/';
 		}
 
 		$email_link = Tribe__Settings::instance()->get_url( array(

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -513,6 +513,21 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		 */
 		add_thickbox();
 
+		$parent = 'admin.php';
+
+		/**
+		 * Filtert to show email form for non-admins.
+		 *
+		 * @since TBD
+		 *
+		 * @param boolean
+		 */
+		$allow_fe = apply_filters( 'tribe_allow_admin_on_frontend', false );
+		if ( $allow_fe && ! is_admin() ) {
+			global $wp;
+			$parent =  $wp->request . '/';
+		}
+
 		$email_link = Tribe__Settings::instance()->get_url( array(
 			'page'      => 'tickets-attendees',
 			'action'    => 'email',
@@ -520,17 +535,28 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 			'TB_iframe' => true,
 			'width'     => 410,
 			'height'    => 300,
-			'parent'    => 'admin.php',
+			'parent'    => $parent,
 		) );
+
+		if ( $allow_fe && ! is_admin() ) {
+			$email_link = str_replace( '/wp-admin/', '/', $email_link );
+			$email_link = str_replace( 'page=tickets-attendees&', '', $email_link );
+
+			$email_link = substr( $email_link, 0, stripos( $email_link, '&post_type' ) );
+		}
 
 		$nav = array(
 			'left' => array(
 				'print'  => sprintf( '<input type="button" name="print" class="print button action" value="%s">', esc_attr__( 'Print', 'event-tickets' ) ),
-				'email'  => '<a class="email button action thickbox" href="' . esc_url( $email_link ) . '">' . esc_attr__( 'Email', 'event-tickets' ) . '</a>',
 				'export' => sprintf( '<a target="_blank" href="%s" class="export button action">%s</a>', esc_url( $export_url ), esc_html__( 'Export', 'event-tickets' ) ),
 			),
 			'right' => array(),
 		);
+
+		// Only show the email button if the user is an admin, or we've enableds it via the filter.
+		if ( current_user_can( 'edit_posts' ) || $allow_fe ) {
+			$nav[ 'left' ][ 'email' ] = '<a class="email button action thickbox" href="' . esc_url( $email_link ) . '">' . esc_attr__( 'Email', 'event-tickets' ) . '</a>';
+		}
 
 		/**
 		 * Allows for customization of the buttons/options available above and below the Attendees table.

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -525,7 +525,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		$allow_fe = apply_filters( 'tribe_allow_admin_on_frontend', false );
 		if ( $allow_fe && ! is_admin() ) {
 			global $wp;
-			$parent =  $wp->request . '/';
+			$parent = $wp->request . '/';
 		}
 
 		$email_link = Tribe__Settings::instance()->get_url( array(

--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -20,7 +20,7 @@ $show_title = apply_filters( 'tribe_tickets_attendees_show_title', true, tribe( 
 
 <div class="wrap tribe-attendees-page">
 	<?php if ( $show_title ) : ?>
-        <h1><?php esc_html_e( 'Attendees', 'event-tickets' ); ?></h1>
+		<h1><?php esc_html_e( 'Attendees', 'event-tickets' ); ?></h1>
 	<?php endif; ?>
 	<div id="tribe-attendees-summary" class="welcome-panel">
 		<div class="welcome-panel-content">


### PR DESCRIPTION
🎫 https://central.tri.be/issues/123070

This is a compromise solution:

The user can activate the email form for non-admins via a filter as it works but it throws notices as it's still trying to load admin stuff on the FE. Once we have the notices corrected, we can add the filter as always-on in CT.