### PR TITLE
fix(global stock): Incorrect global stock on new tickets.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor. [ET-587]
 * Fix - Disable ticket block when password protected is enabled on posts and pages. [ETP-59]
 * Fix - The Events Calendar's List View "RSVP Now!" button again displays for Events having only RSVP tickets and has the correct anchor link. [ETP-51]
+* Fix - Ensure we update the correct event meta for global stock on ticket creation. [ET-614]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -1304,6 +1304,7 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 
 				// Update Event capacity
 				update_post_meta( $post_id, $tickets_handler->key_capacity, $data['event_capacity'] );
+				update_post_meta( $post_id, $event_stock::GLOBAL_STOCK_LEVEL, $data['event_capacity'] );
 			}
 		} else {
 			// If the Global Stock is configured we pull it from the Event

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -748,10 +748,6 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				&& isset( $this->get_event()->ID )
 			) {
 				$stock[] = (int) get_post_meta( $this->get_event()->ID, Tribe__Tickets__Global_Stock::GLOBAL_STOCK_LEVEL, true );
-				bdump(
-					$this->get_event()->ID,
-					get_post_meta( $this->get_event()->ID, Tribe__Tickets__Global_Stock::GLOBAL_STOCK_LEVEL, true )
-				);
 			}
 
 			// return the new Stock

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -748,6 +748,10 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				&& isset( $this->get_event()->ID )
 			) {
 				$stock[] = (int) get_post_meta( $this->get_event()->ID, Tribe__Tickets__Global_Stock::GLOBAL_STOCK_LEVEL, true );
+				bdump(
+					$this->get_event()->ID,
+					get_post_meta( $this->get_event()->ID, Tribe__Tickets__Global_Stock::GLOBAL_STOCK_LEVEL, true )
+				);
 			}
 
 			// return the new Stock


### PR DESCRIPTION
When saving tickets initially, we weren't updating the event meta value we check on the front end,
resulting in new shared tickets appearing sold out. This adds that update.

🐫 http://p.tri.be/iZdLbf
📷 http://p.tri.be/6geO8s

Requires: https://github.com/moderntribe/event-tickets-plus/pull/944

[ET-614]

[ET-614]: https://moderntribe.atlassian.net/browse/ET-614