### PR TITLE
feat(no tickets notice): Refine logic for the notice on the "my tickets" page. ETP-612, ETP-46

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Remove inaccurate display of "You don't have tickets for this event" notice at single event page's list of current user's RSVPs and/or Tickets [ETP-50]
 * Fix - Close opening `<div>` in `blocks/attendees.php` [ET-589]
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor [ET-587]
+* Tweak - Refine logic for the notice on the "my tickets" page. [ETP-151]
 
 = [4.11.1] 2019-12-19 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,7 +123,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Remove inaccurate display of "You don't have tickets for this event" notice at single event page's list of current user's RSVPs and/or Tickets [ETP-50]
 * Fix - Close opening `<div>` in `blocks/attendees.php` [ET-589]
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor [ET-587]
-* Tweak - Refine logic for the notice on the "my tickets" page. [ETP-151]
+* Tweak - Refine logic for the no results notice on the "My Tickets" page. [ETP-151]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1348,7 +1348,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	}
 
 	/**
-	 * Get total count of attendees marked as going for this provider.
+	 * Get total count of attendees marked as not going for this provider.
 	 *
 	 * @since 4.10.6
 	 *
@@ -1361,6 +1361,38 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$repository = tribe_attendees( $this->orm_provider );
 
 		return $repository->by( 'event', $post_id )->by( 'rsvp_status', 'no' )->found();
+	}
+
+	/**
+	 * Get total count of attendees marked as going for this provider and user.
+	 *
+	 * @since 4.10.6
+	 *
+	 * @param int $post_id Post or Event ID.
+	 *
+	 * @return int Total count of attendees marked as going.
+	 */
+	public function get_attendees_count_going_for_user( $post_id, $user_id ) {
+		/** @var Tribe__Tickets__Attendee_Repository $repository */
+		$repository = tribe_attendees( $this->orm_provider );
+
+		return $repository->by( 'event', $post_id )->by( 'user', $user_id )->by( 'rsvp_status', 'yes' )->found();
+	}
+
+	/**
+	 * Get total count of attendees marked as not going for this provider.
+	 *
+	 * @since 4.10.6
+	 *
+	 * @param int $post_id Post or Event ID.
+	 *
+	 * @return int Total count of attendees marked as going.
+	 */
+	public function get_attendees_count_not_going_for_user( $post_id, $user_id ) {
+		/** @var Tribe__Tickets__Attendee_Repository $repository */
+		$repository = tribe_attendees( $this->orm_provider );
+
+		return $repository->by( 'event', $post_id )->by( 'user', $user_id )->by( 'rsvp_status', 'no' )->found();
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1366,7 +1366,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	/**
 	 * Get total count of attendees marked as going for this provider and user.
 	 *
-	 * @since 4.10.6
+	 * @since TBD
 	 *
 	 * @param int $post_id Post or Event ID.
 	 *
@@ -1382,7 +1382,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	/**
 	 * Get total count of attendees marked as not going for this provider.
 	 *
-	 * @since 4.10.6
+	 * @since TBD
 	 *
 	 * @param int $post_id Post or Event ID.
 	 *

--- a/src/views/blocks/attendees.php
+++ b/src/views/blocks/attendees.php
@@ -23,8 +23,7 @@ if ( ! is_array( $attendees ) ) {
 	return;
 }
 ?>
-<div id="tribe-block__attendees">
-	<?php tribe_classes( $classes ); ?>
+<div id="tribe-block__attendees" <?php tribe_classes( $classes ); ?>>
 
 	<?php $this->template( 'blocks/attendees/title', [ 'title' => $title ] ); ?>
 

--- a/src/views/tickets/orders.php
+++ b/src/views/tickets/orders.php
@@ -22,21 +22,48 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Event Tickets Plus would set this from its own injected template to let us know about editable values
 global $tribe_my_tickets_have_meta;
 
+$rsvp                       = Tribe__Tickets__RSVP::get_instance();
 $view                       = Tribe__Tickets__Tickets_View::instance();
 $event_id                   = get_queried_object_id();
 $event                      = get_post( $event_id );
 $post_type                  = get_post_type_object( $event->post_type );
 $user_id                    = get_current_user_id();
+$provider_id                = Tribe__Tickets__Tickets::get_event_ticket_provider( $event_id );
+$provider                   = call_user_func( array( $provider_id, 'get_instance' ) );
+$event_has_tickets          = ! empty( $provider->get_tickets( $event_id ) );
+$event_has_rsvp             = ! empty( $rsvp->get_tickets( $event ) );
+$user_has_tickets           = $view->has_ticket_attendees( $event_id, $user_id );
+$user_has_rsvp              = $rsvp->get_attendees_count_going_for_user( $event_id, $user_id );
 $tribe_my_tickets_have_meta = false;
 
 /**
  * Display a notice if the user doesn't have tickets
  */
 if (
-	! $view->has_ticket_attendees( $event_id, $user_id )
-	&& ! $view->has_rsvp_attendees( $event_id, $user_id )
+	(
+		$event_has_tickets
+		|| $event_has_rsvp
+	)
+	&& ! $user_has_tickets
+	&& ! $user_has_rsvp
 ) {
-	Tribe__Notices::set_notice( 'ticket-no-results', esc_html( sprintf( _x( "You don't have %s for this event", 'notice if user does not have tickets', 'event-tickets' ), tribe_get_ticket_label_plural_lowercase( 'notice_user_does_not_have_tickets' ) ) ) );
+
+	if ( $event_has_tickets ) {
+		$no_ticket_message = sprintf(
+			_x( "You don't have %s for this event", 'notice if user does not have tickets', 'event-tickets' ),
+			tribe_get_ticket_label_plural_lowercase( 'notice_user_does_not_have_tickets' )
+		);
+	} else {
+		$no_ticket_message = sprintf(
+			_x( "You don't have %s for this event", 'notice if user does not have rsvps', 'event-tickets' ),
+			tribe_get_rsvp_label_plural_lowercase( 'notice_user_does_not_have_rsvps' )
+		);
+	}
+
+	Tribe__Notices::set_notice(
+		'ticket-no-results',
+		esc_html( $no_ticket_message )
+	);
 }
 
 $is_event_page = class_exists( 'Tribe__Events__Main' ) && Tribe__Events__Main::POSTTYPE === $event->post_type;


### PR DESCRIPTION
Add logic to comprehensively respond to events with or without tickets or RSVP, and users with or
without tickets or RSVPs.

:camera_flash:
ticket-only, no purchase: http://p.tri.be/TFyuxu
ticket-only, with purchase: http://p.tri.be/sqYmvx
rsvp-only, no rsvp: http://p.tri.be/NBUFAO
rsvp-only, "going": http://p.tri.be/bdTWRs
rsvp-only, "not going": http://p.tri.be/YouQXd
mix, no tickets or RSVP: http://p.tri.be/WoQJtQ
mix, RSVP "going" no ticket: http://p.tri.be/d1otvQ
mix, RSVP "not going" no ticket: http://p.tri.be/XaROBz
mix, RSVP "not going" with ticket: http://p.tri.be/fpvq0R
mix, RSVP "going" (and not going) with ticket: http://p.tri.be/k24eVR
mix, ticket, no RSVP: http://p.tri.be/bQcNEd
mix, ticket, RSVP "not going": http://p.tri.be/MFOSux
mix, ticket, RSVP "going"  (and not going): http://p.tri.be/oYOSHu

ETP-46: https://moderntribe.atlassian.net/browse/ETP-46
ET-612: https://moderntribe.atlassian.net/browse/ETP-612