### PR TITLE
Removing jquery-ui-datepicker from the frontend because it is unused

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -18,7 +18,7 @@ class Tribe__Tickets__Assets {
 				[ 'event-tickets-reset-css', 'reset.css' ],
 				[ 'event-tickets-tickets-css', 'tickets.css', [ 'dashicons', 'event-tickets-reset-css' ] ],
 				[ 'event-tickets-tickets-rsvp-css', 'rsvp.css', [] ],
-				[ 'event-tickets-tickets-rsvp-js', 'rsvp.js', [ 'jquery', 'jquery-ui-datepicker' ] ],
+				[ 'event-tickets-tickets-rsvp-js', 'rsvp.js', [ 'jquery' ] ],
 				[ 'event-tickets-attendees-list-js', 'attendees-list.js', [ 'jquery' ] ],
 				[ 'event-tickets-details-js', 'ticket-details.js', [] ],
 			],

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -371,7 +371,6 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 					'tpp.js',
 					array(
 						'jquery',
-						'jquery-ui-datepicker',
 					),
 				),
 			),

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -172,7 +172,7 @@ extends Tribe__Editor__Blocks__Abstract {
 			$plugin,
 			'tribe-tickets-gutenberg-rsvp',
 			'rsvp-block.js',
-			array( 'jquery', 'jquery-ui-datepicker' ),
+			array( 'jquery' ),
 			null,
 			array(
 				'localize'     => array(

--- a/src/Tribe/Editor/Blocks/Tickets.php
+++ b/src/Tribe/Editor/Blocks/Tickets.php
@@ -103,7 +103,7 @@ extends Tribe__Editor__Blocks__Abstract {
 			$plugin,
 			'tribe-tickets-gutenberg-tickets',
 			'tickets-block.js',
-			[ 'jquery', 'jquery-ui-datepicker', 'wp-util-not-in-footer', 'wp-i18n' ],
+			[ 'jquery', 'wp-util-not-in-footer', 'wp-i18n' ],
 			null,
 			[
 				'type'         => 'js',

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -296,7 +296,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		wp_register_script(
 			'event-tickets-rsvp',
 			$js_url,
-			array( 'jquery', 'jquery-ui-datepicker' ),
+			array( 'jquery' ),
 			apply_filters( 'tribe_tickets_rsvp_js_version', Tribe__Tickets__Main::VERSION ),
 			true
 		);


### PR DESCRIPTION
jQuery Datepicker was conflicting with bootstrap datepicker causing our views navigation to break.

:movie_camera: http://p.tri.be/wpGQRj