### PR TITLE
Bail out of bootstrapping non-destructively if older TEC is present

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -242,7 +242,7 @@ class Tribe__Tickets__Main {
 		add_action( 'network_admin_notices', [ $this, 'tec_compatibility_notice' ] );
 		add_action( 'tribe_plugins_loaded', [ $this, 'remove_exts' ], 0 );
 		/*
-		* After common was loaded by another source (e.g. Event Tickets) let's append this plugin source files
+		* After common was loaded by another source (e.g. The Events Calendar) let's append this plugin source files
 		* to the ones the Autoloader will search. Since we're appending them the ones registered by the plugin
 		* "owning" common will be searched first.
 		*/

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -189,6 +189,21 @@ class Tribe__Tickets__Main {
 	}
 
 	/**
+	 * Resets the global common info back to TEC's common path
+	 *
+	 * @since 4.10.6.2
+	 */
+	private function reset_common_lib_info_back_to_tec() {
+		// if we get in here, we need to reset the global common to TEC's version so that we don't cause a fatal
+		$tec = Tribe__Events__Main::instance();
+		$tec_common_version = file_get_contents( $tec->plugin_path . 'common/src/Tribe/Main.php' );
+		$GLOBALS['tribe-common-info'] = [
+			'dir'     => "{$tec->plugin_path}common/src/Tribe",
+			'version' => $tec_common_version,
+		];
+	}
+
+	/**
 	 * Finalize the initialization of this plugin
 	 */
 	public function plugins_loaded() {
@@ -196,7 +211,7 @@ class Tribe__Tickets__Main {
 		// early check for an older version of The Events Calendar to prevent fatal error
 		if (
 			class_exists( 'Tribe__Events__Main' ) &&
-			! version_compare( Tribe__Events__Main::VERSION, $this->min_tec_version, '>=' )
+			version_compare( Tribe__Events__Main::VERSION, $this->min_tec_version, '<' )
 		) {
 			add_action( 'admin_notices', [ $this, 'tec_compatibility_notice' ] );
 			add_action( 'network_admin_notices', [ $this, 'tec_compatibility_notice' ] );
@@ -207,6 +222,9 @@ class Tribe__Tickets__Main {
 			* "owning" common will be searched first.
 			*/
 			add_action( 'tribe_common_loaded', [ $this, 'register_plugin_autoload_paths' ] );
+
+			// if we get in here, we need to reset the global common to TEC's version so that we don't cause a fatal
+			$this->reset_common_lib_info_back_to_tec();
 
 			return;
 		}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -96,7 +96,7 @@ class Tribe__Tickets__Main {
 	protected $activation_page;
 
 	/**
-	 * @var bool Prevent autoload intialization
+	 * @var bool Prevent autoload initialization
 	 */
 	private $should_prevent_autoload_init = false;
 


### PR DESCRIPTION
**Background**

The `maybe_set_common_lib_info()` method was in `plugins_loaded()` inappropriately. Once relocated _out_ of `plugins_loaded()` and back to `__construct()` where it belongs, a problem reared its head with regards to plugin validation and bailing. 

Before the Plugin Dependency work, we never checked for out-of-date versions from _both_ TEC and ET. When Plugin Dependency was completed, we added a new check to support this desired validation at the expense of moving the common bootstrap to the wrong place.

**The fix**

In a previous PR for this hotfix, `maybe_set_common_lib_info()` was relocated back to `__construct()`. This PR follows along with some more changes of note:

1. There is now a class property that holds a boolean that allows plugins_loaded() to bail if we determine the plugin should not initialize & bootstrap.
2. I've added two hooks to the `plugins_loaded` action at `-1` priority to ensure it runs _before_ we attempt to initialize and bootstrap.
    1. The first hook validates that the other core plugin–TEC if executing from within ET, or ET if executing from within TEC–is of the appropriate version. If not, it _re-points_ common _back_ to the older plugin.
    2. The second hook validates that the appropriate WP or PHP version is running. If not, it _re-points_ common _back_ to the older plugin.
3. If the above hooks determine that the plugin should not init/bootstrap, it doesn't.

See: https://central.tri.be/issues/129478 and https://central.tri.be/issues/129479