### PR TITLE
Update embedded newsletter signup form | #129034

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
 Plugin Name: Event Tickets
 Plugin URI:  http://m.tri.be/1acb
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 4.10.6
+Version: 4.10.6.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, 
 Tags: RSVP, events, tickets, event management, calendar, ticket sales, community, registration, api, dates, date, posts, workshop, conference, meeting, seminar, concert, summit, ticket integration, event ticketing
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 4.10.6
+Stable tag: 4.10.6.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -116,6 +116,10 @@ Currently, the following add-ons are available for Event Tickets:
 * [Eventbrite Tickets](http://m.tri.be/2e), for selling tickets to your event directly through Eventbrite.
 
 == Changelog ==
+
+= [4.10.6.1] 2019-06-11 =
+
+* Tweak - Adjust newsletter signup submission destination [129034]
 
 = [4.10.6] 2019-05-23 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4,7 +4,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '4.10.6';
+	const VERSION = '4.10.6.1';
 
 	/**
 	 * Min required The Events Calendar version

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -58,15 +58,16 @@
 		<h4 data-tribe-icon="dashicons-megaphone"><?php esc_html_e( "Don't Miss Out", 'event-tickets' ); ?></h4>
 		<p><?php esc_html_e( 'Stay in touch with Event Tickets and our entire family of events management tools. We share news, occasional discounts, and hilarious gifs.', 'event-tickets' ); ?></p>
 
-		<form action="https://moderntribe.createsend.com/t/r/s/athqh/" method="post">
-			<p><input id="fieldEmail" class="regular-text" name="cm-athqh-athqh" type="email" placeholder="<?php esc_attr_e( 'Email', 'event-tickets' ); ?>" required /></p>
+		<form action="https://support-api.tri.be/mailing-list/subscribe" method="post">
+			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'event-tickets' ); ?>" required /></p>
 			<div>
-				<input id="cm-privacy-consent" name="cm-privacy-consent" required type="checkbox" role="checkbox" aria-checked="false" />
-				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'event-tickets' ); ?></label>
-		   		<input id="cm-privacy-consent-hidden" name="cm-privacy-consent-hidden" type="hidden" value="true" />
+				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />
+				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'the-events-calendar' ); ?></label>
 			</div>
 			<p>
-				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'event-tickets' ); ?></button>
+				<input type="hidden" name="list" value="tec-newsletter" />
+				<input type="hidden" name="source" value="plugin:et" />
+				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'the-events-calendar' ); ?></button>
 			</p>
 		</form>
 	</div>

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -62,12 +62,12 @@
 			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'event-tickets' ); ?>" required /></p>
 			<div>
 				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />
-				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'the-events-calendar' ); ?></label>
+				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'event-tickets' ); ?></label>
 			</div>
 			<p>
 				<input type="hidden" name="list" value="tec-newsletter" />
 				<input type="hidden" name="source" value="plugin:et" />
-				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'the-events-calendar' ); ?></button>
+				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'event-tickets' ); ?></button>
 			</p>
 		</form>
 	</div>


### PR DESCRIPTION
Parallels what is essentially the [same change but for TEC](https://github.com/moderntribe/the-events-calendar/pull/2551): instead of submitting directly to createsend.com, the newsletter signup form will now submit to our own service.

:warning: Important! As with [TEC PR 2551]((https://github.com/moderntribe/the-events-calendar/pull/2551)) this change depends on [Support API PR 28](https://github.com/moderntribe/support-api.tri.be/pull/28), which introduces the endpoint we need for this to work. That change must be approved and be deployed before this work ships.

:ticket: [♯129034](https://central.tri.be/issues/129034)