### PR TITLE
Attendee Registration: fix getting theme page templates

### DIFF
--- a/src/Tribe/Attendee_Registration/Template.php
+++ b/src/Tribe/Attendee_Registration/Template.php
@@ -116,7 +116,7 @@ class Tribe__Tickets__Attendee_Registration__Template extends Tribe__Templates {
 			case 'default' :
 				// A bit of logic for themes without a page.php
 				$page = locate_template( 'page.php' );
-				$page = ! empty( $page ) ? 'page.php' : array_values( wp_get_theme()->get_page_templates() );
+				$page = ! empty( $page ) ? 'page.php' : array_keys( wp_get_theme()->get_page_templates() );
 				$page = ! empty( $page ) ? $page : 'index.php';
 				$page = ! is_array( $page ) ? $page : $page[0];
 


### PR DESCRIPTION
the current code assumes the array returned by wp_get_theme()->get_templates()
is in the form {template_name} => {filename} while actually it's the opposite.