### PR TITLE
feat(tickets block): Implement tickets block in classic view.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Tweak - Clean up the way we add options to the ticket settings tab in PHP to make it more readable and maintainable. [133048]
 * Tweak - Add ability to track installed version history. Added `$version_history_slug` and `$latest_version_slug` properties to `Tribe__Tickets_Plus__Main` [133048]
+* Feature - Add ability to utilize the block ticket template outside of gun=tenberg views [132568]
 
 = [4.10.8] TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Tweak - Clean up the way we add options to the ticket settings tab in PHP to make it more readable and maintainable. [133048]
 * Tweak - Add ability to track installed version history. Added `$version_history_slug` and `$latest_version_slug` properties to `Tribe__Tickets_Plus__Main` [133048]
-* Feature - Add ability to utilize the block ticket template outside of gun=tenberg views [132568]
+* Feature - Add ability to utilize the block ticket template outside of Gutenberg views [132568]
 
 = [4.10.8] TBD =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -322,23 +322,23 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$post_id = $post_id->ID;
 			}
 
-			$args = array(
-				'post_type'      => array( $this->ticket_object ),
+			$args = [
+				'post_type'      => [ $this->ticket_object ],
 				'posts_per_page' => - 1,
 				'fields'         => 'ids',
 				'post_status'    => 'publish',
 				'orderby'        => 'menu_order',
 				'order'          => 'ASC',
-			);
+			];
 
 			if ( ! empty( $post_id ) ) {
-				$args['meta_query'] = array(
-					array(
+				$args['meta_query'] = [
+					[
 						'key'     => $this->event_key,
 						'value'   => $post_id,
 						'compare' => '=',
-					),
-				);
+					],
+				];
 			}
 
 			/**
@@ -451,12 +451,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$post_url = get_edit_post_link( $post_id, 'admin' );
 
 			$move_type_url = add_query_arg(
-				array(
+				[
 					'dialog'         => Tribe__Tickets__Main::instance()->move_ticket_types()->dialog_name(),
 					'ticket_type_id' => $ticket->ID,
 					'check'          => wp_create_nonce( 'move_tickets' ),
 					'TB_iframe'      => 'true',
-				),
+				],
 				$post_url
 			);
 
@@ -531,7 +531,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		public static function load_ticket_object( $ticket_id ) {
 			foreach ( self::modules() as $provider_class => $name ) {
-				$provider = call_user_func( array( $provider_class, 'get_instance' ) );
+				$provider = call_user_func( [ $provider_class, 'get_instance' ] );
 				$event    = $provider->get_event_for_ticket( $ticket_id );
 
 				if ( ! $event ) {
@@ -616,7 +616,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @return Tribe__Tickets__Ticket_Object[] List of ticket objects.
 		 */
-		protected function get_tickets( $post_id ) {}
+		public function get_tickets( $post_id ) {}
 
 		/**
 		 * Get attendees for a Post ID / Post type.
@@ -914,21 +914,21 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			// Register all Tribe__Tickets__Tickets api consumers
 			self::$active_modules[ $this->class_name ] = $this->plugin_name;
 
-			add_action( 'wp', array( $this, 'hook' ) );
+			add_action( 'wp', [ $this, 'hook' ] );
 
 			/**
 			 * Priority set to 11 to force a specific display order
 			 *
 			 * @since 4.6
 			 */
-			add_action( 'tribe_events_tickets_metabox_edit_main', array( $this, 'do_metabox_capacity_options' ), 11, 2 );
+			add_action( 'tribe_events_tickets_metabox_edit_main', [ $this, 'do_metabox_capacity_options' ], 11, 2 );
 
 			// Ensure ticket prices and event costs are linked
-			add_filter( 'tribe_events_event_costs', array( $this, 'get_ticket_prices' ), 10, 2 );
+			add_filter( 'tribe_events_event_costs', [ $this, 'get_ticket_prices' ], 10, 2 );
 
