### PR TITLE
feat(report styles): Use a class for styles, don't reuse IDs.

### DIFF
--- a/src/admin-views/attendees.php
+++ b/src/admin-views/attendees.php
@@ -22,7 +22,7 @@ $show_title = apply_filters( 'tribe_tickets_attendees_show_title', true, tribe( 
 	<?php if ( $show_title ) : ?>
 		<h1><?php esc_html_e( 'Attendees', 'event-tickets' ); ?></h1>
 	<?php endif; ?>
-	<div id="tribe-attendees-summary" class="welcome-panel">
+	<div id="tribe-attendees-summary" class="welcome-panel tribe-report-panel">
 		<div class="welcome-panel-content">
 			<div class="welcome-panel-column-container">
 

--- a/src/admin-views/tpp-orders.php
+++ b/src/admin-views/tpp-orders.php
@@ -15,7 +15,7 @@
 <div class="wrap tribe-attendees-page">
 	<div id="icon-edit" class="icon32 icon32-tickets-orders"><br></div>
 
-	<div id="tribe-attendees-summary" class="welcome-panel">
+	<div id="tribe-attendees-summary" class="welcome-panel tribe-report-panel">
 		<div class="welcome-panel-content">
 			<div class="welcome-panel-column-container">
 

--- a/src/resources/postcss/tickets-attendees-print.pcss
+++ b/src/resources/postcss/tickets-attendees-print.pcss
@@ -44,7 +44,7 @@
 		}
 	}
 
-	#tribe-attendees-summary {
+	.tribe-report-panel {
 		margin: 0 0 30px 0;
 		border: 0;
 		box-shadow: none;

--- a/src/resources/postcss/tickets-attendees.pcss
+++ b/src/resources/postcss/tickets-attendees.pcss
@@ -1,4 +1,4 @@
-#tribe-attendees-summary {
+.tribe-report-panel {
 	overflow: visible;
 	padding: 0;
 	position: relative;


### PR DESCRIPTION
We've been reusing an ID inappropriately because we hung styles on it.
Move the styling to hang on a class and use that class instead.
Further, use unique IDs for each tab and ensure that any references to it are corrected to the new IDs.

:ticket: https://central.tri.be/issues/131430