### PR TITLE
Add filters for text and disabling the field.

### DIFF
--- a/src/admin-views/editor/fieldset/price.php
+++ b/src/admin-views/editor/fieldset/price.php
@@ -29,7 +29,7 @@ if ( ! isset( $ticket_id ) ) {
 	}
 
 	/**
-	 * Filters twhether we shold disable the ticket - separate from tribe-dependency.
+	 * Filters whether we shold disable the ticket - separate from tribe-dependency.
 	 *
 	 * @param boolean     $$disabled The boolean value tested againt
 	 * @param WP_Post|int $ticket_id The current ticket object or its ID


### PR DESCRIPTION
🎫 https://central.tri.be/issues/132274

Add filters so CT can:

- disable the price field when tickets have already been purchsed.
- change the description text to explain why we are disabling the field.

Related: https://github.com/moderntribe/events-community-tickets/pull/251

.