### PR TITLE
Template tweak to correct missing message

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Attendees Report's "Orders" tab displays amount sold and available regardless of amount, including for unlimited and zero remaining [134108]
 * Fix - Prevent fatal errors when hosting environment does not support multibyte functionality by using new `tribe_strpos()` function [135202]
+* Fix - Remove check for tickets in beginnning of `/src/views/blocks/tickets.php` as it prevents showing the "tickets unavailable" message [134821]
 
 = [4.10.9] 2019-10-01 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Attendees Report's "Orders" tab displays amount sold and available regardless of amount, including for unlimited and zero remaining [134108]
 * Fix - Prevent fatal errors when hosting environment does not support multibyte functionality by using new `tribe_strpos()` function [135202]
-* Fix - Remove check for tickets in beginnning of `/src/views/blocks/tickets.php` as it prevents showing the "tickets unavailable" message [134821]
+* Fix - Remove check for tickets in beginning of `/src/views/blocks/tickets.php` as it prevents showing the "tickets unavailable" message [134821]
 
 = [4.10.9] 2019-10-01 =
 

--- a/src/views/blocks/tickets.php
+++ b/src/views/blocks/tickets.php
@@ -28,7 +28,7 @@ $is_sale_past        = $this->get( 'is_sale_past' );
 $cart_classes        = array( 'tribe-block', 'tribe-block__tickets' );
 
 // We don't display anything if there is no provider or tickets
-if ( ! $provider || empty( $tickets ) ) {
+if ( ! $provider ) {
 	return false;
 }
 

--- a/src/views/blocks/tickets.php
+++ b/src/views/blocks/tickets.php
@@ -11,8 +11,9 @@
  *
  * @since 4.9
  * @since 4.10.8 Updated loading logic for including a renamed template.
+ * @since TBD - Removed initial check for tickets.
  *
- * @version 4.10.8
+ * @version TBD
  *
  * @var Tribe__Tickets__Editor__Template $this
  */


### PR DESCRIPTION
By bailing for no tickets here, we never get to the `else` part of this template.

🎫 https://central.tri.be/issues/134821