### PR TITLE
Use $wpdb->prefix in filter_by_optout()

### DIFF
--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -260,7 +260,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 
 				$this->filter_query->join( "
 					LEFT JOIN {$wpdb->postmeta} attendee_optout
-					ON ( attendee_optout.post_id = wp_posts.ID
+					ON ( attendee_optout.post_id = {$wpdb->prefix}posts.ID
 						AND attendee_optout.meta_key IN ( {$optout_keys} ) )
 				" );
 


### PR DESCRIPTION
`filter_by_optout()` is using the hardcoded `wp_posts` for the query, which causes issues for any installations with a custom database prefix.

**The solution:**
On line 263, switch `wp_posts` with `{$wpdb->prefix}posts`, so the query works correctly with custom database prefixes.