### PR TITLE
fix(RSVP stock): Correct front end form when one RSVP becomes sold out.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor. [ET-587]
 * Fix - Disable ticket block when password protected is enabled on posts and pages. [ETP-59]
 * Fix - The Events Calendar's List View "RSVP Now!" button again displays for Events having only RSVP tickets and has the correct anchor link. [ETP-51]
+* Fix - Correct logic so selling out of one RSVP doesn't prevent "purchasing" another. [ETP-603]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -109,6 +109,7 @@ if ( ! $already_rendered ) {
 			}
 
 			$ticket_id = $ticket->ID;
+			$is_there_any_rsvp_stock = false;
 
 			/** @var Tribe__Tickets__Tickets_Handler $handler */
 			$handler = tribe( 'tickets.handler' );
@@ -125,12 +126,13 @@ if ( ! $already_rendered ) {
 			 */
 			$show_unlimited = apply_filters( 'tribe_rsvp_block_show_unlimited_availability', false, $available );
 
-			$is_there_any_product_to_sell = 0 !== $available;
+			$is_there_any_rsvp_stock      = 0 !== $available;
+			$is_there_any_product_to_sell = $is_there_any_rsvp_stock || $is_there_any_product_to_sell;
 			?>
 			<tr>
 				<td class="tribe-ticket quantity" data-product-id="<?php echo esc_attr( $ticket_id ); ?>">
 					<input type="hidden" name="product_id[]" value="<?php echo absint( $ticket_id ); ?>">
-					<?php if ( $is_there_any_product_to_sell ) : ?>
+					<?php if ( $is_there_any_rsvp_stock ) : ?>
 						<input
 							type="number"
 							class="tribe-tickets-quantity"


### PR DESCRIPTION
THe rsvp form had a variable carried through the loop to check for "product available" - but if the
last RSVP was sold out then it would be set to `false` - resulting in the meta row no showing up.
We've updated that to rely on _two_ variables - one for the specific rsvp and one for all rsvps.

:movie_camera: http://p.tri.be/iRhxoL

:ticket: [ET-603]

BTW: 603 is the area code for NH :tada:

[ET-603]: https://moderntribe.atlassian.net/browse/ET-603