### PR TITLE
Adds a "clean" function to strip separators 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2097,12 +2097,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/moderntribe/tribe-testing-facilities",
-                "reference": "01032a032c51273096219d756e68a8ca2f863f16"
+                "reference": "9fc3e76b464591f203edacf8e2fc19e840acd430"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/01032a032c51273096219d756e68a8ca2f863f16",
-                "reference": "01032a032c51273096219d756e68a8ca2f863f16",
+                "url": "https://api.github.com/repos/moderntribe/tribe-testing-facilities/zipball/9fc3e76b464591f203edacf8e2fc19e840acd430",
+                "reference": "9fc3e76b464591f203edacf8e2fc19e840acd430",
                 "shasum": ""
             },
             "require": {
@@ -2164,7 +2164,7 @@
                 }
             ],
             "description": "Testing facilities, helpers and examples.",
-            "time": "2019-10-23T15:00:43+00:00"
+            "time": "2019-10-24T08:47:57+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -4016,16 +4016,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.7.1",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38"
+                "reference": "e2e5d290e4d2a4f0eb449f510071392e00e10d19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/d15f59a67ff805a44c50ea0516d2341740f81a38",
-                "reference": "d15f59a67ff805a44c50ea0516d2341740f81a38",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/e2e5d290e4d2a4f0eb449f510071392e00e10d19",
+                "reference": "e2e5d290e4d2a4f0eb449f510071392e00e10d19",
                 "shasum": ""
             },
             "require": {
@@ -4061,7 +4061,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2018-01-24T12:46:19+00:00"
+            "time": "2019-10-24T14:27:39+00:00"
         },
         {
             "name": "seld/phar-utils",

--- a/src/resources/js/tickets-block.js
+++ b/src/resources/js/tickets-block.js
@@ -277,7 +277,7 @@ tribe.tickets.block  = {
 
 			$modalCartItem.find( obj.selector.itemQuantityInput ).val( item.qty ).trigger( 'change' );
 
-			( item.qty <= 0 ) ? $modalCartItem.fadeOut() : $modalCartItem.fadeIn();
+			//( item.qty <= 0 ) ? $modalCartItem.fadeOut() : $modalCartItem.fadeIn();
 
 			// We force new DOM queries here to be sure we pick up dynamically generated items.
 			var optoutSelector = obj.selector.itemOptOutInput + $blockCartItem.data( 'ticket-id' );
@@ -322,7 +322,11 @@ tribe.tickets.block  = {
 	obj.maybeShowNonMetaNotice = function( $form ) {
 		var nonMetaCount = 0;
 		var metaCount    = 0;
-		var $cartItems   =  $form.find( obj.selector.item ).filter( ':visible' );
+		var $cartItems   =  $form.find( obj.selector.item ).filter(
+			function( index ) {
+				return $( this ).find( obj.selector.itemQuantityInput ).val() > 0;
+			}
+		);
 
 		if ( ! $cartItems.length ) {
 			return;
@@ -346,7 +350,9 @@ tribe.tickets.block  = {
 		var $notice = $( '.tribe-tickets__notice--non-ar' );
 		var $title  = $( '.tribe-tickets__item__attendee__fields__title' );
 
-		if ( 0 < nonMetaCount && 0 !== metaCount ) {
+		// If there are no non-meta tickets, we don't need the notice
+		// Likewise, if there are no tickets with meta the notice seems redundant.
+		if ( 0 < nonMetaCount && 0 < metaCount ) {
 			$( '#tribe-tickets__non-ar-count' ).text( nonMetaCount );
 			$notice.removeClass( 'tribe-common-a11y-hidden' );
 			$title.show();
@@ -934,7 +940,7 @@ tribe.tickets.block  = {
 			if ( $item ) {
 				var quantity  = $block_item.find( '.tribe-tickets-quantity' ).val();
 				if ( 0 < quantity ) {
-					$item.find( '.tribe-ticket-quantity' ).val( quantity );
+
 					$item.fadeIn();
 				}
 			}
@@ -1115,10 +1121,6 @@ tribe.tickets.block  = {
 		var tickets   = [];
 		var $cartForm = $( obj.modalSelector.cartForm );
 
-		if ( ! $cartForm.length ) {
-			$cartForm = $( obj.selector.container );
-		}
-
 		// Handle non-modal instances
 		if ( ! $cartForm.length ) {
 			$cartForm = $( obj.selector.container );
@@ -1138,14 +1140,12 @@ tribe.tickets.block  = {
 					optout = $optoutInput.prop( 'checked' ) ? 1 : 0;
 				}
 
-				if ( 0 < qty ) {
-					var data          = {};
-					data['ticket_id'] = ticket_id;
-					data['quantity']  = qty;
-					data['optout']    = optout;
+				var data          = {};
+				data['ticket_id'] = ticket_id;
+				data['quantity']  = qty;
+				data['optout']    = optout;
 
-					tickets.push( data );
-				}
+				tickets.push( data );
 			}
 		);
 
@@ -1510,6 +1510,7 @@ tribe.tickets.block  = {
 
 			ticket.id    = $cartItem.data( 'ticketId' );
 			ticket.qty   = 0;
+			$cartItem.find( obj.selector.itemQuantityInput ).val( ticket.qty );
 			ticket.price = obj.getPrice( $cartItem );
 
 			obj.updateTotal( ticket.qty, ticket.price, $cartItem );
@@ -1519,7 +1520,7 @@ tribe.tickets.block  = {
 				.removeClass( 'tribe-tickets--has-tickets' )
 				.find( obj.modalSelector.metaItem ).remove();
 
-				// Short delay to ensure the fadeOut has finished.
+			// Short delay to ensure the fadeOut has finished.
 			var timeoutID = window.setTimeout( obj.maybeShowNonMetaNotice, 500, $cart );
 
 			// Close then modal if we remove the last item

--- a/src/resources/js/tickets-block.js
+++ b/src/resources/js/tickets-block.js
@@ -206,7 +206,9 @@ tribe.tickets.block  = {
 			var $price   = $( this ).closest( obj.selector.item ).find( obj.selector.itemPrice ).first();
 			var quantity = parseInt( $( this ).val(), 10 );
 			quantity     = isNaN( quantity ) ? 0 : quantity;
-			var price    = parseFloat( $price.text() );
+			var text     = $price.text();
+			text         = obj.cleanNumber( text );
+			var price    = obj.numberFormat ( text );
 			price        = price * quantity;
 			footerAmount += price;
 		} );
@@ -675,6 +677,23 @@ tribe.tickets.block  = {
 	};
 
 	/**
+	 * Removes separator characters and converts deciaml character to '.'
+	 * So they play nice with other functions.
+	 *
+	 * @since TBD
+	 *
+	 * @param number The number to clean.
+	 * @returns {string}
+	 */
+	obj.cleanNumber = function( number ) {
+		var format = obj.getCurrencyFormatting();
+		number     = number.split(format.thousands_sep).join('');
+		number     = number.split(format.decimal_point).join('.');
+
+		return number;
+	}
+
+	/**
 	 * Format the number according to provider settings.
 	 * Based off coding fron https://stackoverflow.com/a/2901136.
 	 *
@@ -686,7 +705,6 @@ tribe.tickets.block  = {
 	 */
 	obj.numberFormat = function ( number ) {
 		var format = obj.getCurrencyFormatting();
-
 		if ( ! format ) {
 			return false;
 		}
@@ -715,7 +733,6 @@ tribe.tickets.block  = {
 			s[1] = s[1] || '';
 			s[1] += new Array( prec - s[1].length + 1 ).join( '0' );
 		}
-
 		return s.join( dec );
 	}
 

--- a/src/resources/js/tickets-block.js
+++ b/src/resources/js/tickets-block.js
@@ -705,6 +705,7 @@ tribe.tickets.block  = {
 	 */
 	obj.numberFormat = function ( number ) {
 		var format = obj.getCurrencyFormatting();
+
 		if ( ! format ) {
 			return false;
 		}
@@ -733,6 +734,7 @@ tribe.tickets.block  = {
 			s[1] = s[1] || '';
 			s[1] += new Array( prec - s[1].length + 1 ).join( '0' );
 		}
+
 		return s.join( dec );
 	}
 


### PR DESCRIPTION
and convert decimals so we can pass numbers to `parseFloat` and the like.

🎫 https://central.tri.be/issues/136300

Don't hide items when qty drops to zero.
Pass all tickets, even those with qty 0.
🎫 https://central.tri.be/issues/136295 && https://central.tri.be/issues/136250
