### PR TITLE
#132279 - disable ar redirects if modal is active

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2782,6 +2782,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				return;
 			}
 
+			// Return if Ticket Modal is Active
+			if ( Tribe__Settings_Manager::get_option( 'ticket-attendee-modal' ) ) {
+				return;
+			}
+
 			/**
 	 		 * Modify the tickets in cart, useful to
 	 		 * change the contents for each vendor


### PR DESCRIPTION
_Ref:_ [C#132279](https://central.tri.be/issues/132279)

I am not sure this is required, but I thought I would put it out here to review and for information at this point and not to merge.  

This method was redirecting me away from the EDD checkout when I had AR fields.

The AR it not complete so that is the reason now. My coding disables it if the modal is active. 

We might want to keep the coding as is and not merge this if it can detect if AR fields are complete for EDD tickets, but otherwise  not redirect.