-			add_action( 'event_tickets_checkin', array( $this, 'purge_attendees_transient' ) );
-			add_action( 'event_tickets_uncheckin', array( $this, 'purge_attendees_transient' ) );
-			add_action( 'template_redirect', array( $this, 'maybe_redirect_to_attendees_registration_screen' ), 0 );
+			add_action( 'event_tickets_checkin', [ $this, 'purge_attendees_transient' ] );
+			add_action( 'event_tickets_uncheckin', [ $this, 'purge_attendees_transient' ] );
+			add_action( 'template_redirect', [ $this, 'maybe_redirect_to_attendees_registration_screen' ], 0 );
 		}
 
 		/**
@@ -945,12 +945,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$ticket_form_hook = $this->get_ticket_form_hook();
 
 			if ( ! empty( $ticket_form_hook ) ) {
-				add_action( $ticket_form_hook, array( $this, 'maybe_add_front_end_tickets_form' ), 5 );
-				add_filter( $ticket_form_hook, array( $this, 'show_tickets_unavailable_message' ), 6 );
+				add_action( $ticket_form_hook, [ $this, 'maybe_add_front_end_tickets_form' ], 5 );
+				add_filter( $ticket_form_hook, [ $this, 'show_tickets_unavailable_message' ], 6 );
 			}
 
-			add_filter( 'the_content', array( $this, 'front_end_tickets_form_in_content' ), 11 );
-			add_filter( 'the_content', array( $this, 'show_tickets_unavailable_message_in_content' ), 12 );
+			add_filter( 'the_content', [ $this, 'front_end_tickets_form_in_content' ], 11 );
+			add_filter( 'the_content', [ $this, 'show_tickets_unavailable_message_in_content' ], 12 );
 			/**
 			 * Trigger an action every time a new ticket instance has been created
 			 *
@@ -1425,7 +1425,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$modules = self::modules();
 
 			foreach ( $modules as $class => $module ) {
-				$obj              = call_user_func( array( $class, 'get_instance' ) );
+				$obj              = call_user_func( [ $class, 'get_instance' ] );
 				$provider_tickets = $obj->get_tickets( $post_id );
 				if ( is_array( $provider_tickets ) ) {
 					$tickets[] = $provider_tickets;
@@ -1450,7 +1450,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		public static function find_matching_event( $possible_ticket ) {
 			foreach ( self::modules() as $class => $module ) {
-				$obj   = call_user_func( array( $class, 'get_instance' ) );
+				$obj   = call_user_func( [ $class, 'get_instance' ] );
 				$event = $obj->get_event_for_ticket( $possible_ticket );
 				if ( $event instanceof WP_Post ) {
 					return $event;
@@ -1486,7 +1486,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 */
 		public static function global_stock_available() {
 			foreach ( self::modules() as $class => $module ) {
-				$provider = call_user_func( array( $class, 'get_instance' ) );
+				$provider = call_user_func( [ $class, 'get_instance' ] );
 
 				if ( method_exists( $provider, 'supports_global_stock' ) && $provider->supports_global_stock() ) {
 					return true;
@@ -1535,10 +1535,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return array
 		 */
 		protected function global_stock_mode_options() {
-			return array(
+			return [
 				Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE => __( 'Shared capacity with other tickets', 'event-tickets' ),
 				Tribe__Tickets__Global_Stock::OWN_STOCK_MODE    => __( 'Set capacity for this ticket only', 'event-tickets' ),
-			);
+			];
 		}
 
 		/**
@@ -1553,11 +1553,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			if ( ! self::$frontend_script_enqueued ) {
 				$url = Tribe__Tickets__Main::instance()->plugin_url . 'src/resources/js/frontend-ticket-form.js';
 				$url = Tribe__Template_Factory::getMinFile( $url, true );
-				wp_enqueue_script( 'tribe_tickets_frontend_tickets', $url, array( 'jquery' ), Tribe__Tickets__Main::VERSION, true );
+				wp_enqueue_script( 'tribe_tickets_frontend_tickets', $url, [ 'jquery' ], Tribe__Tickets__Main::VERSION, true );
 			}
 
 			self::$frontend_ticket_data = array_filter( array_merge( self::$frontend_ticket_data, $tickets ) );
-			add_action( 'wp_footer', array( __CLASS__, 'enqueue_frontend_stock_data' ) );
+			add_action( 'wp_footer', [ __CLASS__, 'enqueue_frontend_stock_data' ] );
 		}
 
 		/**
@@ -1584,19 +1584,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 * This order is important so that tickets overwrite RSVP on
 			 * the Buy Now Button on the front-end
 			 */
-			$types['rsvp']    = array(
+			$types['rsvp']    = [
 				'count'     => 0,
 				'stock'     => 0,
 				'unlimited' => 0,
 				'available' => 0,
-			);
-			$types['tickets'] = array(
+			];
+			$types['tickets'] = [
 				'count'     => 0, // count of ticket types currently for sale
 				'stock'     => 0, // current stock of tickets available for sale
 				'global'    => 0, // global stock ticket
 				'unlimited' => 0, // unlimited stock tickets
 				'available' => 0, // are tickets available for sale right now
-			);
+			];
 
 			foreach ( $tickets as $ticket ) {
 				// If a ticket is not current for sale do not count it
@@ -1699,10 +1699,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * Takes any global stock data and makes it available via a wp_localize_script() call.
 		 */
 		public static function enqueue_frontend_stock_data() {
-			$data = array(
+			$data = [
 				'tickets' => [],
 				'events'  => [],
-			);
+			];
 
 			foreach ( self::$frontend_ticket_data as $ticket ) {
 				$post = $ticket->get_event();
@@ -1715,19 +1715,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$global_stock = new Tribe__Tickets__Global_Stock( $post_id );
 				$stock_mode   = $ticket->global_stock_mode();
 
-				$ticket_data = array(
+				$ticket_data = [
 					'event_id' => $post_id,
 					'mode'     => $stock_mode,
 					'cap'      => $ticket->capacity(),
-				);
+				];
 
 				if ( $ticket->managing_stock() ) {
 					$ticket_data['stock'] = $ticket->available();
 				}
 
-				$data['events'][ $post_id ] = array(
+				$data['events'][ $post_id ] = [
 					'stock' => $global_stock->get_stock_level(),
-				);
+				];
 
 				$data['tickets'][ $ticket->ID ] = $ticket_data;
 			}
@@ -1812,7 +1812,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			foreach ( self::modules() as $class => $module ) {
 				/** @var Tribe__Tickets__Tickets $obj */
-				$obj = call_user_func( array( $class, 'get_instance' ) );
+				$obj = call_user_func( [ $class, 'get_instance' ] );
 
 				$provider_tickets = $obj->get_tickets( $post_id );
 
@@ -1831,7 +1831,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return string
 		 */
 		public function generate_tickets_email_content( $tickets ) {
-			return tribe_tickets_get_template_part( 'tickets/email', null, array( 'tickets' => $tickets ), false );
+			return tribe_tickets_get_template_part( 'tickets/email', null, [ 'tickets' => $tickets ], false );
 		}
 
 		/**
@@ -1846,7 +1846,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$template .= '.php';
 			}
 
-			if ( $theme_file = locate_template( array( 'tribe-events/' . $template ) ) ) {
+			if ( $theme_file = locate_template( [ 'tribe-events/' . $template ] ) ) {
 				$file = $theme_file;
 			} else {
 				$file = $this->plugin_path . 'src/views/' . $template;
@@ -1924,12 +1924,12 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				return false;
 			}
 
-			$first_matched_attendee = get_posts( array(
+			$first_matched_attendee = get_posts( [
 				'post_type'  => $attendee_object,
 				'meta_key'   => $attendee_order_key,
 				'meta_value' => $order_id,
 				'posts_per_page' => 1,
-			) );
+			] );
 
 			if ( empty( $first_matched_attendee ) ) {
 				return false;
@@ -2070,11 +2070,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					$value = $meta[ $field->slug ];
 				}
 
-				$meta_values[ $field->slug ] = array(
+				$meta_values[ $field->slug ] = [
 					'slug'  => $field->slug,
 					'label' => $field->label,
 					'value' => $value,
-				);
+				];
 			}
 
 			return $meta_values;
@@ -2139,7 +2139,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				// if any ticket is available for this event, consider the availability slug as 'available'
 				if ( 'available' === $availability_slug ) {
 					// reset the collected slugs to "available" only
-					$slugs = array( 'available' );
+					$slugs = [ 'available' ];
 					break;
 				}
 
@@ -2850,7 +2850,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				/** @var \Tribe__Tickets__Commerce__PayPal__Main $commerce_paypal */
 				$commerce_paypal = tribe( 'tickets.commerce.paypal' );
 
-				$url = add_query_arg( array( 'event_tickets_redirect_to' => $key, 'provider' => $commerce_paypal->attendee_object ), $url );
+				$url = add_query_arg(
+					[
+						'event_tickets_redirect_to' => $key,
+						'provider' => $commerce_paypal->attendee_object,
+					],
+					$url
+				);
 			}
 
 			wp_safe_redirect( $url, 307 );

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -959,7 +959,6 @@ class Tribe__Tickets__Tickets_View {
 
 		$tickets = $provider->get_tickets( $post_id );
 
-
 		$args = [
 			'post_id'             => $post_id,
 			'provider'            => $provider,
@@ -971,7 +970,6 @@ class Tribe__Tickets__Tickets_View {
 			'has_tickets_on_sale' => tribe_events_has_tickets_on_sale( $post_id ),
 			'is_sale_past'        => $blocks_tickets->get_is_sale_past( $tickets ),
 		];
-
 
 		// Add the rendering attributes into global context.
 		$template->add_template_globals( $args );

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Tribe__Tickets__Tickets_View {
 
 	/**
-	 * Get (and instantiate, if necessary) the instance of the class
+	 * Get (and instantiate, if necessary) the instance of the class.
 	 *
 	 * @static
 	 * @return self
@@ -32,38 +32,34 @@ class Tribe__Tickets__Tickets_View {
 	public static function hook() {
 		$myself = self::instance();
 
-		add_action( 'template_redirect', array( $myself, 'authorization_redirect' ) );
-		add_action( 'template_redirect', array( $myself, 'update_tickets' ) );
+		add_action( 'template_redirect', [ $myself, 'authorization_redirect' ] );
+		add_action( 'template_redirect', [ $myself, 'update_tickets' ] );
 
 		// Generate Non TEC Permalink
-		add_action( 'generate_rewrite_rules', array( $myself, 'add_non_event_permalinks' ) );
-		add_filter( 'query_vars', array( $myself, 'add_query_vars' ) );
-		add_action( 'parse_request', array( $myself, 'prevent_page_redirect' ) );
-		add_filter( 'the_content', array( $myself, 'intercept_content' ) );
-		add_action( 'parse_request', array( $myself, 'maybe_regenerate_rewrite_rules' ) );
+		add_action( 'generate_rewrite_rules', [ $myself, 'add_non_event_permalinks' ] );
+		add_filter( 'query_vars', [ $myself, 'add_query_vars' ] );
+		add_action( 'parse_request', [ $myself, 'prevent_page_redirect' ] );
+		add_filter( 'the_content', [ $myself, 'intercept_content' ] );
+		add_action( 'parse_request', [ $myself, 'maybe_regenerate_rewrite_rules' ] );
 
 		// Only Applies this to TEC users
 		if ( class_exists( 'Tribe__Events__Rewrite' ) ) {
-			add_action( 'tribe_events_pre_rewrite', array( $myself, 'add_permalink' ) );
-			add_filter( 'tribe_events_rewrite_base_slugs', array( $myself, 'add_rewrite_base_slug' ) );
+			add_action( 'tribe_events_pre_rewrite', [ $myself, 'add_permalink' ] );
+			add_filter( 'tribe_events_rewrite_base_slugs', [ $myself, 'add_rewrite_base_slug' ] );
 		}
 
 		// Intercept Template file for Tickets
-		add_action( 'tribe_events_pre_get_posts', array( $myself, 'modify_ticket_display_query' ) );
-		add_filter( 'tribe_events_template', array( $myself, 'intercept_template' ), 20, 2 );
-
-		// We will inject on the Priority 4, to be happen before RSVP
-		add_action( 'tribe_events_single_event_after_the_meta', array( $myself, 'inject_link_template' ), 4 );
-		add_filter( 'the_content', array( $myself, 'inject_link_template_the_content' ), 9 );
+		add_action( 'tribe_events_pre_get_posts', [ $myself, 'modify_ticket_display_query' ] );
+		add_filter( 'tribe_events_template', [ $myself, 'intercept_template' ], 20, 2 );
 
 		return $myself;
 	}
 
 	/**
-	 * By default WordPress has a nasty if query_var['p'] is a page then redirect to the page
-	 * so we will change the variables accordingly
+	 * By default WordPress has a nasty if query_var['p'] is a page then redirect to the page,
+	 * so we will change the variables accordingly.
 	 *
-	 * @param  WP_Query $query The current Query
+	 * @param  WP_Query $query The current Query.
 	 * @return void
 	 */
 	public function prevent_page_redirect( $query ) {
@@ -96,7 +92,7 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Tries to Flush the Rewrite rules
+	 * Tries to Flush the Rewrite rules.
 	 *
 	 * @return void
 	 */
@@ -120,22 +116,22 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Gets the List of Rewrite rules we are using here
+	 * Gets the List of Rewrite rules we are using here.
 	 *
 	 * @return array
 	 */
 	public function rewrite_rules_array() {
 		$bases = $this->add_rewrite_base_slug();
 
-		$rules = array(
+		$rules = [
 			sanitize_title_with_dashes( $bases['tickets'][0] ) . '/([0-9]{1,})/?' => 'index.php?p=$matches[1]&tribe-edit-orders=1',
-		);
+		];
 
 		return $rules;
 	}
 
 	/**
-	 * For non events the links will be a little bit weird, but it's the safest way
+	 * For non events the links will be a little bit weird, but it's the safest way.
 	 *
 	 * @param WP_Rewrite $wp_rewrite
 	 */
@@ -159,12 +155,12 @@ class Tribe__Tickets__Tickets_View {
 
 
 	/**
-	 * Sort Attendee by Order Status to Process Not Going First
+	 * Sort Attendee by Order Status to Process Not Going First.
 	 *
 	 * @since 4.7.1
 	 *
-	 * @param $a array an array of ticket id and status
-	 * @param $b array an array of ticket id and status
+	 * @param $a array An array of ticket id and status.
+	 * @param $b array An array of ticket id and status.
 	 *
 	 * @return int
 	 */
@@ -173,7 +169,7 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Update the RSVP and Tickets values for each Attendee
+	 * Update the RSVP and Tickets values for each Attendee.
 	 */
 	public function update_tickets() {
 		$is_correct_page = $this->is_edit_page();
@@ -198,7 +194,7 @@ class Tribe__Tickets__Tickets_View {
 
 		$post_id = get_the_ID();
 
-		$attendees = ! empty( $_POST['attendee'] ) ? $_POST['attendee'] : array();
+		$attendees = ! empty( $_POST['attendee'] ) ? $_POST['attendee'] : [];
 
 		/**
 		 * Sort list to handle all not attending first
@@ -208,7 +204,7 @@ class Tribe__Tickets__Tickets_View {
 		if ( function_exists( 'wp_list_sort' ) ) {
 			$attendees = wp_list_sort( $attendees, 'order_status', 'ASC', true );
 		} else {
-			uasort( $attendees, array( $this, 'sort_attendees' ) );
+			uasort( $attendees, [ $this, 'sort_attendees' ] );
 		}
 
 		foreach ( $attendees as $order_id => $data ) {
@@ -240,7 +236,7 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Helper function to generate the Link to the tickets page of an event
+	 * Helper function to generate the Link to the tickets page of an event.
 	 *
 	 * @since 4.7.1
 	 *
@@ -304,12 +300,12 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * To allow `tickets` to be translatable we need to add it as a base
+	 * To allow `tickets` to be translatable we need to add it as a base.
 	 *
-	 * @param  array $bases The translatable bases
+	 * @param  array $bases The translatable bases.
 	 * @return array
 	 */
-	public function add_rewrite_base_slug( $bases = array() ) {
+	public function add_rewrite_base_slug( $bases = [] ) {
 		/**
 		 * Allows users to filter and change the base for the order page
 		 *
@@ -323,7 +319,7 @@ class Tribe__Tickets__Tickets_View {
 
 
 	/**
-	 * Checks if this is the ticket page based on the current query var
+	 * Checks if this is the ticket page based on the current query var.
 	 *
 	 * This only works after parse_query has run.
 	 *
@@ -334,7 +330,7 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Adds the Permalink for the tickets end point
+	 * Adds the Permalink for the tickets end point.
 	 *
 	 * @param Tribe__Events__Rewrite $rewrite
 	 */
@@ -342,31 +338,31 @@ class Tribe__Tickets__Tickets_View {
 
 		// Adds the 'tickets' endpoint for single event pages.
 		$rewrite->single(
-			array( '{{ tickets }}' ),
-			array(
+			[ '{{ tickets }}' ],
+			[
 				Tribe__Events__Main::POSTTYPE => '%1',
 				'post_type' => Tribe__Events__Main::POSTTYPE,
 				'eventDisplay' => 'tickets',
-			)
+			]
 		);
 
 		// Adds the `tickets` endpoint for recurring events
 		$rewrite->single(
-			array( '(\d{4}-\d{2}-\d{2})', '{{ tickets }}' ),
-			array(
+			[ '(\d{4}-\d{2}-\d{2})', '{{ tickets }}' ],
+			[
 				Tribe__Events__Main::POSTTYPE => '%1',
 				'eventDate' => '%2',
 				'post_type' => Tribe__Events__Main::POSTTYPE,
 				'eventDisplay' => 'tickets',
-			)
+			]
 		);
 
 	}
 
 	/**
-	 * Intercepts the_content from the posts to include the orders structure
+	 * Intercepts the_content from the posts to include the orders structure.
 	 *
-	 * @param  string $content Normally the_content of a post
+	 * @param  string $content Normally the_content of a post.
 	 * @return string
 	 */
 	public function intercept_content( $content = '' ) {
@@ -393,11 +389,11 @@ class Tribe__Tickets__Tickets_View {
 
 	/**
 	 * Modify the front end ticket list display for it to always display
-	 * even when Hide From Event Listings is checked for an event
+	 * even when Hide From Event Listings is checked for an event.
 	 *
 	 * @since 4.7.3
 	 *
-	 * @param $query WP_Query Query object
+	 * @param $query WP_Query Query object.
 	 *
 	 */
 	public function modify_ticket_display_query( $query ) {
@@ -414,11 +410,11 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * We need to intercept the template loading and load the correct file
+	 * We need to intercept the template loading and load the correct file.
 	 *
-	 * @param  string $old_file Non important variable with the previous path
-	 * @param  string $template Which template we are dealing with
-	 * @return string           The correct File path for the tickets endpoint
+	 * @param  string $old_file Non important variable with the previous path.
+	 * @param  string $template Which template we are dealing with.
+	 * @return string           The correct File path for the tickets endpoint.
 	 */
 	public function intercept_template( $old_file, $template ) {
 		global $wp_query;
@@ -456,7 +452,8 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Injects the Link to The front-end Tickets page normally at `tribe_events_single_event_after_the_meta`
+	 * Injects the Link to The front-end Tickets page normally
+	 * at `tribe_events_single_event_after_the_meta`.
 	 *
 	 * @return void
 	 */
@@ -505,9 +502,9 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Injects the Link to The front-end Tickets page to non Events
+	 * Injects the Link to The front-end Tickets page to non Events.
 	 *
-	 * @param string $content  The content form the post
+	 * @param string $content  The content form the post.
 	 * @return string $content
 	 */
 	public function inject_link_template_the_content( $content ) {
@@ -561,13 +558,13 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Fetches from the Cached attendees list the ones that are relevant for this user and event
-	 * Important to note that this method will bring the attendees organized by order id
+	 * Fetches from the Cached attendees list the ones that are relevant for this user and event.
+	 * Important to note that this method will return the attendees organized by order id.
 	 *
-	 * @param  int       $event_id      The Event ID it relates to
-	 * @param  int|null  $user_id       An Optional User ID
-	 * @param  boolean   $include_rsvp  If this should include RSVP, which by default is false
-	 * @return array                    List of Attendees grouped by order id
+	 * @param  int       $event_id      The Event ID we're checking.
+	 * @param  int|null  $user_id       An Optional User ID.
+	 * @param  boolean   $include_rsvp  If this should include RSVP, default is false.
+	 * @return array                    List of Attendees grouped by order id.
 	 */
 	public function get_event_attendees_by_order( $event_id, $user_id = null, $include_rsvp = false ) {
 		if ( ! $user_id ) {
@@ -585,7 +582,7 @@ class Tribe__Tickets__Tickets_View {
 			$attendees = $attendee_data['attendees'];
 		}
 
-		$orders = array();
+		$orders = [];
 
 		foreach ( $attendees as $key => $attendee ) {
 			// Ignore RSVP if we don't tell it specifically
@@ -600,15 +597,15 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Fetches from the Cached attendees list the ones that are relevant for this user and event
-	 * Important to note that this method will bring the attendees from RSVP
+	 * Fetches from the Cached attendees list the ones that are relevant for this user and event.
+	 * Important to note that this method will return the attendees from RSVP.
 	 *
-	 * @param  int       $event_id     The Event ID it relates to
-	 * @param  int|null  $user_id      An Optional User ID
-	 * @return array                   Array with the RSVP attendees
+	 * @param  int       $event_id     The Event ID we're checking.
+	 * @param  int|null  $user_id      An Optional User ID.
+	 * @return array                   Array with the RSVP attendees.
 	 */
 	public function get_event_rsvp_attendees( $event_id, $user_id = null ) {
-		$attendees = array();
+		$attendees = [];
 
 		/** @var Tribe__Tickets__RSVP $rsvp */
 		$rsvp = tribe( 'tickets.rsvp' );
@@ -621,25 +618,25 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Groups RSVP attendees by purchaser name/email
+	 * Groups RSVP attendees by purchaser name/email.
 	 *
-	 * @param int $event_id The Event ID it relates to
-	 * @param int|null $user_id An optional user ID
-	 * @return array Array with the RSVP attendees grouped by purchaser name/email
+	 * @param int $event_id The Event ID we're checking.
+	 * @param int|null $user_id An optional user ID.
+	 * @return array Array with the RSVP attendees grouped by purchaser name/email.
 	 */
 	public function get_event_rsvp_attendees_by_purchaser( $event_id, $user_id = null ) {
 		$attendees = $this->get_event_rsvp_attendees( $event_id, $user_id );
 
 		if ( ! $attendees ) {
-			return array();
+			return [];
 		}
 
-		$attendee_groups = array();
+		$attendee_groups = [];
 		foreach ( $attendees as $attendee ) {
 			$key = $attendee['purchaser_name'] . '::' . $attendee['purchaser_email'];
 
 			if ( ! isset( $attendee_groups[ $key ] ) ) {
-				$attendee_groups[ $key ] = array();
+				$attendee_groups[ $key ] = [];
 			}
 
 			$attendee_groups[ $key ][] = $attendee;
@@ -649,9 +646,9 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Gets a List of Possible RSVP answers
+	 * Gets a List of Possible RSVP answers.
 	 *
-	 * @param string $selected    Allows users to check if an option exists or get it's label
+	 * @param string $selected    Allows users to check if an option exists or get it's label.
 	 * @param bool   $just_labels Whether just the options labels should be returned.
 	 *
 	 * @return array|bool An array containing the RSVP states, an array containing the selected
@@ -679,8 +676,8 @@ class Tribe__Tickets__Tickets_View {
 		 */
 		$options = apply_filters( 'event_tickets_rsvp_options', $options, $selected );
 
-		$options = array_filter( $options, array( $this, 'has_rsvp_format' ) );
-		array_walk( $options, array( $this, 'normalize_rsvp_option' ) );
+		$options = array_filter( $options, [ $this, 'has_rsvp_format' ] );
+		array_walk( $options, [ $this, 'normalize_rsvp_option' ] );
 
 		// If an option was passed return it's label, but if doesn't exist return false
 		if ( null !== $selected ) {
@@ -694,9 +691,9 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Check if the RSVP is a valid option
+	 * Check if the RSVP option is a valid one.
 	 *
-	 * @param  string  $option Which rsvp option to check
+	 * @param  string  $option Which rsvp option to check.
 	 * @return boolean
 	 */
 	public function is_valid_rsvp_option( $option ) {
@@ -706,7 +703,7 @@ class Tribe__Tickets__Tickets_View {
 	/**
 	 * Counts the amount of RSVP attendees.
 	 *
-	 * @param int      $event_id The Event ID it relates to.
+	 * @param int      $event_id The Event ID we're checking.
 	 * @param int|null $user_id  An Optional User ID.
 	 *
 	 * @return int
@@ -730,10 +727,10 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Counts the Amount of Tickets attendees
+	 * Counts the Amount of Tickets attendees.
 	 *
-	 * @param  int       $event_id     The Event ID it relates to
-	 * @param  int|null  $user_id      An Optional User ID
+	 * @param  int       $event_id     The Event ID we're checking.
+	 * @param  int|null  $user_id      An Optional User ID.
 	 * @return int
 	 */
 	public function count_ticket_attendees( $event_id, $user_id = null ) {
@@ -757,10 +754,10 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Verifies if we have RSVP attendees for this user and event
+	 * Verifies if we have RSVP attendees for this user and event.
 	 *
-	 * @param  int       $event_id     The Event ID it relates to
-	 * @param  int|null  $user_id      An Optional User ID
+	 * @param  int       $event_id     The Event ID we're checking.
+	 * @param  int|null  $user_id      An Optional User ID.
 	 * @return int
 	 */
 	public function has_rsvp_attendees( $event_id, $user_id = null ) {
@@ -771,8 +768,8 @@ class Tribe__Tickets__Tickets_View {
 	/**
 	 * Verifies if we have Tickets attendees for this user and event
 	 *
-	 * @param  int       $event_id     The Event ID it relates to
-	 * @param  int|null  $user_id      An Optional User ID
+	 * @param  int       $event_id     The Event ID we're checking.
+	 * @param  int|null  $user_id      An Optional User ID.
 	 * @return int
 	 */
 	public function has_ticket_attendees( $event_id, $user_id = null ) {
@@ -786,7 +783,7 @@ class Tribe__Tickets__Tickets_View {
 	 * @since 4.2
 	 * @since TBD Deprecated the 3rd parameter (whether or not to use 'plurals') in favor of figuring it out per type.
 	 *
-	 * @param int      $event_id   The Event ID it relates to.
+	 * @param int      $event_id   The Event ID we're checking.
 	 * @param int|null $user_id    An optional User ID.
 	 * @param null     $deprecated Deprecated argument.
 	 *
@@ -816,12 +813,12 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Creates the HTML for the Select Element for RSVP options
+	 * Creates the HTML for the Select Element for RSVP options.
 	 *
-	 * @param  string $name     The Name of the Field
-	 * @param  string $selected The Current selected option
-	 * @param  int  $event_id   The Event/Post ID (optional)
-	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional)
+	 * @param  string $name     The Name of the Field.
+	 * @param  string $selected The Current selected option.
+	 * @param  int  $event_id   The Event/Post ID (optional).
+	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional).
 	 * @return void
 	 */
 	public function render_rsvp_selector( $name, $selected, $event_id = null, $ticket_id = null ) {
@@ -837,11 +834,11 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Verifies if the Given Event has RSVP restricted
+	 * Verifies if the Given Event has RSVP restricted.
 	 *
-	 * @param  int  $event_id   The Event/Post ID (optional)
-	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional)
-	 * @param  int  $user_id    An User ID (optional)
+	 * @param  int  $event_id   The Event/Post ID (optional).
+	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional).
+	 * @param  int  $user_id    A User ID (optional).
 	 * @return boolean
 	 */
 	public function is_rsvp_restricted( $event_id = null, $ticket_id = null, $user_id = null ) {
@@ -864,8 +861,8 @@ class Tribe__Tickets__Tickets_View {
 	/**
 	 * Gets a HTML Attribute for input/select/textarea to be disabled
 	 *
-	 * @param  int  $event_id   The Event/Post ID (optional)
-	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional)
+	 * @param  int  $event_id   The Event/Post ID (optional).
+	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional).
 	 * @return boolean
 	 */
 	public function get_restriction_attr( $event_id = null, $ticket_id = null ) {
@@ -880,10 +877,10 @@ class Tribe__Tickets__Tickets_View {
 	/**
 	 * Creates the HTML for the status of the  RSVP choice.
 	 *
-	 * @param  string $name     The Name of the Field
-	 * @param  string $selected The Current selected option
-	 * @param  int  $event_id   The Event/Post ID (optional)
-	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional)
+	 * @param  string $name     The Name of the Field.
+	 * @param  string $selected The Current selected option.
+	 * @param  int  $event_id   The Event/Post ID (optional).
+	 * @param  int  $ticket_id  The Ticket/RSVP ID (optional).
 	 * @return void
 	 */
 	public function render_rsvp_status( $name, $selected, $event_id = null, $ticket_id = null ) {
@@ -924,9 +921,65 @@ class Tribe__Tickets__Tickets_View {
 	protected function normalize_rsvp_option( &$option ) {
 		$label_only_format = ! is_array( $option );
 		if ( $label_only_format ) {
-			$option = array( 'label' => $option, 'decrease_stock_by' => 1 );
+			$option = [ 'label' => $option, 'decrease_stock_by' => 1 ];
 		} else {
 			$option['decrease_stock_by'] = isset( $option['decrease_stock_by'] ) ? $option['decrease_stock_by'] : 1;
 		}
+	}
+
+	/**
+	 * Gets the block template "out of context" and makes it useable for non-gutenberg views.
+	 *
+	 * @param WP_Post|int $post the post/event we're viewing.
+	 *
+	 * @return string HTML.
+	 */
+	public function get_tickets_block( $post ) {
+		if ( empty( $post ) ) {
+			return;
+		}
+
+		if ( is_numeric( $post ) ) {
+			$post = get_post( $post );
+		}
+
+		if ( empty( $post ) || ! ( $post instanceof WP_Post ) ) {
+			return;
+		}
+
+		$post_id     = $post->ID;
+		$provider_id = Tribe__Tickets__Tickets::get_event_ticket_provider( $post_id );
+		$provider    = call_user_func( [ $provider_id, 'get_instance' ] );
+
+		/** @var \Tribe__Tickets__Editor__Template $template */
+		$template       = tribe( 'tickets.editor.template' );
+
+		/** @var \Tribe__Tickets__Editor__Blocks__Tickets $blocks_tickets */
+		$blocks_tickets = tribe( 'tickets.editor.blocks.tickets' );
+
+		$tickets = $provider->get_tickets( $post_id );
+
+
+		$args = [
+			'post_id'             => $post_id,
+			'provider'            => $provider,
+			'provider_id'         => $provider_id,
+			'tickets'             => $tickets,
+			'cart_url'            => $provider->get_cart_url( $post_id ),
+			'cart_classes'        => [ 'tribe-block', 'tribe-block__tickets' ],
+			'tickets_on_sale'     => $blocks_tickets->get_tickets_on_sale( $tickets ),
+			'has_tickets_on_sale' => tribe_events_has_tickets_on_sale( $post_id ),
+			'is_sale_past'        => $blocks_tickets->get_is_sale_past( $tickets ),
+		];
+
+
+		// Add the rendering attributes into global context.
+		$template->add_template_globals( $args );
+
+		// Enqueue assets.
+		tribe_asset_enqueue( 'tribe-tickets-gutenberg-tickets' );
+		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-tickets-style' );
+
+		return $template->template( 'blocks/tickets', $args );
 	}
 }

--- a/src/views/blocks/tickets.php
+++ b/src/views/blocks/tickets.php
@@ -17,15 +17,14 @@
  * @var Tribe__Tickets__Editor__Template $this
  */
 
-$post_id             = $this->get( 'post_id' );
-$tickets             = $this->get( 'tickets', array() );
-$provider            = $this->get( 'provider' );
-$provider_id         = $this->get( 'provider_id' );
+$cart_classes        = [ 'tribe-block', 'tribe-block__tickets' ];
 $cart_url            = $this->get( 'cart_url' );
-$tickets_on_sale     = $this->get( 'tickets_on_sale' );
 $has_tickets_on_sale = $this->get( 'has_tickets_on_sale' );
 $is_sale_past        = $this->get( 'is_sale_past' );
-$cart_classes        = array( 'tribe-block', 'tribe-block__tickets' );
+$provider            = $this->get( 'provider' );
+$provider_id         = $this->get( 'provider_id' );
+$tickets             = $this->get( 'tickets', [] );
+$tickets_on_sale     = $this->get( 'tickets_on_sale' );
 
 // We don't display anything if there is no provider or tickets
 if ( ! $provider || empty( $tickets ) ) {
@@ -35,8 +34,9 @@ if ( ! $provider || empty( $tickets ) ) {
 $html = $this->template( 'blocks/attendees/order-links', [], false );
 
 if ( empty( $html ) ) {
-	$html = $this->template( 'blocks/attendees/view-link', [], false );;
+	$html = $this->template( 'blocks/attendees/view-link', [], false );
 }
+
 
 echo $html;
 ?>
@@ -50,13 +50,13 @@ echo $html;
 	data-provider="<?php echo esc_attr( $provider->class_name ); ?>"
 	novalidate
 >
-	<?php $this->template( 'blocks/tickets/commerce/fields', array( 'provider' => $provider, 'provider_id' => $provider_id ) ); ?>
+	<?php $this->template( 'blocks/tickets/commerce/fields', [ 'provider' => $provider, 'provider_id' => $provider_id ] ); ?>
 	<?php if ( $has_tickets_on_sale ) : ?>
 		<?php foreach ( $tickets_on_sale as $key => $ticket ) : ?>
-			<?php $this->template( 'blocks/tickets/item', array( 'ticket' => $ticket, 'key' => $key ) ); ?>
+			<?php $this->template( 'blocks/tickets/item', [ 'ticket' => $ticket, 'key' => $key ] ); ?>
 		<?php endforeach; ?>
-		<?php $this->template( 'blocks/tickets/submit', array( 'provider' => $provider, 'provider_id' => $provider_id, 'ticket' => $ticket ) ); ?>
+		<?php $this->template( 'blocks/tickets/submit', [ 'provider' => $provider, 'provider_id' => $provider_id, 'ticket' => $ticket ] ); ?>
 	<?php else : ?>
-		<?php $this->template( 'blocks/tickets/item-inactive', array( 'is_sale_past' => $is_sale_past ) ); ?>
+		<?php $this->template( 'blocks/tickets/item-inactive', [ 'is_sale_past' => $is_sale_past ] ); ?>
 	<?php endif; ?>
 </form>

--- a/src/views/blocks/tickets/item.php
+++ b/src/views/blocks/tickets/item.php
@@ -14,18 +14,13 @@
  * @version 4.9.4
  *
  */
-
-$post_id  = $this->get( 'post_id' );
-$ticket   = $this->get( 'ticket' );
+$classes  = [ 'tribe-block__tickets__item' ];
 $provider = $this->get( 'provider' );
-$classes  = array(
-	'tribe-block__tickets__item',
-);
-
-$context = array(
+$ticket   = $this->get( 'ticket' );
+$context  = [
 	'ticket' => $ticket,
 	'key'    => $this->get( 'key' ),
-);
+];
 
 if (
 	empty( $provider )

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -17,7 +17,7 @@
 
 /* translators: %s is the event or post title the tickets are attached to. */
 $title       = sprintf( __( '%s Tickets', 'event-tickets-plus' ), esc_html__( get_the_title() ) );
-$button_text = esc_html__( 'Get Tickets!', 'event-tickets-plus');
+$button_text = __( 'Get Tickets!', 'event-tickets-plus');
 $content     = apply_filters( 'tribe_events_tickets_edd_attendee_registration_modal_content', '<p>EDD Tickets modal needs content, badly.</p>' );
 $content     = wp_kses_post( $content );
 $args = [

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -24,7 +24,7 @@ $args = [
 	'button_type'  => 'submit',
 	'button_name'  => 'edd-submit',
 	'button_text'  => $button_text,
-	'title'        => esc_html( $title ),
+	'title'        => $title,
 ];
 
 tribe( 'dialog.view' )->render_modal( $content, $args );

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Block: Tickets
+ * Submit Button - Modal
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/blocks/tickets/submit-button-modal.php
+ *
+ * See more documentation about our Blocks Editor templating system.
+ *
+ * @link {INSERT_ARTICLE_LINK_HERE}
+ *
+ * @since TBD
+ * @version TBD
+ *
+ */
+
+/* translators: %s is the event or post title the tickets are attached to. */
+$title       = sprintf( __( '%s Tickets', 'event-tickets-plus' ), esc_html__( get_the_title() ) );
+$button_text = esc_html__( 'Get Tickets!', 'event-tickets-plus');
+$content     = apply_filters( 'tribe_events_tickets_edd_attendee_registration_modal_content', '<p>EDD Tickets modal needs content, badly.</p>' );
+$content     = wp_kses_post( $content );
+$args = [
+	'button_type'  => 'submit',
+	'button_name'  => 'edd-submit',
+	'button_text'  => $button_text,
+	'title'        => esc_html( $title ),
+];
+
+tribe( 'dialog.view' )->render_modal( $content, $args );

--- a/src/views/blocks/tickets/submit.php
+++ b/src/views/blocks/tickets/submit.php
@@ -20,6 +20,8 @@ $must_login = ! is_user_logged_in() && $ticket->get_provider()->login_required()
 ?>
 <?php if ( $must_login ) : ?>
 	<?php $this->template( 'blocks/tickets/submit-login' ); ?>
+<?php elseif ( Tribe__Settings_Manager::get_option( 'ticket-attendee-modal' ) ) : ?>
+	<?php $this->template( 'blocks/tickets/submit-button-modal' ); ?>
 <?php else : ?>
 	<?php $this->template( 'blocks/tickets/submit-button' ); ?>
 <?php endif; ?>


### PR DESCRIPTION
Add functions to call block ticket template out of context so it is usable in non-Gutenberg views.

Does NOT implement for RSVP or TPP at this time.

Adds a check for `ticket-attendee-modal` and queues the modal via a new submit button template.

:ticket: https://central.tri.be/issues/132568