### PR TITLE
Add variable not defined

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Use buttons instead of links and add better feedback on checkin (disable buttons) [70618]
 * Tweak - Use get_stylesheet_directory() instead of get_template_directory() to honor child themes for AR template [123613]
 * Tweak - Remove empty "Primary Info" column from attendee list email and export [122274]
+* Fix - Add variable not defined when a ticket was moved to a different event [124164]
 * Fix - Resolve problems with WP_Theme::get_page_templates() usage, use array_keys() instead of array_values() since the array is keyed by filename, not template name. Props to @eri-trabiccolo for flagging this! [123613]
 * Fix - Allow IE users to increment/decrement the ticket quantity field via the buttons [121073]
 * Fix - Use a md5 hash for checkbox and radio option names to prevent fields from not saving if they a large amount of characters [119448]

--- a/src/Tribe/Admin/Move_Ticket_Types.php
+++ b/src/Tribe/Admin/Move_Ticket_Types.php
@@ -94,8 +94,9 @@ class Tribe__Tickets__Admin__Move_Ticket_Types extends Tribe__Tickets__Admin__Mo
 			wp_send_json_error();
 		}
 
-		$ticket_type_id = absint( $args[ 'ticket_type_id' ] );
-		$destination_id = absint( $args[ 'target_post_id' ] );
+		$ticket_type_id = absint( $args['ticket_type_id'] );
+		$destination_id = absint( $args['target_post_id'] );
+		$src_post_id    = absint( $args['src_post_id'] );
 
 		if ( ! $ticket_type_id || ! $destination_id ) {
 			wp_send_json_error( array(


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/124164

----

Variable `$src_post_id` is used here:

- https://github.com/moderntribe/event-tickets/blob/910b6883a79935b56f09b4f90174ade582087c2f/src/Tribe/Admin/Move_Ticket_Types.php#L116

But is not defined nowhere inside of this method: https://github.com/moderntribe/event-tickets/blob/910b6883a79935b56f09b4f90174ade582087c2f/src/Tribe/Admin/Move_Ticket_Types.php#L85-L121