### PR TITLE
Fix ticketed event saves.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
-= [TBD] TBD =
+= [4.10.11.1] 2019-11-15 =
 
 * Fix - Force null values to 0 for `_tribe_ticket_capacity` so RSVPs save correctly in 5.3 block editor. [137383]
 * Fix - Bypass REST update/delete of virtual meta key `_tribe_tickets_list` so events will save in WP 5.3. [137383]

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,11 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Force null values to 0 for `_tribe_ticket_capacity` so RSVPs save correctly in 5.3 block editor. [137383]
+* Fix - Bypass REST update/delete of virtual meta key `_tribe_tickets_list` so events will save in WP 5.3. [137383]
+
 = [4.10.11] 2019-11-13 =
 
 * Fix - Add a check for empty tickets to `Tribe__Tickets__Editor__Blocks__Tickets::ticket_availability()` method to avoid PHP error notices showing [122334]

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -191,6 +191,8 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 	/**
 	 * Don't delete virtual meta.
 	 *
+	 * @since TBD
+	 *
 	 * @param null|bool $delete            Whether to allow metadata deletion of the given type.
 	 * @param int       $unused_object_id  Object ID.
 	 * @param string    $meta_key          Meta key.

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -184,6 +184,49 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 			}
 			$list_of_tickets[] = $ticket->ID;
 		}
+
 		return $list_of_tickets;
+	}
+
+	/**
+	 * Don't delete virtual meta.
+	 *
+	 * @param null|bool $delete            Whether to allow metadata deletion of the given type.
+	 * @param int       $unused_object_id  Object ID.
+	 * @param string    $meta_key          Meta key.
+	 * @param mixed     $unused_meta_value Meta value. Must be serializable if non-scalar.
+	 * @param bool      $unused_delete_all Whether to delete the matching metadata entries
+	 *                              for all objects, ignoring the specified $object_id.
+	 *                              Default false.
+	 *
+	 * @return bool
+	 */
+	public function delete_tickets_list_in_rest( $delete, $unused_object_id, $meta_key, $unused_meta_value, $unused_delete_all ) {
+		if ( '_tribe_tickets_list' === $meta_key ) {
+			return true;
+		}
+
+		return $delete;
+	}
+
+	/**
+	 * Don't update virtual meta.
+	 *
+	 * @param null|bool $check      Whether to allow updating metadata for the given type.
+	 * @param int       $object_id  Object ID.
+	 * @param string    $meta_key   Meta key.
+	 * @param mixed     $meta_value Meta value. Must be serializable if non-scalar.
+	 * @param mixed     $prev_value Optional. If specified, only update existing
+	 *                              metadata entries with the specified value.
+	 *                              Otherwise, update all entries.
+	 *
+	 * @return bool
+	 */
+	public function update_tickets_list_in_rest( $check, $unused_object_id, $meta_key, $unused_meta_value, $unused_prev_value ) {
+		if ( '_tribe_tickets_list' === $meta_key ) {
+			return true;
+		}
+
+		return $check;
 	}
 }

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -214,6 +214,8 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 	/**
 	 * Don't update virtual meta.
 	 *
+	 * @since TBD
+	 *
 	 * @param null|bool $check      Whether to allow updating metadata for the given type.
 	 * @param int       $object_id  Object ID.
 	 * @param string    $meta_key   Meta key.

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -80,6 +80,20 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 			4
 		);
 
+		add_filter(
+			'delete_post_metadata',
+			tribe_callback( 'tickets.editor.meta', 'delete_tickets_list_in_rest' ),
+			15,
+			5
+		);
+
+		add_filter(
+			'update_post_metadata',
+			tribe_callback( 'tickets.editor.meta', 'update_tickets_list_in_rest' ),
+			15,
+			5
+		);
+
 		// Setup the Rest compatibility layer for WP
 		tribe( 'tickets.editor.rest.compatibility' );
 

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -80,6 +80,7 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 			4
 		);
 
+		// Don't delete virtual meta.
 		add_filter(
 			'delete_post_metadata',
 			tribe_callback( 'tickets.editor.meta', 'delete_tickets_list_in_rest' ),
@@ -87,6 +88,7 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 			5
 		);
 
+		// Don't update virtual meta.
 		add_filter(
 			'update_post_metadata',
 			tribe_callback( 'tickets.editor.meta', 'update_tickets_list_in_rest' ),

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -488,9 +488,9 @@ class Tribe__Tickets__Tickets_Handler {
 			return false;
 		}
 
-		// We don't accept any non-numeric values here
-		if ( ! is_numeric( $event_capacity ) ) {
-			return false;
+		// We don't accept any non-numeric values here, so set to 0.
+		if ( ! is_numeric( $event_capacity ) && ! is_null( $event_capacity ) ) {
+			$event_capacity = 0;
 		}
 
 		// Make sure we are updating the Shared Stock when we update it's capacity


### PR DESCRIPTION
WP 5.3 fixes:
Force null values to 0 for `_tribe_ticket_capacity` so RSVPs save correctly.
Tell REST to not update/delete `_tribe_tickets_list` so events save correctly.

🎫 https://central.tri.be/issues/137383