### PR TITLE
Remove CSS that hides RSVP forms when Event Blocks are disabled

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -133,7 +133,8 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Connect Tribe Commerce PayPal tickets into the share capacity and fix counts in PayPal sales report [109419]
 * Fix - Show RSVP on list view when it's the only attached ticket [123124]
 * Fix - Make submit button dependent on presence of editable meta data [114111]
-* Fix - Stop claiming that the AR page is an archive, add shortcode to display on any page. [123044]
+* Fix - Stop claiming that the AR page is an archive, add shortcode to display on any page [123044]
+* Fix - Remove CSS that was hiding the RSVP form when Blocks are disabled [123136]
 
 = [4.10.1.1] 2019-03-06 =
 
@@ -541,7 +542,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Improved get_ticket_counts() to account for tickets with global stock enabled  [82684]
 * Fix - Improved tribe_events_count_available_tickets() to account for tickets with global stock enabled (thanks to Florian for reporting this) [81967]
-* Fix — Fixed some PHP notices that would show up when buying EDD tickets. [83277]
+* Fix — Fixed some PHP notices that would show up when buying EDD tickets [83277]
 
 
 = [4.5.2] 2017-07-13 =
@@ -627,8 +628,8 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Resolve the Fatals related to undefined methods and Memory exhaustion [71958, 71912]
 * Fix - Use timezoned time for `tribe_events_ticket_is_on_sale()` [71959]
-* Tweak - Improvements to the Front End UX Tickets RSVP Styles. [72036]
-* Fix - Prevent content from being cut off on check in screen on iphone, other tweaks to mobile views. [70771]
+* Tweak - Improvements to the Front End UX Tickets RSVP Styles [72036]
+* Fix - Prevent content from being cut off on check in screen on iphone, other tweaks to mobile views [70771]
 * Fix - Prevent PHP 5.2 Strict mode from throwing notices due to usage of `is_a` [72812]
 
 = [4.4.0.1] 2017-01-09 =
@@ -674,7 +675,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.3.1] 2016-10-20 =
 
-* Tweak - Registered plugin as active with Tribe Common. [66657]
+* Tweak - Registered plugin as active with Tribe Common [66657]
 * Fix - When searching in the attendees list the ticket meta details can still be toggled after search [61783]
 * Fix - Fixed an issue where long file names would break plugin updates on some Windows installations [62552]
 

--- a/src/styles/rsvp/frontend.pcss
+++ b/src/styles/rsvp/frontend.pcss
@@ -4,9 +4,6 @@
  * @since  0.3.0-alpha
  */
 
- /* Hide this for now */
-#rsvp-now { display: none; }
-
 .tribe-block__rsvp {}
 
 .tribe-block__rsvp__ticket {


### PR DESCRIPTION
https://central.tri.be/issues/123136