### PR TITLE
Add stripslashes so data is parsed correctly.

### DIFF
--- a/src/Tribe/Commerce/Cart.php
+++ b/src/Tribe/Commerce/Cart.php
@@ -31,6 +31,7 @@ class Tribe__Tickets__Commerce__Cart {
 
 			// Attempt to JSON decode data if needed.
 			if ( ! is_array( $data ) ) {
+				$data = stripslashes( $data );
 				$data = json_decode( $data, true );
 			}
 		}

--- a/src/Tribe/Commerce/Cart.php
+++ b/src/Tribe/Commerce/Cart.php
@@ -41,16 +41,6 @@ class Tribe__Tickets__Commerce__Cart {
 		$tickets  = isset( $data['tribe_tickets_tickets'] ) ? $data['tribe_tickets_tickets'] : null;
 		$meta     = isset( $data['tribe_tickets_meta'] ) ? $data['tribe_tickets_meta'] : null;
 
-		// Attempt to JSON decode tickets if needed.
-		if ( null !== $tickets && ! is_array( $tickets ) ) {
-			$tickets = json_decode( $tickets, true );
-		}
-
-		// Attempt to JSON decode meta if needed.
-		if ( null !== $meta && ! is_array( $meta ) ) {
-			$meta = json_decode( $meta, true );
-		}
-
 		$response = $this->update( [
 			'post_id'  => $post_id,
 			'provider' => $provider,


### PR DESCRIPTION
The `json_stringify`-d value gets escaped along the way - we need to `stripslashes` or `json_decode` fails.