### PR TITLE
update repo names to be lowercase | spotfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "wp-coding-standards/wpcs": "^2.1",
     "automattic/vipwpcs": "^2.0",
-    "moderntribe/TribalScents": "dev-master",
+    "moderntribe/tribalscents": "dev-master",
     "lucatume/wp-browser": "2.2.15",
     "codeception/codeception": "^2.5.6",
     "phpunit/phpunit": "^6.5.14",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "845fc6a2ce4cf780ff2d0787de11b0a8",
+    "content-hash": "2966cf8861d189b31afa3f11b0f997cb",
     "packages": [],
     "packages-dev": [
         {
@@ -1235,27 +1235,28 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.3.3",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+                "reference": "0895c932405407fd3a7368b6910c09a24d26db11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
-                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/0895c932405407fd3a7368b6910c09a24d26db11",
+                "reference": "0895c932405407fd3a7368b6910c09a24d26db11",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4",
+                "guzzlehttp/psr7": "^1.6.1",
                 "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.0"
+                "psr/log": "^1.1"
             },
             "suggest": {
                 "psr/log": "Required for using the Log middleware"
@@ -1267,12 +1268,12 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1296,7 +1297,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2018-04-22T15:46:56+00:00"
+            "time": "2019-10-23T15:58:00+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2096,12 +2097,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/tribe-testing-facilities",
-                "reference": "29ac08f5a9a787a67a457ab97c35f4164f88783c"
+                "reference": "01032a032c51273096219d756e68a8ca2f863f16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/29ac08f5a9a787a67a457ab97c35f4164f88783c",
-                "reference": "29ac08f5a9a787a67a457ab97c35f4164f88783c",
+                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/01032a032c51273096219d756e68a8ca2f863f16",
+                "reference": "01032a032c51273096219d756e68a8ca2f863f16",
                 "shasum": ""
             },
             "require": {
@@ -2163,7 +2164,7 @@
                 }
             ],
             "description": "Testing facilities, helpers and examples.",
-            "time": "2019-10-03T10:04:39+00:00"
+            "time": "2019-10-23T15:00:43+00:00"
         },
         {
             "name": "mustache/mustache",


### PR DESCRIPTION
> Deprecation warning: require-dev.moderntribe/TribalScents is invalid, it should not contain uppercase characters. Please use moderntribe/tribalscents instead. Make sure you fix this as Composer 2.0 will error.