### PR TITLE
#126749 - add a filter to remove product and download from the saved …

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -139,7 +139,6 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Correct escaping on attendee registration shortcode [125964]
 * Fix - Fix error with creating new ticket in block editor [126266]
 
-
 = [4.10.4.3] 2019-04-26 =
 
 * Fix - Prevent Composer autoloader from throwing Fatal due to unexistent `setClassMapAuthoritative()` method [126590]

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Update status manage to accept provider names or abbreviations [120862]
 * Tweak - In the Ticket Block add link to EDD Orders Page [121440]
 * Tweak - Change "Attendee Registration" to "Attendee Information" in several locations [126038]
-* Tweak - Exclude WooCommerce Product and EDD Downloads as supported post types for tickets to prevent recursion errors [126749]
+* Tweak - Exclude WooCommerce Product and EDD Downloads as supported post types when saving for tickets to prevent recursion errors, in case they were previously saved before we removed them from the options list [126749]
 * Fix - Add checks to `tribe_events_count_available_tickets()` and `tribe_events_has_unlimited_stock_tickets()` to properly detect unlimited tickets. [119844]
 * Fix - Change `inventory` to compare the correct ticket when checking event shared capacity [119844]
 * Fix - Make Attendees Report match the order report, specifically "Total Tickets Issued" should not include cancelled tickets [69823]

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Update status manage to accept provider names or abbreviations [120862]
 * Tweak - In the Ticket Block add link to EDD Orders Page [121440]
 * Tweak - Change "Attendee Registration" to "Attendee Information" in several locations [126038]
+* Tweak - Supported post types for tickets by removing product and download from saved options to prevent recursion errors [126749]
 * Fix - Add checks to `tribe_events_count_available_tickets()` and `tribe_events_has_unlimited_stock_tickets()` to properly detect unlimited tickets. [119844]
 * Fix - Change `inventory` to compare the correct ticket when checking event shared capacity [119844]
 * Fix - Make Attendees Report match the order report, specifically "Total Tickets Issued" should not include cancelled tickets [69823]
@@ -137,6 +138,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Ensure capacity changes for source and target tickets when moving a ticket from one type to another [102636]
 * Fix - Correct escaping on attendee registration shortcode [125964]
 * Fix - Fix error with creating new ticket in block editor [126266]
+
 
 = [4.10.4.3] 2019-04-26 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Update status manage to accept provider names or abbreviations [120862]
 * Tweak - In the Ticket Block add link to EDD Orders Page [121440]
 * Tweak - Change "Attendee Registration" to "Attendee Information" in several locations [126038]
-* Tweak - Supported post types for tickets by removing product and download from saved options to prevent recursion errors [126749]
+* Tweak - Exclude WooCommerce Product and EDD Downloads as supported post types for tickets to prevent recursion errors [126749]
 * Fix - Add checks to `tribe_events_count_available_tickets()` and `tribe_events_has_unlimited_stock_tickets()` to properly detect unlimited tickets. [119844]
 * Fix - Change `inventory` to compare the correct ticket when checking event shared capacity [119844]
 * Fix - Make Attendees Report match the order report, specifically "Total Tickets Issued" should not include cancelled tickets [69823]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -760,7 +760,7 @@ class Tribe__Tickets__Main {
 			tribe_update_option( 'ticket-enabled-post-types', $defaults );
 		}
 
-		// removes WooCommerce Product and EDD Download Post Type to Prevent Recursion Fatal Error on Saving
+		// Remove WooCommerce Product and EDD post types to prevent recursion fatal error on save.
 		$filtered_post_types = array_diff( $options['ticket-enabled-post-types'], [ 'product', 'download' ] );
 
 		/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -761,7 +761,7 @@ class Tribe__Tickets__Main {
 		}
 
 		// removes WooCommerce Product and EDD Download Post Type to Prevent Recursion Fatal Error on Saving
-		$filtered_post_types = array_diff( $options['ticket-enabled-post-types'], array( 'product', 'download' ) );
+		$filtered_post_types = array_diff( $options['ticket-enabled-post-types'], [ 'product', 'download' ] );
 
 		/**
 		 * Filters the list of post types that support tickets

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -768,7 +768,7 @@ class Tribe__Tickets__Main {
 		 *
 		 * @param array $post_types Array of post types
 		 */
-		return apply_filters( 'tribe_tickets_post_types', (array) $filtered_post_types );
+		return apply_filters( 'tribe_tickets_post_types', $filtered_post_types );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -761,7 +761,7 @@ class Tribe__Tickets__Main {
 		}
 
 		// Remove WooCommerce Product and EDD post types to prevent recursion fatal error on save.
-		$filtered_post_types = array_diff( $options['ticket-enabled-post-types'], [ 'product', 'download' ] );
+		$filtered_post_types = array_diff( (array) $options['ticket-enabled-post-types'], [ 'product', 'download' ] );
 
 		/**
 		 * Filters the list of post types that support tickets

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -760,12 +760,15 @@ class Tribe__Tickets__Main {
 			tribe_update_option( 'ticket-enabled-post-types', $defaults );
 		}
 
+		// removes WooCommerce Product and EDD Download Post Type to Prevent Recursion Fatal Error on Saving
+		$filtered_post_types = array_diff( $options['ticket-enabled-post-types'], array( 'product', 'download' ) );
+
 		/**
 		 * Filters the list of post types that support tickets
 		 *
 		 * @param array $post_types Array of post types
 		 */
-		return apply_filters( 'tribe_tickets_post_types', (array) $options['ticket-enabled-post-types'] );
+		return apply_filters( 'tribe_tickets_post_types', (array) $filtered_post_types );
 	}
 
 	/**


### PR DESCRIPTION
_Ref:_ [C#126749](https://central.tri.be/issues/126749)

A customer upgraded from ET 4.4 to 4.10 and their saved supported post types included product and downloads. When trying to save it was creating a recursion with wp_update_post() trying to save the ticket order. 

- I attempted to make this work using the filter tribe_tickets_post_types in Woo and EDD, but it would run to late to change it. 
- I tried numerous places to get it to run and it would always be late due to when Ticket Handler gets called. 
- I also attempted to run it from a theme function.php, but again it was not working. It finally worked in a plugin that runs before ET. 
- Considering that I added some code to remove it directly in the method. The filter could be used if someone desires to crash their site from a plugin to add them back. ;)