### PR TITLE
change to wp-browser 2.2.15 for tests to pass without create() null e…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "wp-coding-standards/wpcs": "^2.1",
     "automattic/vipwpcs": "^2.0",
     "moderntribe/tribalscents": "dev-master",
-    "lucatume/wp-browser": "^2.2.9",
+    "lucatume/wp-browser": "2.2.15",
     "codeception/codeception": "^2.5.6",
     "phpunit/phpunit": "^6.5.14",
     "facebook/webdriver": "1.6.0",
@@ -42,6 +42,9 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "config": {
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "platform": {
+      "php": "7.0.33"
+    }
   }
 }


### PR DESCRIPTION
…rror

Change to use wp-browser 2.2.15 to get all tests to pass