### PR TITLE
Handle special characters for Event Ticket field labels like single quotes and colons so they don't break the saving

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - If running WP 5.3+, add `show_in_rest` as an array configuration for capacity and the RSVP not going fields so that they save properly. [137875]
 * Fix - Gracefully handle enter key in modal form to prevent missing data when submitting. [136595]
 * Fix - Increase size of -/+ signs for decreasing/increasing quantity on tickets. [138558]
+* Fix - Handle special characters for Event Ticket field labels like single quotes and colons so they don't break the saving. [136451]
 
 = [4.11.0.1] 2019-12-11 =
 

--- a/src/resources/js/tickets.js
+++ b/src/resources/js/tickets.js
@@ -612,7 +612,7 @@ var ticketHeaderImage = window.ticketHeaderImage || {};
 			var $orders = $base_panel.find( '.tribe-ticket-field-order' );
 			var params = {
 				action: 'tribe-ticket-add',
-				data: $edit_panel.find( 'input,textarea' ).serialize(),
+				data: $edit_panel.find( 'input,textarea' ).serialize().replace( /\'/g, '%27' ).replace( /\:/g, '%3A' ),
 				post_id: $post_id.val(),
 				nonce: TribeTickets.add_ticket_nonce,
 				menu_order: $orders.length,


### PR DESCRIPTION
https://central.tri.be/issues/136451

Screencast: https://p199.p4.n0.cdn.getcloudapp.com/items/P8uYRnn5/Screen+Recording+2019-12-14+at+12.26+PM.mov

Tested against:
```
Johnny's `~!@#$%^&*()_+-={}|[]:";'<>?,.\/ yes
```

Only character not saving correctly is backslash but it gets stripped out and does not effect the rest of the text (previously single quotes would break everything on save).