### PR TITLE
fix(attendee registration shortcode): Correct issue with TC

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Ensure capacity changes for source and target tickets when moving a ticket from one type to another [102636]
 * Fix - Correct escaping on attendee registration shortcode [125964]
 * Fix - Fix error with creating new ticket in block editor [126266]
+* Fix - Fix issue where tribe commerce would not submit correctly when using the attendee registration shortcode [126779]
 
 = [4.10.4.4] 2019-05-03 =
 

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -70,11 +70,12 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 			],
 			// form fields - input
 			'input' => [
-				'class' => [],
-				'id'    => [],
-				'name'  => [],
-				'value' => [],
-				'type'  => [],
+				'class'   => [],
+				'id'      => [],
+				'name'    => [],
+				'value'   => [],
+				'type'    => [],
+				'checked' => [],
 			],
 			// select
 			'select' => [

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -66,6 +66,7 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 				'value'  => [],
 				'type'   => [],
 				'action' => [],
+				'method' => [],
 			],
 			// form fields - input
 			'input' => [

--- a/src/Tribe/Attendee_Registration/Template.php
+++ b/src/Tribe/Attendee_Registration/Template.php
@@ -247,7 +247,6 @@ class Tribe__Tickets__Attendee_Registration__Template extends Tribe__Templates {
 		return $classes;
 	}
 
-
 	/**
 	 * Checks if theme needs a compatibility fix
 	 *


### PR DESCRIPTION
Correct issue where Tribe Comerce would not submit on clicking "Save and Checkout". 
Also orrect missing checked attribute on checkboxes and radios upon submit/refresh when using shortcode.
Wound up being `wp_kses_post` filtering out the form/input attributes.

:ticket: https://central.tri.be/issues/126779