### PR TITLE
feat(ticket price): Show original price on ticket block if ticket is on sale.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [4.11.2] TBD =
 
+* Feature - Show original price on ticket block if ticket on sale. Allow turning off via the `tribe_tickets_show_original_price_on_sale` filter. [ETP-47]
 * Fix - Create new function `tribe_get_event_capacity` for checking the capacity of an entire event. Have `tribe_tickets_get_capacity` pass off to it as when given an event. [ETP-48]
 * Fix - Price formatting method now correctly prevents incorrect display when a comma is used as the decimal separator. [ETP-53]
 * Fix - Display WooCommerce price taxation suffix, if applicable. [ETP-33]

--- a/src/resources/postcss/tickets-registration-page.pcss
+++ b/src/resources/postcss/tickets-registration-page.pcss
@@ -195,6 +195,7 @@ body.page-tribe-attendee-registration {
 			.tribe-tickets__item__extra__price {
 				font-family: var(--font-family-sans-serif);
 				font-size: var(--font-size-2);
+				font-weight: var(--font-weight-bold);
 
 				@media(--viewport-medium) {
 					font-size: var(--font-size-2);

--- a/src/resources/postcss/tickets.pcss
+++ b/src/resources/postcss/tickets.pcss
@@ -229,6 +229,7 @@
 	}
 
 	.tribe-tickets__item__extra__price {
+		font-weight: var(--font-weight-bold);
 		white-space: nowrap;
 
 		@media(--viewport-medium) {
@@ -236,6 +237,12 @@
 			grid-column: 1;
 			-ms-grid-row: 1;
 			grid-row: 1;
+		}
+
+		.tribe-tickets__original_price {
+			color: var(--color-text-secondary);
+			font-weight: var(--font-weight-regular);
+			text-decoration: line-through;
 		}
 	}
 
@@ -270,6 +277,8 @@
 		background-color: transparent;
 		color: var(--color-icon-secondary);
 		display: inline-block;
+		font-size: 24px;
+		font-weight: var(--font-weight-regular);
 		margin-bottom: var(--spacer-0);
 		width: 12px;
 
@@ -954,6 +963,7 @@
 
 			.tribe-tickets__item__extra__price {
 				@mixin mobile-body-1;
+				font-weight: var(--font-weight-bold);
 
 				@media (--viewport-medium) {
 					@mixin desktop-body-1-sup;
@@ -1030,7 +1040,7 @@
 
 			.tribe-tickets-quantity {
 				@mixin mobile-body-2;
-					font-weight: var(--font-weight-bold);
+				font-weight: var(--font-weight-regular);
 
 				@media (--viewport-medium) {
 					@mixin desktop-body-1-sup;

--- a/src/styles/tickets/frontend.pcss
+++ b/src/styles/tickets/frontend.pcss
@@ -108,6 +108,7 @@
 
 	.tribe-tickets__item__extra__price {
 		color: var(--color-icon-secondary);
+		font-weight: var(--font-weight-bold);
 	}
 
 	.tribe-tickets__item__extra__available {

--- a/src/views/blocks/tickets/extra-price.php
+++ b/src/views/blocks/tickets/extra-price.php
@@ -21,6 +21,9 @@ $ticket = $this->get( 'ticket' );
 
 /** @var Tribe__Tickets__Tickets $provider */
 $provider = $this->get( 'provider' );
+$provider_class = $provider->class_name;
+
+$show_original_price_on_sale = apply_filters( 'tribe_tickets_show_original_price_on_sale', true);
 
 /** @var Tribe__Tickets__Commerce__Currency $tribe_commerce_currency */
 $tribe_commerce_currency = tribe( 'tickets.commerce.currency' );
@@ -28,5 +31,10 @@ $tribe_commerce_currency = tribe( 'tickets.commerce.currency' );
 <div
 	class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__item__extra__price"
 >
-	<?php echo $tribe_commerce_currency->get_formatted_currency_with_symbol( $ticket->price, $post_id, $provider->class_name ) ?>
+	<?php if ( ! empty( $ticket->on_sale ) ) : ?>
+		<span class="tribe-common-b2 tribe-tickets__original_price">
+		<?php echo $tribe_commerce_currency->get_formatted_currency_with_symbol( $ticket->regular_price, $post_id, $provider_class ) ?>
+		</span>
+	<?php endif; ?>
+	<?php echo $tribe_commerce_currency->get_formatted_currency_with_symbol( $ticket->price, $post_id, $provider_class ) ?>
 </div>


### PR DESCRIPTION
Put in a check for `$ticket->on_sale` and show the original price before it on the tickets block.
Add `tribe_tickets_show_original_price_on_sale` filter to turn off if desired.

Also sneak in a few style tweaks for Mr. Randall.

:ticket: [ETP-47]

[ETP-47]: https://moderntribe.atlassian.net/browse/ETP-47

Requires https://github.com/moderntribe/event-tickets-plus/pull/946 for correct calculations!

📷 📸 
mobile: http://p.tri.be/3RijFK
desktop: http://p.tri.be/c3h7gU