### PR TITLE
fix(ticket end date): Correct the automatic generation of ticket end dates.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
-= [TBD] TBD =
+= [4.11.1] TBD =
 
 * Fix - Ensure that tickets without an end date set in the Classic editor get set to end at the start of an event per the tooltip [125969]
 

--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,6 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Ensure that tickets without an end date set in the Classic editor get set to end at the start of an event per the tooltip [125969]
 
-
 = [4.11] 2019-11-21 =
 
 * Feature - Add ability to utilize the block ticket template outside of Gutenberg views [132568]

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,11 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure that tickets without an end date set in the Classic editor get set to end at the start of an event per the tooltip [125969]
+
+
 = [4.11] 2019-11-21 =
 
 * Feature - Add ability to utilize the block ticket template outside of Gutenberg views [132568]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2765,6 +2765,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$tickets_handler->toggle_manual_update_flag( false );
 
 			$post = get_post( $post_id );
+			// If ticket start date is not set, set it to the post date.
 			if ( empty( $data['ticket_start_date'] ) ) {
 				$date = strtotime( $post->post_date );
 				$date = date( 'Y-m-d 00:00:00', $date );
@@ -2772,9 +2773,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				update_post_meta( $ticket->ID, $tickets_handler->key_start_date, $date );
 			}
 
+			// If the ticket end date has not been set and we have an event,
+			// set the ticket end date to the event start date.
 			if ( empty( $data['ticket_end_date'] ) && 'tribe_events' === $post->post_type ) {
-				$event_end = get_post_meta( $post_id, '_EventEndDate', true );
-				update_post_meta( $ticket->ID, $tickets_handler->key_end_date, $event_end );
+				$event_start = get_post_meta( $post_id, '_EventStartDate', true );
+				update_post_meta( $ticket->ID, $tickets_handler->key_end_date, $event_start );
 			}
 
 			tribe( 'tickets.version' )->update( $ticket->ID );

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2773,8 +2773,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				update_post_meta( $ticket->ID, $tickets_handler->key_start_date, $date );
 			}
 
-			// If the ticket end date has not been set and we have an event,
-			// set the ticket end date to the event start date.
+			/*
+			 * If the ticket end date has not been set and we have an event,
+			 * set the ticket end date to the event start date.
+			 */
 			if ( empty( $data['ticket_end_date'] ) && 'tribe_events' === $post->post_type ) {
 				$event_start = get_post_meta( $post_id, '_EventStartDate', true );
 				update_post_meta( $ticket->ID, $tickets_handler->key_end_date, $event_start );

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2765,6 +2765,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$tickets_handler->toggle_manual_update_flag( false );
 
 			$post = get_post( $post_id );
+
 			// If ticket start date is not set, set it to the post date.
 			if ( empty( $data['ticket_start_date'] ) ) {
 				$date = strtotime( $post->post_date );

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -179,7 +179,7 @@ class Tribe__Tickets__Tickets_Handler {
 	}
 
 	/**
-	 * On update of the Event End date we update the ticket end date
+	 * On update of the event start date we update the ticket end date
 	 * if it wasn't manually updated
 	 *
 	 * @since  4.6
@@ -193,7 +193,7 @@ class Tribe__Tickets__Tickets_Handler {
 	 */
 	public function update_meta_date( $meta_id, $object_id, $meta_key, $date ) {
 		$meta_map = array(
-			'_EventEndDate' => $this->key_end_date,
+			'_EventStartDate' => $this->key_end_date,
 		);
 
 		// Bail when it's not on the Map Meta


### PR DESCRIPTION
Ensure that the ticket end date (classic editor) is set to the event start date, not the event end
date.

🎫  https://central.tri.be/issues/135218
🎫 https://central.tri.be/issues/125969

📹 http://p.tri.be/8ekMnh