### PR TITLE
fix(provider in template): Add check for incorrect provider `tribe_events_has_tickets_on_sale`

### DIFF
--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -410,7 +410,7 @@ if ( ! function_exists( 'tribe_events_has_tickets_on_sale' ) ) {
 			$ticket_provider = $ticket->get_provider();
 
 			// Skip tickets that are for a different provider than the event provider.
-			if( $default_provider !== $ticket_provider->class_name ) {
+			if ( $default_provider !== $ticket_provider->class_name ) {
 				continue;
 			}
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -403,8 +403,17 @@ if ( ! function_exists( 'tribe_events_has_tickets_on_sale' ) ) {
 	 */
 	function tribe_events_has_tickets_on_sale( $event_id ) {
 		$has_tickets_on_sale = false;
-		$tickets = Tribe__Tickets__Tickets::get_all_event_tickets( $event_id );
+		$tickets             = Tribe__Tickets__Tickets::get_all_event_tickets( $event_id );
+		$default_provider    = Tribe__Tickets__Tickets::get_event_ticket_provider( $event_id );
+
 		foreach ( $tickets as $ticket ) {
+			$ticket_provider = $ticket->get_provider();
+
+			// Skip tickets that are for a different provider than the event provider.
+			if( $default_provider !== $ticket_provider->class_name ) {
+				continue;
+			}
+
 			$has_tickets_on_sale = ( $has_tickets_on_sale || tribe_events_ticket_is_on_sale( $ticket ) );
 		}
 


### PR DESCRIPTION
Test the ticket's provider against the event's provider and skip tickets that don't match to avoid issues.

🎫 https://central.tri.be/issues/136194