### PR TITLE
fix(ticket header image): Allow adding ticket header image on non-event posts.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Ensure that attendee images display horizontally in the frontend for Twenty Nineteen and Twenty Twenty themes. [ET-590]
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor [ET-587]
+* Fix - Allow adding ticket header image on non-event posts. [ETP-54]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -458,7 +458,19 @@ export function* updateRSVPHeaderImage( action ) {
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
 		const post_type = wpSelect('core/editor').getCurrentPostType();
-		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+		let rest_base = post_type;
+
+		switch ( post_type ) {
+			case 'post':
+				rest_base = 'posts';
+				break;
+			case 'page':
+				rest_base = 'pages';
+				break;
+			default:
+				rest_base = post_type;
+				break;
+		}
 
 		const { response } = yield call( api.wpREST, {
 			path: `${ rest_base }/${ postId }`,
@@ -512,7 +524,19 @@ export function* deleteRSVPHeaderImage() {
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
 		const post_type = wpSelect('core/editor').getCurrentPostType();
-		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+		let rest_base = post_type;
+
+		switch ( post_type ) {
+			case 'post':
+				rest_base = 'posts';
+				break;
+			case 'page':
+				rest_base = 'pages';
+				break;
+			default:
+				rest_base = post_type;
+				break;
+		}
 
 		const { response } = yield call( api.wpREST, {
 			path: `${ rest_base }/${ postId }`,

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -457,23 +457,12 @@ export function* updateRSVPHeaderImage( action ) {
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
-		const post_type = wpSelect('core/editor').getCurrentPostType();
-		let rest_base = post_type;
-
-		switch ( post_type ) {
-			case 'post':
-				rest_base = 'posts';
-				break;
-			case 'page':
-				rest_base = 'pages';
-				break;
-			default:
-				rest_base = post_type;
-				break;
-		}
+		const slug = wpSelect('core/editor').getCurrentPostType();
+		const postType = wpSelect('core').getPostType(slug);
+		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {
-			path: `${ rest_base }/${ postId }`,
+			path: `${ restBase }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},
@@ -523,23 +512,12 @@ export function* deleteRSVPHeaderImage() {
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
-		const post_type = wpSelect('core/editor').getCurrentPostType();
-		let rest_base = post_type;
-
-		switch ( post_type ) {
-			case 'post':
-				rest_base = 'posts';
-				break;
-			case 'page':
-				rest_base = 'pages';
-				break;
-			default:
-				rest_base = post_type;
-				break;
-		}
+		const slug = wpSelect('core/editor').getCurrentPostType();
+		const postType = wpSelect('core').getPostType(slug);
+		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {
-			path: `${ rest_base }/${ postId }`,
+			path: `${ restBase }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -456,8 +456,12 @@ export function* updateRSVPHeaderImage( action ) {
 		 */
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
+
+		const post_type = wpSelect('core/editor').getCurrentPostType();
+		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+
 		const { response } = yield call( api.wpREST, {
-			path: `tribe_events/${ postId }`,
+			path: `${ rest_base }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},
@@ -506,8 +510,12 @@ export function* deleteRSVPHeaderImage() {
 		 */
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
+
+		const post_type = wpSelect('core/editor').getCurrentPostType();
+		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+
 		const { response } = yield call( api.wpREST, {
-			path: `tribe_events/${ postId }`,
+			path: `${ rest_base }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -457,8 +457,8 @@ export function* updateRSVPHeaderImage( action ) {
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
-		const slug = wpSelect('core/editor').getCurrentPostType();
-		const postType = wpSelect('core').getPostType(slug);
+		const slug = wpSelect( 'core/editor' ).getCurrentPostType();
+		const postType = wpSelect( 'core' ).getPostType( slug );
 		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {
@@ -512,8 +512,8 @@ export function* deleteRSVPHeaderImage() {
 		yield put( actions.setRSVPIsSettingsLoading( true ) );
 		yield put( ticketActions.setTicketsIsSettingsLoading( true ) );
 
-		const slug = wpSelect('core/editor').getCurrentPostType();
-		const postType = wpSelect('core').getPostType(slug);
+		const slug = wpSelect( 'core/editor' ).getCurrentPostType();
+		const postType = wpSelect( 'core' ).getPostType( slug );
 		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -661,7 +661,19 @@ export function* updateTicketsHeaderImage( action ) {
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
 		const post_type = wpSelect('core/editor').getCurrentPostType();
-		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+		let rest_base = post_type;
+
+		switch ( post_type ) {
+			case 'post':
+				rest_base = 'posts';
+				break;
+			case 'page':
+				rest_base = 'pages';
+				break;
+			default:
+				rest_base = post_type;
+				break;
+		}
 
 		const { response } = yield call( wpREST, {
 			path: `${ rest_base }/${ postId }`,
@@ -715,7 +727,19 @@ export function* deleteTicketsHeaderImage() {
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
 		const post_type = wpSelect('core/editor').getCurrentPostType();
-		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+		let rest_base = post_type;
+
+		switch ( post_type ) {
+			case 'post':
+				rest_base = 'posts';
+				break;
+			case 'page':
+				rest_base = 'pages';
+				break;
+			default:
+				rest_base = post_type;
+				break;
+		}
 
 		const { response } = yield call( api.wpREST, {
 			path: `${ rest_base }/${ postId }`,

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -659,8 +659,12 @@ export function* updateTicketsHeaderImage( action ) {
 		 */
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
+
+		const post_type = wpSelect('core/editor').getCurrentPostType();
+		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+
 		const { response } = yield call( wpREST, {
-			path: `tribe_events/${ postId }`,
+			path: `${ rest_base }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},
@@ -709,8 +713,12 @@ export function* deleteTicketsHeaderImage() {
 		 */
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
-		const { response } = yield call( wpREST, {
-			path: `tribe_events/${ postId }`,
+
+		const post_type = wpSelect('core/editor').getCurrentPostType();
+		const rest_base = ( 'tribe_events' === post_type ) ? 'tribe_events' : 'posts';
+
+		const { response } = yield call( api.wpREST, {
+			path: `${ rest_base }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -660,23 +660,12 @@ export function* updateTicketsHeaderImage( action ) {
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
-		const post_type = wpSelect('core/editor').getCurrentPostType();
-		let rest_base = post_type;
-
-		switch ( post_type ) {
-			case 'post':
-				rest_base = 'posts';
-				break;
-			case 'page':
-				rest_base = 'pages';
-				break;
-			default:
-				rest_base = post_type;
-				break;
-		}
+		const slug = wpSelect('core/editor').getCurrentPostType();
+		const postType = wpSelect('core').getPostType(slug);
+		const restBase = postType.rest_base;
 
 		const { response } = yield call( wpREST, {
-			path: `${ rest_base }/${ postId }`,
+			path: `${ restBase }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},
@@ -726,23 +715,12 @@ export function* deleteTicketsHeaderImage() {
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
-		const post_type = wpSelect('core/editor').getCurrentPostType();
-		let rest_base = post_type;
-
-		switch ( post_type ) {
-			case 'post':
-				rest_base = 'posts';
-				break;
-			case 'page':
-				rest_base = 'pages';
-				break;
-			default:
-				rest_base = post_type;
-				break;
-		}
+		const slug = wpSelect('core/editor').getCurrentPostType();
+		const postType = wpSelect('core').getPostType(slug);
+		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {
-			path: `${ rest_base }/${ postId }`,
+			path: `${ restBase }/${ postId }`,
 			headers: {
 				'Content-Type': 'application/json',
 			},

--- a/src/modules/data/blocks/ticket/sagas.js
+++ b/src/modules/data/blocks/ticket/sagas.js
@@ -660,8 +660,8 @@ export function* updateTicketsHeaderImage( action ) {
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
-		const slug = wpSelect('core/editor').getCurrentPostType();
-		const postType = wpSelect('core').getPostType(slug);
+		const slug = wpSelect( 'core/editor' ).getCurrentPostType();
+		const postType = wpSelect( 'core' ).getPostType( slug );
 		const restBase = postType.rest_base;
 
 		const { response } = yield call( wpREST, {
@@ -715,8 +715,8 @@ export function* deleteTicketsHeaderImage() {
 		yield put( actions.setTicketsIsSettingsLoading( true ) );
 		yield put( rsvpActions.setRSVPIsSettingsLoading( true ) );
 
-		const slug = wpSelect('core/editor').getCurrentPostType();
-		const postType = wpSelect('core').getPostType(slug);
+		const slug = wpSelect( 'core/editor' ).getCurrentPostType();
+		const postType = wpSelect( 'core' ).getPostType( slug );
 		const restBase = postType.rest_base;
 
 		const { response } = yield call( api.wpREST, {


### PR DESCRIPTION
The block editor always used the event REST API for adding ticket(and RSVP) images - this fails if we're not editing an event. 

This code changes it to detect the post type and use the appropriate endpoint (`tribe_events` for events, `posts` otherwise).

Code changes are only to update and delete for both RSVP and Ticket.

:ticket: [ET-54]
📸   http://p.tri.be/E6sYH4