### PR TITLE
 feat(admin ticket block): Add sold/available tooltips

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Feature - Add tooltips to Attendee Report page [120856]
 * Feature - Add tooltip to explain what statues are behind Pending Order Completion [120862]
 * Feature - Add tooltip to explain the Available Count Per Ticket [120862]
+* Feature - Add tooltips to explain the sold & available amounts in the ticket block [121992]
 * Tweak - Add method to get all possible names of the completed status by Commerce [122458]
 * Tweak - Change success message for ticket move [102635]
 * Tweak - Ticket Attendee and Order Page Header css by changing overflow to visible [120862]

--- a/src/modules/blocks/ticket/container-header/quantity/template.js
+++ b/src/modules/blocks/ticket/container-header/quantity/template.js
@@ -52,7 +52,7 @@ const TicketContainerHeaderDescription = ( {
 	);
 
 	return ! isSelected && (
-		<div className="tribe-editor__ticket__container-header-quantity tribe-tooltip" title="This pertains to Orders that have been marked Completed.">
+		<div className="tribe-editor__ticket__container-header-quantity tribe-tooltip" title={ __( 'This pertains to Orders that have been marked Completed.', 'event-tickets' ) }>
 			<span className="tribe-editor__ticket__container-header-quantity-label">
 				{ getLabel() }<i class="dashicons dashicons-info"></i>
 			</span>

--- a/src/modules/blocks/ticket/container-header/quantity/template.js
+++ b/src/modules/blocks/ticket/container-header/quantity/template.js
@@ -52,9 +52,9 @@ const TicketContainerHeaderDescription = ( {
 	);
 
 	return ! isSelected && (
-		<div className="tribe-editor__ticket__container-header-quantity">
+		<div className="tribe-editor__ticket__container-header-quantity tribe-tooltip" title="This pertains to Orders that have been marked Completed.">
 			<span className="tribe-editor__ticket__container-header-quantity-label">
-				{ getLabel() }
+				{ getLabel() }<i class="dashicons dashicons-info"></i>
 			</span>
 			{ getQuantityBar() }
 		</div>

--- a/src/modules/blocks/tickets/availability/style.pcss
+++ b/src/modules/blocks/tickets/availability/style.pcss
@@ -21,9 +21,16 @@
 
 .tribe-editor__tickets__availability-label--available {
 
-	&:after {
-		content: '|';
-		padding-left: 15px;
-		padding-right: 15px;
+	+ .dashicons-info {
+		margin-right: 25px;
+		position: relative;
+
+		&:after {
+			content: '|';
+			padding-left: 10px;
+			padding-right: 10px;
+			position: absolute;
+			top: -2px;
+		}
 	}
 }

--- a/src/modules/blocks/tickets/availability/template.js
+++ b/src/modules/blocks/tickets/availability/template.js
@@ -49,7 +49,7 @@ const Availability = ( { available, total } ) => {
 		<div className="tribe-editor__tickets__availability">
 			<span
 				class="tribe-tooltip"
-				title="Ticket availability is based on the lowest number of inventory, stock, and capacity."
+				title={ __( 'Ticket availability is based on the lowest number of inventory, stock, and capacity.', 'event-tickets' ) }
 			>{ Available }<span className="dashicons dashicons-info"></span></span>
 			{ Total }
 		</div>

--- a/src/modules/blocks/tickets/availability/template.js
+++ b/src/modules/blocks/tickets/availability/template.js
@@ -25,6 +25,7 @@ const Availability = ( { available, total } ) => {
 			className={ classNames(
 				'tribe-editor__tickets__availability-label',
 				'tribe-editor__tickets__availability-label--available',
+				'tribe-tooltip'
 			) }
 			count={ available }
 			singular={ __( '%d ticket available', 'event-tickets' ) }
@@ -46,7 +47,10 @@ const Availability = ( { available, total } ) => {
 
 	return (
 		<div className="tribe-editor__tickets__availability">
-			{ Available }
+			<span
+				class="tribe-tooltip"
+				title="Ticket availability is based on the lowest number of inventory, stock, and capacity."
+			>{ Available }<i className="dashicons dashicons-info"></i></span>
 			{ Total }
 		</div>
 	);

--- a/src/modules/blocks/tickets/availability/template.js
+++ b/src/modules/blocks/tickets/availability/template.js
@@ -50,7 +50,7 @@ const Availability = ( { available, total } ) => {
 			<span
 				class="tribe-tooltip"
 				title="Ticket availability is based on the lowest number of inventory, stock, and capacity."
-			>{ Available }<i className="dashicons dashicons-info"></i></span>
+			>{ Available }<span className="dashicons dashicons-info"></span></span>
 			{ Total }
 		</div>
 	);


### PR DESCRIPTION
Add tooltips to the sold and available numbers explaining them (and their differences)

🎫 https://central.tri.be/issues/121992

Notes: I hard-coded the tooltips as they are only using the title for now (clicking on icons in blocks is...tricksy, and there is an overlay at one point 🤢 )

Required tweaking the styles for the block to accommodate the icon.

<img width="1172" alt="Screen Shot 2019-04-19 at 3 50 25 PM" src="https://user-images.githubusercontent.com/929375/56441504-54a4be80-62bb-11e9-9462-3d28fa2920bd.png">
<img width="1207" alt="Screen Shot 2019-04-19 at 3 50 19 PM" src="https://user-images.githubusercontent.com/929375/56441505-553d5500-62bb-11e9-9d56-31f8a7a5dac4.png">
