### PR TITLE
fix(translations): Fixed domain in string to be translated.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Add class to wrapper div around ticket controls in admin [127193]
 * Tweak - Reduced file size by removing .po files and directing anyone creating or editing local translations to translate.wordpress.org
 * Tweak - Modify methods to check for a post id of 0 to prevent PHP notices [128346]
+* Fix - Correct two places where the translation domain was incorrect. Thanks to @cfaria for the catch! []
 
 = [4.10.6] 2019-05-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Add class to wrapper div around ticket controls in admin [127193]
 * Tweak - Reduced file size by removing .po files and directing anyone creating or editing local translations to translate.wordpress.org
 * Tweak - Modify methods to check for a post id of 0 to prevent PHP notices [128346]
-* Fix - Correct two places where the translation domain was incorrect. Thanks to @cfaria for the catch! []
+* Fix - Correct two places where the translation domain was incorrect. Thanks to @cfaria for the catch! [128193]
 
 = [4.10.6] 2019-05-23 =
 

--- a/src/views/blocks/rsvp/form/submit-login.php
+++ b/src/views/blocks/rsvp/form/submit-login.php
@@ -20,5 +20,5 @@ $going     = $this->get( 'going' );
 // Note: the anchor tag is urlencoded here ('%23tribe-block__rsvp__ticket-') so it passes through the login redirect
 ?>
 <a href="<?php echo esc_url( Tribe__Tickets__Tickets::get_login_url( $event_id ) . '?going=' . $going . '%23tribe-block__rsvp__ticket-' . $ticket_id ); ?>">
-	<?php esc_html_e( 'Log in to RSVP', 'events-tickets' ); ?>
+	<?php esc_html_e( 'Log in to RSVP', 'event-tickets' ); ?>
 </a>

--- a/src/views/registration/attendees/fields/select.php
+++ b/src/views/registration/attendees/fields/select.php
@@ -36,7 +36,7 @@ $option_id = "tribe-tickets-meta_{$slug}_{$ticket->ID}" . ( $attendee_id ? '_' .
 		class="ticket-meta"
 		name="<?php echo esc_attr( $field_name ); ?>"
 		<?php echo $required ? 'required' : ''; ?>>
-		<option value=""><?php esc_html_e( 'Select an option', 'events-tickets' ); ?></option>
+		<option value=""><?php esc_html_e( 'Select an option', 'event-tickets' ); ?></option>
 		<?php foreach ( $options as $option => $label ) : ?>
 			<option <?php selected( $label, $value ); ?> value="<?php echo esc_attr( $label ); ?>"><?php echo esc_html( $label ); ?></option>
 		<?php endforeach; ?>


### PR DESCRIPTION
Correct two places where we had `events-tickets` instead of `event-tickets`, preventing correct
string translations.

:ticket: https://central.tri.be/issues/128193

Ref: https://github.com/moderntribe/event-tickets/pull/1263