### PR TITLE
Ensure common version is declared early to make decisions on loading

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,10 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [4.10.6.2] TBD =
+
+* Fix - Prevent issue where older versions of the tribe-common libraries could be bootstrapped [129478]
+
 = [4.10.6.1] 2019-06-13 =
 
 * Tweak - Adjust newsletter signup submission destination [129034]

--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.10.6.2] TBD =
 
-* Fix - Prevent issue where older versions of the tribe-common libraries could be bootstrapped [129478]
+* Fix - Prevent issue where older versions of the tribe-common libraries could be bootstrapped [129479]
 
 = [4.10.6.1] 2019-06-13 =
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -141,6 +141,8 @@ class Tribe__Tickets__Main {
 
 		$this->plugin_url = trailingslashit( plugins_url( $dir_prefix . $this->plugin_dir ) );
 
+		$this->maybe_set_common_lib_info();
+
 		add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ), 0 );
 		register_activation_hook( EVENT_TICKETS_MAIN_PLUGIN_FILE, array( $this, 'on_activation' ) );
 	}
@@ -171,12 +173,14 @@ class Tribe__Tickets__Main {
 
 		$common_version = $matches[1];
 
-		if ( empty( $GLOBALS['tribe-common-info'] ) ) {
-			$GLOBALS['tribe-common-info'] = array(
-				'dir'     => "{$this->plugin_path}common/src/Tribe",
-				'version' => $common_version,
-			);
-		} elseif ( 1 == version_compare( $GLOBALS['tribe-common-info']['version'], $common_version, '<' ) ) {
+		/**
+		 * If we don't have a version of Common or a Older version of the Lib
+		 * overwrite what should be loaded by the auto-loader
+		 */
+		if (
+			empty( $GLOBALS['tribe-common-info'] )
+			|| version_compare( $GLOBALS['tribe-common-info']['version'], $common_version, '<' )
+		) {
 			$GLOBALS['tribe-common-info'] = array(
 				'dir'     => "{$this->plugin_path}common/src/Tribe",
 				'version' => $common_version,
@@ -214,8 +218,6 @@ class Tribe__Tickets__Main {
 
 			return;
 		}
-
-		$this->maybe_set_common_lib_info();
 
 		/**
 		 * Before any methods from this plugin are called, we initialize our Autoloading


### PR DESCRIPTION
This moves the tribe-common registration back to `__construct()` so that it happens _before_ `plugins_loaded` priority `0` as per the Plugin Dependency spec.

See: https://central.tri.be/issues/129479
Related: https://github.com/moderntribe/the-events-calendar/pull/2561