### PR TITLE
Don't assume a `wp_` prefix for db tables | spotfix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [4.10.6.1] 2019-06-11 =
 
 * Tweak - Adjust newsletter signup submission destination [129034]
-* Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries []
+* Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries [129053]
 
 = [4.10.6] 2019-05-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [4.10.6.1] 2019-06-11 =
 
 * Tweak - Adjust newsletter signup submission destination [129034]
+* Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries []
 
 = [4.10.6] 2019-05-23 =
 

--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -260,7 +260,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 
 				$this->filter_query->join( "
 					LEFT JOIN {$wpdb->postmeta} attendee_optout
-					ON ( attendee_optout.post_id = wp_posts.ID
+					ON ( attendee_optout.post_id = {$wpdb->posts}.ID
 						AND attendee_optout.meta_key IN ( {$optout_keys} ) )
 				" );
 


### PR DESCRIPTION
Fixes a hardcoded reference to `wp_posts` (otherwise, for installs that use a different prefix, the query will break):

> Unknown column 'wp_posts.ID' in 'on clause'

Targeting `master` since I wasn't sure which branch would be best given where we are in the release cycle, feel free to update as needed.

https://central.tri.be/issues/129053