### PR TITLE
fix(admin ticket blocks): Remove ability to add multiple tickets or rsvp blocks to a single event/post

### DIFF
--- a/src/modules/blocks/rsvp/index.js
+++ b/src/modules/blocks/rsvp/index.js
@@ -30,6 +30,7 @@ export default {
 
 	supports: {
 		html: false,
+		multiple: false,
 	},
 
 	attributes: {

--- a/src/modules/blocks/tickets/index.js
+++ b/src/modules/blocks/tickets/index.js
@@ -30,6 +30,7 @@ export default {
 
 	supports: {
 		html: false,
+		multiple: false,
 	},
 
 	attributes: {


### PR DESCRIPTION
Add `supports/multiple:false` to the block registration, as multiple/duplicate blocks create all kinds
of havoc.

🎫 https://central.tri.be/issues/127507
🎫 https://central.tri.be/issues/127563