### PR TITLE
Fix/136194 correct template logic

### DIFF
--- a/src/Tribe/Editor/Blocks/Tickets.php
+++ b/src/Tribe/Editor/Blocks/Tickets.php
@@ -62,6 +62,7 @@ extends Tribe__Editor__Blocks__Abstract {
 		$args['tickets_on_sale']     = $this->get_tickets_on_sale( $tickets );
 		$args['has_tickets_on_sale'] = ! empty( $args['tickets_on_sale'] );
 		$args['is_sale_past']        = $this->get_is_sale_past( $tickets );
+		$args['is_sale_future']      = $this->get_is_sale_future( $tickets );
 
 		// Add the rendering attributes into global context
 		$template->add_template_globals( $args );
@@ -262,6 +263,25 @@ extends Tribe__Editor__Blocks__Abstract {
 		}
 
 		return $is_sale_past;
+	}
+
+	/**
+	 * Get whether no ticket sales have started yet
+	 *
+	 * @since TBD
+	 *
+	 * @param  array $tickets Array of all tickets
+	 *
+	 * @return bool
+	 */
+	public function get_is_sale_future( $tickets ) {
+		$is_sale_future = ! empty( $tickets );
+
+		foreach ( $tickets as $ticket ) {
+			$is_sale_future = ( $is_sale_future && $ticket->date_is_earlier() );
+		}
+
+		return $is_sale_future;
 	}
 
 	/**

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -409,11 +409,11 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		}
 
 		/**
-		 * Determines if the given date is smaller than the ticket's start date
+		 * Determines if the given date is before the ticket's start date
 		 *
-		 * @param null|string $datetime The date/time that we want to determine if it is smaller than the ticket's start date
+		 * @param null|string $datetime The date/time that we want to compare to the ticket's start date
 		 *
-		 * @return boolean Whether or not the provided date/time is smaller than the ticket's start date
+		 * @return boolean Whether or not the provided date/time is before than the ticket's start date
 		 */
 		public function date_is_earlier( $datetime = null ) {
 			$date = $this->get_date( $datetime, false );
@@ -428,11 +428,11 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		}
 
 		/**
-		 * Determines if the given date is greater than the ticket's end date
+		 * Determines if the given date is after the ticket's end date
 		 *
-		 * @param null|string $datetime The date/time that we want to determine if it is smaller than the ticket's start date
+		 * @param null|string $datetime The date/time that we want to compare to the ticket's start date
 		 *
-		 * @return boolean Whether or not the provided date/time is greater than the ticket's end date
+		 * @return boolean Whether or not the provided date/time is after than the ticket's end date
 		 */
 		public function date_is_later( $datetime = null ) {
 			$date = $this->get_date( $datetime, false );

--- a/src/resources/postcss/tickets.pcss
+++ b/src/resources/postcss/tickets.pcss
@@ -66,6 +66,10 @@
 		}
 	}
 
+	.tribe-tickets__item--inactive + .tribe-tickets__item--inactive {
+		display: none;
+	}
+
 	.tribe-tickets__item__content__title {
 		align-self: end;
 		-ms-grid-column: 1;

--- a/src/views/blocks/tickets.php
+++ b/src/views/blocks/tickets.php
@@ -22,14 +22,18 @@
 $currency            = tribe( 'tickets.commerce.currency' );
 $cart_classes        = [ 'tribe-block', 'tribe-tickets', 'tribe-common' ];
 $has_tickets_on_sale = $this->get( 'has_tickets_on_sale' );
+$is_sale_future      = $this->get( 'is_sale_future' );
 $is_sale_past        = $this->get( 'is_sale_past' );
+$post_id             = $this->get( 'post_id' );
 $provider            = $this->get( 'provider' );
 $provider_id         = $this->get( 'provider_id' );
 $tickets             = $this->get( 'tickets', [] );
 $tickets_on_sale     = $this->get( 'tickets_on_sale' );
 
-// We don't display anything if there is no provider or tickets
-if ( ! $provider ) {
+$event_tickets       = $provider->get_tickets( $post_id );
+
+// We don't display anything if there is no provider or tickets.
+if ( ! $is_sale_future && ( ! $provider || ! $event_tickets ) ) {
 	return false;
 }
 
@@ -57,7 +61,6 @@ if ( ! $already_rendered ) {
 	add_filter( 'tribe_tickets_order_link_template_already_rendered', '__return_true' );
 }
 ?>
-
 <form
 	id="tribe-tickets"
 	action=""

--- a/src/views/blocks/tickets/item.php
+++ b/src/views/blocks/tickets/item.php
@@ -53,16 +53,22 @@ if ( $must_login ) {
 	data-shared-cap="<?php echo ( tribe( 'tickets.handler' )->has_shared_capacity( $ticket ) ) ? 'true' : 'false'; ?>"
 >
 	<input type="hidden" name="product_id[]" value="<?php echo esc_attr( $ticket->ID ); ?>" />
-	<?php if ( true === $modal ) { $this->template( 'modal/item-remove', $context ); } ?>
+	<?php if ( true === $modal ) : ?>
+		<?php $this->template( 'modal/item-remove', $context ); ?>
+	<?php endif ?>
+
 	<?php $this->template( 'blocks/tickets/content', $context ); ?>
+
 	<?php if ( true !== $mini ) : ?>
 		<?php $this->template( 'blocks/tickets/quantity', $context ); ?>
 	<?php else: ?>
-	<div class="tribe-ticket-quantity">0</div>
+		<div class="tribe-ticket-quantity">0</div>
 	<?php endif; ?>
+
 	<?php if ( true === $modal || true === $mini ) : ?>
 		<?php $this->template( 'modal/item-total', $context ); ?>
 	<?php endif; ?>
+
 	<?php if ( ! $modal && ! $mini ) : ?>
 		<?php $this->template( 'blocks/rsvp/form/opt-out', $context ); ?>
 	<?php elseif( true === $modal ): ?>


### PR DESCRIPTION
Add `is_sale_future` param and function for more precise logic.
Clean up some template conditionals, tweak the logic around showing the tickets block - specifically around past/future sales.
Hide duplicated ticket blocks.