### PR TITLE
update hardcoded `wp_postmeta`

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
 Plugin Name: Event Tickets
 Plugin URI:  http://m.tri.be/1acb
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 4.10.6
+Version: 4.10.6.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/lang/event-tickets.pot
+++ b/lang/event-tickets.pot
@@ -2,17 +2,17 @@
 # This file is distributed under the same license as the Event Tickets package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Event Tickets 4.10.6\n"
+"Project-Id-Version: Event Tickets 4.10.6.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/event-tickets\n"
-"POT-Creation-Date: 2019-05-22 18:43:37+00:00\n"
+"POT-Creation-Date: 2019-06-11 00:12:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-05-22 18:43\n"
+"PO-Revision-Date: 2019-06-11 00:12\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 
-#. #-#-#-#-#  event-tickets.pot (Event Tickets 4.10.6)  #-#-#-#-#
+#. #-#-#-#-#  event-tickets.pot (Event Tickets 4.10.6.1)  #-#-#-#-#
 #. Plugin Name of the plugin/theme
 #: event-tickets.php:59 src/Tribe/Main.php:586 src/Tribe/Privacy.php:32
 msgid "Event Tickets"
@@ -69,7 +69,7 @@ msgid ""
 msgstr ""
 
 #: src/Tribe/Admin/Move_Ticket_Types.php:305
-#: src/Tribe/Admin/Move_Tickets.php:735
+#: src/Tribe/Admin/Move_Tickets.php:738
 msgid "Changes to your tickets from %s"
 msgstr ""
 
@@ -144,7 +144,7 @@ msgstr[1] ""
 msgid "This ticket was moved to %1$s %2$s from %3$s %4$s"
 msgstr ""
 
-#: src/Tribe/Admin/Move_Tickets.php:797
+#: src/Tribe/Admin/Move_Tickets.php:800
 msgid "This ticket was moved to %1$s from %2$s"
 msgstr ""
 
@@ -2093,25 +2093,25 @@ msgstr ""
 msgid "Add me to the list"
 msgstr ""
 
-#: src/admin-views/admin-welcome-message.php:69
+#: src/admin-views/admin-welcome-message.php:70
 msgid "Sign Up"
 msgstr ""
 
-#: src/admin-views/admin-welcome-message.php:77
+#: src/admin-views/admin-welcome-message.php:78
 msgid "We Need Your Help"
 msgstr ""
 
-#: src/admin-views/admin-welcome-message.php:78
+#: src/admin-views/admin-welcome-message.php:79
 msgid ""
 "Your ratings keep us focused on making our plugins as useful as possible so "
 "we can help other WordPress users just like you."
 msgstr ""
 
-#: src/admin-views/admin-welcome-message.php:79
+#: src/admin-views/admin-welcome-message.php:80
 msgid "Rate us today!"
 msgstr ""
 
