### PR TITLE
Fix/etp 41 woo widget checkout link

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.11.2] TBD =
 
-* Fix - WooCommerce Mini-Cart widget checkout link to use the custom page for attendee registration if it is setup [ETP-41]
+* Fix - Override checkout link in WooCommerce Mini-Cart widget so it uses the custom page for attendee registration if it is setup. [ETP-41]
 * Fix - Ensure that attendee images display horizontally in the frontend for Twenty Nineteen and Twenty Twenty themes. [ET-590]
 * Fix - Remove inaccurate display of "You don't have tickets for this event" notice at single event page's list of current user's RSVPs and/or Tickets. [ETP-50]
 * Fix - Close opening `<div>` in `blocks/attendees.php`. [ET-589]

--- a/readme.txt
+++ b/readme.txt
@@ -119,8 +119,6 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.11.2] TBD =
 
-* Fix - Load JavaScript assets with Ticket Block when using Classic Editor [ET-587]
-* Fix - Disable ticket block when password protected is enabled on posts and pages [ETP-59]
 * Fix - WooCommerce Mini-Cart widget checkout link to use the custom page for attendee registration if it is setup [ETP-41]
 * Fix - Ensure that attendee images display horizontally in the frontend for Twenty Nineteen and Twenty Twenty themes. [ET-590]
 * Fix - Remove inaccurate display of "You don't have tickets for this event" notice at single event page's list of current user's RSVPs and/or Tickets. [ETP-50]

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor [ET-587]
 * Fix - Disable ticket block when password protected is enabled on posts and pages [ETP-59]
+* Fix - WooCommerce Mini-Cart widget checkout link to use the custom page for attendee registration if it is setup [ETP-41]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/Tribe/Attendee_Registration/Shortcode.php
+++ b/src/Tribe/Attendee_Registration/Shortcode.php
@@ -9,7 +9,7 @@ class Tribe__Tickets__Attendee_Registration__Shortcode {
 
 	public function hook() {
 		// block editor has a fit if we don't bail on the admin...don't really need them in other places?
-		if ( is_admin() || wp_doing_ajax() || tribe( 'context' )->doing_cron() ) {
+		if ( is_admin() || tribe( 'context' )->doing_cron() ) {
 			return;
 		}
 


### PR DESCRIPTION
_Ref:_ [ETP-41](https://moderntribe.atlassian.net/browse/ETP-41)

Modify the Attendee Registration Shortcode so that is loads with ajax calls.
This prevents the has_shortcode from failing to find it when updating the checkout link in the WooCommerce Mini Cart Widget.