### PR TITLE
Implement _or_null methods and don't update/delete fake meta fields

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Force null values to 0 for `_tribe_ticket_capacity` so RSVPs save correctly in 5.3 block editor. [137383]
 * Fix - Bypass REST update/delete of virtual meta key `_tribe_tickets_list` so events will save in WP 5.3. [137383]
+* Fix - Allow `null` to be sent for REST API updates in WP 5.3 for certain meta fields that we intentionally send null for but don't match the registered schema type. [137383]
 
 = [4.10.11] 2019-11-13 =
 

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -46,7 +46,7 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta(
 			'post',
 			$handler->key_capacity,
-			$this->text()
+			$this->text_or_null()
 		);
 
 		register_meta(
@@ -73,7 +73,7 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta(
 			'post',
 			'_tribe_ticket_show_not_going',
-			$this->boolean()
+			$this->boolean_or_null()
 		);
 
 		// Global Stock
@@ -132,8 +132,52 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta(
 			'post',
 			'_tribe_ticket_has_attendee_info_fields',
-			$this->boolean()
+			$this->boolean_or_null()
 		);
+	}
+
+	/**
+	 * Default definition for an attribute of type text
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function text_or_null() {
+		$args = $this->text();
+
+		if ( ! function_exists( 'is_wp_version_compatible' ) || ! is_wp_version_compatible( '5.3' ) ) {
+			return $args;
+		}
+
+		$args['type'] = [
+			$args['type'],
+			'null',
+		];
+
+		return $args;
+	}
+
+	/**
+	 * Default definition for an attribute of boolean text
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function boolean_or_null() {
+		$args = $this->boolean();
+
+		if ( ! function_exists( 'is_wp_version_compatible' ) || ! is_wp_version_compatible( '5.3' ) ) {
+			return $args;
+		}
+
+		$args['type'] = [
+			$args['type'],
+			'null',
+		];
+
+		return $args;
 	}
 
 	/**
@@ -204,7 +248,7 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 	 * @return bool
 	 */
 	public function delete_tickets_list_in_rest( $delete, $unused_object_id, $meta_key, $unused_meta_value, $unused_delete_all ) {
-		if ( '_tribe_tickets_list' === $meta_key ) {
+		if ( in_array( $meta_key, $this->get_ghost_meta_fields(), true ) ) {
 			return true;
 		}
 
@@ -227,10 +271,26 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 	 * @return bool
 	 */
 	public function update_tickets_list_in_rest( $check, $unused_object_id, $meta_key, $unused_meta_value, $unused_prev_value ) {
-		if ( '_tribe_tickets_list' === $meta_key ) {
+		if ( in_array( $meta_key, $this->get_ghost_meta_fields(), true ) ) {
 			return true;
 		}
 
 		return $check;
+	}
+
+	/**
+	 * Get ghost meta fields that we don't actually store/update/delete.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_ghost_meta_fields() {
+		return [
+			'_tribe_tickets_list',
+			'_tribe_ticket_going_count',
+			'_tribe_ticket_not_going_count',
+			'_tribe_ticket_has_attendee_info_fields',
+		];
 	}
 }

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -488,9 +488,9 @@ class Tribe__Tickets__Tickets_Handler {
 			return false;
 		}
 
-		// We don't accept any non-numeric values here, so set to 0.
-		if ( ! is_numeric( $event_capacity ) && ! is_null( $event_capacity ) ) {
-			$event_capacity = 0;
+		// We don't accept any non-numeric values here.
+		if ( ! is_numeric( $event_capacity ) ) {
+			return false;
 		}
 
 		// Make sure we are updating the Shared Stock when we update it's capacity


### PR DESCRIPTION
https://central.tri.be/issues/137383

* Implements _or_null methods for capacity and a few other fields
* Also avoids updating/deleting certain meta fields we don't store/update/delete meta for