### PR TITLE
fix(RSVP): Check for block content and don't show classic form if present.

### DIFF
--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1074,7 +1074,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return $content;
 		}
 
-		// test for blocks in content, but usually called after the blocks have been convereted
+		// test for blocks in content, but usually called after the blocks have been converted
 		if (
 			has_blocks( $content )
 			|| false !== strpos( (string) $content, 'tribe-block ' )

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1077,7 +1077,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		// test for blocks in content, but usually called after the blocks have been convereted
 		if (
 			has_blocks( $content )
-			|| false !== strpos( (string) $content, 'tribe-block' )
+			|| false !== strpos( (string) $content, 'tribe-block ' )
 		) {
 			return $content;
 		}

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1071,18 +1071,13 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$tickets = $this->get_tickets( $post->ID );
 
 		if ( empty( $tickets ) ) {
-			return;
+			return $content;
 		}
 
-		// Bail on Gutenberg
-		$template_overwrite = tribe( 'tickets.editor.template.overwrite' );
-
+		// test for blocks in content, but usually called after the blocks have been convereted
 		if (
-			tribe_get_option( 'toggle_blocks_editor' )
-			&& (
-				has_blocks( $post->ID )
-				|| ! $template_overwrite->has_classic_editor( $post->ID )
-			)
+			has_blocks( $content )
+			|| false !== strpos( (string) $content, 'tribe-block' )
 		) {
 			return $content;
 		}


### PR DESCRIPTION
Test the post content for blocks and for the tribe-block class before allowing the RSVP classic form to display.

:ticket: https://central.tri.be/issues/124394