### PR TITLE
Fix additive handling of meta saves from AR page

### DIFF
--- a/src/Tribe/Commerce/Cart.php
+++ b/src/Tribe/Commerce/Cart.php
@@ -42,7 +42,7 @@ class Tribe__Tickets__Commerce__Cart {
 		$meta     = isset( $data['tribe_tickets_meta'] ) ? $data['tribe_tickets_meta'] : null;
 
 		// On AR Page, we use replace logic, not additive.
-		$is_ar_modal = empty( $data['tribe_tickets_ar_page'] );
+		$is_ar_modal = empty( $_POST['tribe_tickets_ar_page'] );
 
 		// We only update tickets from the modal, not the AR page right now.
 		if ( ! $is_ar_modal ) {


### PR DESCRIPTION
https://central.tri.be/issues/137719

Screencast showing you no longer get sent back to AR page (if you go to AR page from EDD checkout): https://p199.p4.n0.cdn.getcloudapp.com/items/7KuxO9lx/Screen+Recording+2019-11-22+at+12.09+PM.mov