### PR TITLE
Fix/test gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Makefile
 codeception.yml
 tests/*.suite.yml
 phpunit.xml
+.env.testing
 .env.testing.local
 
 # Tests - local output files


### PR DESCRIPTION
Removes and then gitignore's the .env.testing file.
So we can create/change it as we wish and not have it commit to the repo (less thrash)