### PR TITLE
 fix(tickets block): Prevent duplicate blocks on provider change.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Feature - Use the same loading icon for the RSVP block that we're using for the tickets block. [135660]
 * Fix - Fix the header image attachment handling for RSVP blocks [137243]
 * Fix - Ensure that tickets without an end date set in the Classic editor get set to end at the start of an event per the tooltip [125969]
+* Fix - Prevent duplicate blocks on provider change. Add logic to test current provider against event default provider. [137925]
 
 = [4.11] 2019-11-21 =
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1484,7 +1484,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		if ( empty( $tickets ) ) {
 			return;
 		}
-		bdump('tpp');
+
 		Tribe__Tickets__Tickets_View::instance()->get_tickets_block( $post->ID );
 	}
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1484,7 +1484,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		if ( empty( $tickets ) ) {
 			return;
 		}
-
+		bdump('tpp');
 		Tribe__Tickets__Tickets_View::instance()->get_tickets_block( $post->ID );
 	}
 
@@ -2607,13 +2607,20 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	 * @since 4.7
 	 */
 	public function get_tickets( $post_id ) {
+		$default_provider = Tribe__Tickets__Tickets::get_event_ticket_provider( $post_id );
+
+		// If the event provider is set to something else, let's save some time, shall we?
+		if ( ! is_admin() && __CLASS__ !== $default_provider ) {
+			return [];
+		}
+
 		$ticket_ids = $this->get_tickets_ids( $post_id );
 
 		if ( ! $ticket_ids ) {
-			return array();
+			return [];
 		}
 
-		$tickets = array();
+		$tickets = [];
 
 		foreach ( $ticket_ids as $post ) {
 			$ticket = $this->get_ticket( $post_id, $post );


### PR DESCRIPTION
Add logic to test provider against event default provider. Prevent iterating through those tickets
that are not from the event provider on the front end.

🎫 https://central.tri.be/issues/137925

Related: https://github.com/moderntribe/event-tickets-plus/pull/914
