### PR TITLE
fix(tickets block js): Ensure we have the post ID. ET-640

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,6 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Price formatting method now correctly prevents incorrect display when a comma is used as the decimal separator. [ETP-53]
 * Fix - Display WooCommerce price taxation suffix, if applicable. [ETP-33]
-* Tweak - Remove duplicate ticket script to prevent conflicts. [ET-596]
 * Fix - Override checkout link in WooCommerce Mini-Cart widget so it uses the custom page for attendee registration if it is setup. [ETP-41]
 * Fix - Ensure that attendee images display horizontally in the frontend for Twenty Nineteen and Twenty Twenty themes. [ET-590]
 * Fix - Load JavaScript assets with Ticket Block when using Classic Editor. [ET-587]
@@ -133,7 +132,9 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - The Events Calendar's List View "RSVP Now!" button again displays for Events having only RSVP tickets and has the correct anchor link. [ETP-51]
 * Fix - Ensure we update the correct event meta for global stock on ticket creation. [ET-614]
 * Fix - Correct logic so selling out of one RSVP doesn't prevent "purchasing" another. [ETP-603]
+* Fix - Correct broken javascript for themes that change the base post classes. [GTRIA-20]
 * Tweak - Refine logic for the no results notice on the "My Tickets" page. [ETP-151]
+* Tweak - Remove duplicate ticket script to prevent conflicts. [ET-596]
 
 = [4.11.1] 2019-12-19 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1568,6 +1568,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$availability_check_interval = apply_filters( 'tribe_tickets_availability_check_interval', 60000 );
 
 			return [
+				'post_id'                     => get_the_ID(),
 				'ajaxurl'                     => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 				'availability_check_interval' => $availability_check_interval,
 			];

--- a/src/resources/js/tickets-block.js
+++ b/src/resources/js/tickets-block.js
@@ -94,7 +94,7 @@ tribe.tickets.block = {
 	};
 
 	obj.tribe_ticket_provider = $tribeTicket.data( 'provider' );
-	obj.postId = $( '.status-publish' ).attr( 'id' ).replace( 'post-', '' );
+	obj.postId = TribeTicketOptions.post_id;
 
 	/**
 	 * Init the tickets script.


### PR DESCRIPTION
Some themes do not follow the standards of official themes and alter where they put either the post ID or the publish status. We were relying on those to find the post ID - now we make it available via localize_script().

:ticket: [ET-640]

[ET-640]: https://moderntribe.atlassian.net/browse/ET-640