### PR TITLE
Make get_tickets() protected again

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,10 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [4.11.0.1] 2019-12-11 =
+
+* Fix - Make get_tickets() protected to avoid errors with it not being public before upgrading ET+ [138385]
+
 = [4.11] 2019-12-10 =
 
 * Feature - Add ability to utilize the block ticket template outside of Gutenberg views [132568]

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -626,7 +626,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @return Tribe__Tickets__Ticket_Object[] List of ticket objects.
 		 */
-		public function get_tickets( $post_id ) {}
+		protected function get_tickets( $post_id ) {}
 
 		/**
 		 * Get attendees for a Post ID / Post type.


### PR DESCRIPTION
Make get_tickets() protected to avoid errors with it not being public before upgrading ET+

https://central.tri.be/issues/138385