### PR TITLE
fix(attendee registration shortcode): Use tribe context for cron discovery.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Prevent potential PayPal issues by not allowing $0 tickets in the block editor for Tribe Commerce [123835]
 * Fix - When moving an attendee prevent shared capacity from being enabled on the receiving event [120727]
 * Fix - Tidy attendee list print styles [125299]
+* Fix - Use trbe.context->doing_cron to avoid issues with WordPress verions before 4.8 [26111]
 * Fix - Prevent PHP notices when looking for a template that does not exist in `tribe_tickets_get_template_part()` (props @stian-overasen) [125913]
 
 = [4.10.3] 2019-04-17 =

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -9,7 +9,7 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 
 	public function hook() {
 		// block editor has a fit if we don't bail on the admin...don't really need them in other places?
-		if ( is_admin() || wp_doing_cron() || wp_doing_ajax() ) {
+		if ( is_admin() || wp_doing_ajax() || tribe( 'context' )->doing_cron() ) {
 			return;
 		}
 


### PR DESCRIPTION
Use the `doing_cron` function from tribe.context to be backward compatible with WP versions before
4.8

:ticket: https://central.tri.be/issues/126111

see: https://github.com/moderntribe/tribe-common/blob/f8f3ec8aca567b84a37629d036a8181cd9e2dc22/src/Tribe/Context.php#L242