### PR TITLE
Use the default `datepickerFormat` value if the option hasn't been set yet when setting up validation rules for the ticket add/edit admin form

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - When Classic Editor plugin is activated, prevent ticket availability AJAX errors by temporarily disabling the AJAX requests. [ET-730]
 * Fix - When not using blocks, the scripts to obtain an RSVP ticket now work even if required Attendee Information (from Event Tickets Plus) is missing upon initial attempt to submit the form. [ET-686]
 * Fix - Prevent The Events Calendar plugin from overriding the Attendee Registration page content when Events Page is set as site home page. [ET-732]
+* Fix - Use the default `datepickerFormat` value if the option hasn't been set yet when setting up validation rules for the ticket add/edit admin form. [ET-727]
 
 = [4.11.3.1] 2020-02-11 =
 

--- a/src/admin-views/editor/fieldset/advanced.php
+++ b/src/admin-views/editor/fieldset/advanced.php
@@ -1,5 +1,5 @@
 <?php
-$datepicker_format = Tribe__Date_Utils::datepicker_formats( tribe_get_option( 'datepickerFormat' ) );
+$datepicker_format = Tribe__Date_Utils::datepicker_formats( Tribe__Date_Utils::get_datepicker_format_index() );
 
 if ( ! isset( $post_id ) ) {
 	$post_id = get_the_ID();
@@ -41,7 +41,7 @@ $start_date_errors = array(
 <button class="accordion-header tribe_advanced_meta">
 	<?php esc_html_e( 'Advanced', 'event-tickets' ); ?>
 </button>
-<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="<?php echo esc_attr( tribe_get_option( 'datepickerFormat' ) ); ?>">
+<section id="ticket_form_advanced" class="advanced accordion-content" data-datepicker_format="<?php echo esc_attr( Tribe__Date_Utils::get_datepicker_format_index() ); ?>">
 	<h4 class="accordion-label screen_reader_text"><?php esc_html_e( 'Advanced Settings', 'event-tickets' ); ?></h4>
 	<div class="input_block">
 		<label class="ticket_form_label ticket_form_left" for="ticket_description"><?php esc_html_e( 'Description:', 'event-tickets' ); ?></label>


### PR DESCRIPTION
[ET-727]

Screencast: https://share.getcloudapp.com/jkuKoPny

[ET-727]: https://moderntribe.atlassian.net/browse/ET-727