### PR TITLE
Allow content on page with shortcode - even if it's the AR page

### DIFF
--- a/src/Tribe/Attendee_Registration/Main.php
+++ b/src/Tribe/Attendee_Registration/Main.php
@@ -50,7 +50,7 @@ class Tribe__Tickets__Attendee_Registration__Main {
 	public function is_on_page() {
 		global $wp_query;
 
-		return ! empty( $wp_query->query_vars[ $this->key_query_var ] ) || ( ! empty( $wp_query->queried_object->post_content ) && has_shortcode( $wp_query->queried_object->post_content, 'tribe_attendee_registration' ) );
+		return ! empty( $wp_query->query_vars[ $this->key_query_var ] ) ;
 	}
 
 	/**

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -26,7 +26,7 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 	public function render() {
 		ob_start();
 
-		echo tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' );
+		echo wp_kses_post( tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' ) );
 
 		return ob_get_clean();
 	}

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -26,7 +26,41 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 	public function render() {
 		ob_start();
 
-		echo wp_kses_post( tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' ) );
+		// things we need added, arrays so we can filter more if necessary
+		$additional_allowed = [
+			// forms
+			'form' => [
+				'class' => [],
+				'id'    => [],
+				'name'  => [],
+				'value' => [],
+				'type'  => [],
+			],
+			// form fields - input
+			'input' => [
+				'class' => [],
+				'id'    => [],
+				'name'  => [],
+				'value' => [],
+				'type'  => [],
+			],
+			// select
+			'select' => [
+				'class'  => [],
+				'id'     => [],
+				'name'   => [],
+				'value'  => [],
+				'type'   => [],
+			],
+			// select options
+			'option' => [
+				'selected' => [],
+			],
+		];
+
+		$allowed_tags = array_merge( wp_kses_allowed_html( 'post' ), $additional_allowed );
+
+		echo wp_kses( tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' ), $allowed_tags );
 
 		return ob_get_clean();
 	}

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -26,7 +26,7 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 	public function render() {
 		ob_start();
 
-		tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' );
+		echo tribe( 'tickets.attendee_registration.view' )->display_attendee_registration_page( null, 'shortcode' );
 
 		return ob_get_clean();
 	}

--- a/src/Tribe/Attendee_Registration/View.php
+++ b/src/Tribe/Attendee_Registration/View.php
@@ -26,8 +26,6 @@ class Tribe__Tickets__Attendee_Registration__View extends Tribe__Template {
 	 * @return string The resulting template content
 	 */
 	public function display_attendee_registration_page( $content = '', $context = 'default' ) {
-		global $wp_query;
-
 		// Bail if we don't have the flag to be in the registration page (or we're not using a shortcode to display it)
 		if ( 'shortcode' !== $context && ! tribe( 'tickets.attendee_registration' )->is_on_page() ) {
 			return $content;
@@ -110,6 +108,8 @@ class Tribe__Tickets__Attendee_Registration__View extends Tribe__Template {
 			'is_meta_up_to_date'     => $is_meta_up_to_date,
 			'cart_has_required_meta' => $cart_has_required_meta,
 			'providers'              => $providers,
+			'context'                => $context,
+			'original_content'       => $content,
 		);
 
 		// enqueue styles and scripts for this page

--- a/src/resources/postcss/tickets-registration-page.pcss
+++ b/src/resources/postcss/tickets-registration-page.pcss
@@ -335,6 +335,12 @@ body.page-tribe-attendee-registration {
 /*
  * Attendee Registration Checkout Form
  */
+ .tribe-block__tickets__registration__checkout{
+	 float: right;
+	 margin-bottom: 30px;
+	 width: 100%;
+ }
+
 .tribe-block__tickets__registration__checkout__submit {
 
 	&:disabled {

--- a/src/resources/postcss/tickets-registration-page.pcss
+++ b/src/resources/postcss/tickets-registration-page.pcss
@@ -335,7 +335,7 @@ body.page-tribe-attendee-registration {
 /*
  * Attendee Registration Checkout Form
  */
- .tribe-block__tickets__registration__checkout{
+ .tribe-block__tickets__registration__checkout {
 	 float: right;
 	 margin-bottom: 30px;
 	 width: 100%;


### PR DESCRIPTION
🎫 https://central.tri.be/issues/123044

While doing the video for QA I noticed that the other content was still being overridden when using the shortcode.