### PR TITLE
feat(RSVP): Prevent classic rsvp form showing on blocks posts.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Allow the PayPal confirmation email address sender to be empty, so it can default to the WordPress site email address [122745]
 * Fix - Stop claiming that the Attendee Registration page is an archive, add shortcode to display on any page [123044]
 * Fix - Remove CSS that was hiding the RSVP form when Blocks are disabled [123136]
+* Fix - Prevent classic rsvp form showing on blocks posts front-end [124394]
 
 = [4.10.1.2] 2019-03-14 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,7 +138,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Allow the PayPal confirmation email address sender to be empty, so it can default to the WordPress site email address [122745]
 * Fix - Stop claiming that the Attendee Registration page is an archive, add shortcode to display on any page [123044]
 * Fix - Remove CSS that was hiding the RSVP form when Blocks are disabled [123136]
-* Fix - Prevent classic rsvp form showing on blocks posts front-end [124394]
+* Fix - Prevent the classic RSVP form from showing in block-enabled posts on front-end [124394]
 
 = [4.10.1.2] 2019-03-14 =
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1074,6 +1074,12 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return;
 		}
 
+		// Bail on gutenberg
+		$template_overwrite = tribe( 'tickets.editor.template.overwrite' );
+		if ( tribe_get_option( 'toggle_blocks_editor' ) && ( has_blocks( $post->ID ) || ! $template_overwrite->has_classic_editor( $post->ID ) ) ) {
+			return $content;
+		}
+
 		// Check to see if all available tickets' end-sale dates have passed, in which case no form
 		// should show on the front-end.
 		$expired_tickets = 0;

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1074,9 +1074,16 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return;
 		}
 
-		// Bail on gutenberg
+		// Bail on Gutenberg
 		$template_overwrite = tribe( 'tickets.editor.template.overwrite' );
-		if ( tribe_get_option( 'toggle_blocks_editor' ) && ( has_blocks( $post->ID ) || ! $template_overwrite->has_classic_editor( $post->ID ) ) ) {
+
+		if (
+			tribe_get_option( 'toggle_blocks_editor' )
+			&& (
+				has_blocks( $post->ID )
+				|| ! $template_overwrite->has_classic_editor( $post->ID )
+			)
+		) {
 			return $content;
 		}
 


### PR DESCRIPTION
Add a check to RSVP.php to test if the user has enabled the MT blocks editor, and the post has blocks. If so, bail before adding the classic front-end RSVP form.

:ticket: https://central.tri.be/issues/124394