### PR TITLE
fix(report tooltips): Correct one message that was C&P wrong.

### DIFF
--- a/src/Tribe/Abstract_Attendance_Totals.php
+++ b/src/Tribe/Abstract_Attendance_Totals.php
@@ -73,7 +73,7 @@ abstract class Tribe__Tickets__Abstract_Attendance_Totals {
 	 * @return string a string of html for the tooltip
 	 */
 	public function get_total_completed_tooltip() {
-		$message = _x( 'Pending order completion counts tickets from orders with the following statuses:', 'total complete tooltip', 'event-tickets' );
+		$message = _x( 'This pertains to Orders that have been marked Completed.', 'total complete tooltip', 'event-tickets' );
 		$args    = [ 'classes' => 'required' ];
 
 		return tribe( 'tooltip.view' )->render_tooltip( $message, $args );


### PR DESCRIPTION
Correct message. No changelog needed, it's accounted for in original PR.

:ticket: https://central.tri.be/issues/126342