-#: src/admin-views/admin-welcome-message.php:80
+#: src/admin-views/admin-welcome-message.php:81
 msgid "Rate It"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, 
 Tags: RSVP, events, tickets, event management, calendar, ticket sales, community, registration, api, dates, date, posts, workshop, conference, meeting, seminar, concert, summit, ticket integration, event ticketing
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 4.10.6
+Stable tag: 4.10.6.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -116,6 +116,10 @@ Currently, the following add-ons are available for Event Tickets:
 * [Eventbrite Tickets](http://m.tri.be/2e), for selling tickets to your event directly through Eventbrite.
 
 == Changelog ==
+
+= [4.10.6.1] 2019-06-11 =
+
+* Tweak - Adjust newsletter signup submission destination [129034]
 
 = [4.10.6] 2019-05-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Tweak - Adjust newsletter signup submission destination [129034]
 * Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries [129053]
+* Language - 0 new strings added, 8 updated, 0 fuzzied, and 0 obsoleted
 
 = [4.10.6] 2019-05-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [4.10.6.1] 2019-06-11 =
 
 * Tweak - Adjust newsletter signup submission destination [129034]
+* Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries [129053]
 
 = [4.10.6] 2019-05-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
-= [4.10.6.1] 2019-06-11 =
+= [4.10.6.1] 2019-06-12 =
 
 * Tweak - Adjust newsletter signup submission destination [129034]
 * Fix - Resolve hardcoded reference to `wp_posts` table in optout ORM queries [129053]

--- a/src/Tribe/Admin/Move_Tickets.php
+++ b/src/Tribe/Admin/Move_Tickets.php
@@ -674,7 +674,10 @@ class Tribe__Tickets__Admin__Move_Tickets {
 		$to_notify = array();
 
 		$args = [
-			'not_in' => $ticket_ids,
+			'in' => $ticket_ids,
+			'by' => [
+				'ticket' => $tgt_ticket_type_id,
+			],
 		];
 
 		$attendee_data = Tribe__Tickets__Tickets::get_event_attendees_by_args( $tgt_event_id, $args );

--- a/src/Tribe/Attendee_Repository.php
+++ b/src/Tribe/Attendee_Repository.php
@@ -260,7 +260,7 @@ class Tribe__Tickets__Attendee_Repository extends Tribe__Repository {
 
 				$this->filter_query->join( "
 					LEFT JOIN {$wpdb->postmeta} attendee_optout
-					ON ( attendee_optout.post_id = wp_posts.ID
+					ON ( attendee_optout.post_id = {$wpdb->posts}.ID
 						AND attendee_optout.meta_key IN ( {$optout_keys} ) )
 				" );
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -4,7 +4,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '4.10.6';
+	const VERSION = '4.10.6.1';
 
 	/**
 	 * Min required The Events Calendar version

--- a/src/Tribe/Shortcodes/User_Event_Confirmation_List.php
+++ b/src/Tribe/Shortcodes/User_Event_Confirmation_List.php
@@ -120,7 +120,7 @@ class Tribe__Tickets__Shortcodes__User_Event_Confirmation_List {
 			)
 			AND NOT EXISTS (
 				SELECT 1
-				  FROM wp_postmeta ticket_status
+				  FROM {$wpdb->postmeta} ticket_status
 				 WHERE ticket_status.meta_key = '_wp_trash_meta_status'
 				   AND ticket_status.post_id = match_events.post_id
 			)

--- a/src/admin-views/admin-welcome-message.php
+++ b/src/admin-views/admin-welcome-message.php
@@ -58,14 +58,15 @@
 		<h4 data-tribe-icon="dashicons-megaphone"><?php esc_html_e( "Don't Miss Out", 'event-tickets' ); ?></h4>
 		<p><?php esc_html_e( 'Stay in touch with Event Tickets and our entire family of events management tools. We share news, occasional discounts, and hilarious gifs.', 'event-tickets' ); ?></p>
 
-		<form action="https://moderntribe.createsend.com/t/r/s/athqh/" method="post">
-			<p><input id="fieldEmail" class="regular-text" name="cm-athqh-athqh" type="email" placeholder="<?php esc_attr_e( 'Email', 'event-tickets' ); ?>" required /></p>
+		<form action="https://support-api.tri.be/mailing-list/subscribe" method="post">
+			<p><input id="fieldEmail" class="regular-text" name="email" type="email" placeholder="<?php esc_attr_e( 'Email', 'event-tickets' ); ?>" required /></p>
 			<div>
-				<input id="cm-privacy-consent" name="cm-privacy-consent" required type="checkbox" role="checkbox" aria-checked="false" />
+				<input id="cm-privacy-consent" name="consent" required type="checkbox" role="checkbox" aria-checked="false" />
 				<label for="cm-privacy-consent"><?php esc_html_e( 'Add me to the list', 'event-tickets' ); ?></label>
-		   		<input id="cm-privacy-consent-hidden" name="cm-privacy-consent-hidden" type="hidden" value="true" />
 			</div>
 			<p>
+				<input type="hidden" name="list" value="tec-newsletter" />
+				<input type="hidden" name="source" value="plugin:et" />
 				<button type="submit" class="button-primary"><?php esc_html_e( 'Sign Up', 'event-tickets' ); ?></button>
 			</p>
 		</form>


### PR DESCRIPTION
Fixes hardcoded wp_postmeta call on [tribe-user-event-confirmations] 

https://central.tri.be/issues/129402