### PR TITLE
Correct bad attendee #s getting passed.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Attendees Report's "Orders" tab displays amount sold and available regardless of amount, including for unlimited and zero remaining [134108]
 * Fix - Prevent fatal errors when hosting environment does not support multibyte functionality by using new `tribe_strpos()` function [135202]
+* Fix - Prevent issues with attendee ID not matching stored number [134408]
 
 = [4.10.9] 2019-10-01 =
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1900,8 +1900,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$attendee_optout       = $attendee_details['optout'];
 		$order_id              = $attendee_details['order_id'];
 
-		$order_attendee_id = 0;
-
 		// Get the event this tickets is for
 		$post_id = get_post_meta( $product_id, $this->event_key, true );
 
@@ -1989,10 +1987,9 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			 * @param int $product_id RSVP ticket post ID
 			 * @param int $order_attendee_id Attendee # for order
 			 */
-			do_action( 'event_tickets_rsvp_ticket_created', $attendee_id, $post_id, $product_id, $order_attendee_id );
+			do_action( 'event_tickets_rsvp_ticket_created', $attendee_id, $post_id, $product_id, $i );
 
 			$this->record_attendee_user_id( $attendee_id );
-			$order_attendee_id++;
 		}
 
 		/**


### PR DESCRIPTION
:ticket: https://central.tri.be/issues/134408

Somehow the attendee ID was getting out of sync - no reason for the extra var anyway.