### PR TITLE
 fix(capacity): Add a check for unlimited tickets 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,8 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.10.4] TBD =
 
+* Fix - Add checks to `tribe_events_count_available_tickets()` and `tribe_events_has_unlimited_stock_tickets()` to properly detect unlimited tickets. [119844]
+
 = [4.10.3] TBD =
 
 = [4.10.2] TBD =

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -155,7 +155,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 			$stock_level = $global_stock_mode === Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE ? $ticket->global_stock_cap : $ticket->stock;
 
 			// If we find an unlimted ticket, just return unlimited so we don't use -1 as a real stock
-			if ( -1 === $stock_level ) {
+			if ( -1 === $stock_level || Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $stock_level ) {
 				return $stock_level;
 			}
 
@@ -322,6 +322,10 @@ if ( ! function_exists( 'tribe_tickets_has_unlimited_stock_tickets' ) ) {
 		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $event->ID ) as $ticket ) {
 			// Using equal operator as identical comparison operator causes this to always be false
 			if ( Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $ticket->stock() ) {
+				return true;
+			}
+			// We also return -1 for stock on unlimited tickets
+			if ( -1 === $ticket->stock() ) {
 				return true;
 			}
 		}

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -156,7 +156,6 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 
 			// If we find an unlimted ticket, just return unlimited so we don't use -1 as a real stock
 			if ( -1 === $stock_level ) {
-				bdump('unlimited');
 				return $stock_level;
 			}
 
@@ -166,7 +165,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 		$global_stock = new Tribe__Tickets__Global_Stock( $event->ID );
 		$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
 		$count += $global_stock;
-		bdump( 'limited: ' . $count );
+
 		return $count;
 	}
 }//end if

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -155,7 +155,7 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 			$stock_level = $global_stock_mode === Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE ? $ticket->global_stock_cap : $ticket->stock;
 
 			// If we find an unlimited ticket, just return unlimited (-1) so we don't use -1 or an empty string as a numeric stock and try to do math with it
-			if ( -1 === $stock_level || Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $stock_level ) {
+			if ( Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $stock_level || -1 === (int) $stock_level ) {
 				return -1;
 			}
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -154,12 +154,12 @@ if ( ! function_exists( 'tribe_events_count_available_tickets' ) ) {
 
 			$stock_level = $global_stock_mode === Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE ? $ticket->global_stock_cap : $ticket->stock;
 
-			// If we find an unlimted ticket, just return unlimited so we don't use -1 as a real stock
+			// If we find an unlimited ticket, just return unlimited (-1) so we don't use -1 or an empty string as a numeric stock and try to do math with it
 			if ( -1 === $stock_level || Tribe__Tickets__Ticket_Object::UNLIMITED_STOCK === $stock_level ) {
-				return $stock_level;
+				return -1;
 			}
 
-			$count += (int) $stock_level; // Explicit cast needed because it's possible $stock_level will be an empty string (unlimited stock)
+			$count += (int) $stock_level; // Explicit cast as a failsafe in case a string slips through
 		}
 
 		$global_stock = new Tribe__Tickets__Global_Stock( $event->ID );
@@ -325,7 +325,7 @@ if ( ! function_exists( 'tribe_tickets_has_unlimited_stock_tickets' ) ) {
 				return true;
 			}
 			// We also return -1 for stock on unlimited tickets
-			if ( -1 === $ticket->stock() ) {
+			if ( -1 === (int) $ticket->stock() ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Add a check to tribe_events_count_available_tickets() for unlimited tickets so it returns -1 when
one is found.

🎫 https://central.tri.be/issues/119844