### PR TITLE
fix(attendee registration shortcode): Remove extraneous comment

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - On deletion of an attendee update the shared capacity for Tribe Commerce Tickets [106516]
 * Fix - On the Attendee page use the shared capacity in Overview if ticket has it enabled  [106516]
 * Fix - Ensure capacity changes for source and target tickets when moving a ticket from one type to another [102636]
+* Fix - Correct escaping on attendee registration shortcode [125964]
 
 = [4.10.4] TBD =
 

--- a/src/views/registration/content.php
+++ b/src/views/registration/content.php
@@ -48,7 +48,7 @@ $passed_provider_class = $this->get_form_class( $passed_provider );
 
 			<form
 				method="post"
-				class="tribe-block__tickets__item__attendee__fields__form <?php echo sanitize_html_class( $provider_class ); ?>"// here
+				class="tribe-block__tickets__item__attendee__fields__form <?php echo sanitize_html_class( $provider_class ); ?>"
 				name="<?php echo 'event' . esc_attr( $event_id ); ?>"
 				novalidate
 			>


### PR DESCRIPTION
Remove comment that was breaking `wp_kses` escaping when the shortcode was run.

:ticket: https://central.tri.be/issues/125964