### PR TITLE
[ET-819] Add checkbox to show/hide RSVP type on the FE

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,10 @@ Currently, the following add-ons are available for Event Tickets:
 
 == Changelog ==
 
+= [TBD] =
+
+* Feature - You can now choose whether to display the RSVP type in the front-end as well as the description. [ET-819]
+
 = [4.12.1] 2020-05-20 =
 
 * Feature - Added new field types to choose from when requiring Attendee Information on a Ticket or RSVP: Email, URL, Date of Birth, Date and Telephone, when using Event Tickets Plus. [ETP-89]

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -918,8 +918,8 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return false;
 		}
 
-		// Updates if we should show Type and Description
-		$ticket->show_type = isset( $ticket->show_type ) && tribe_is_truthy( $ticket->show_type ) ? 'yes' : 'no';
+		// Updates if we should show Type and Description.
+		$ticket->show_type = ( isset( $ticket->show_type ) && tribe_is_truthy( $ticket->show_type ) ) ? 'yes' : 'no';
 		$ticket->show_description = isset( $ticket->show_description ) && tribe_is_truthy( $ticket->show_description ) ? 'yes' : 'no';
 		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_type, $ticket->show_type );
 		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_description, $ticket->show_description );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -918,8 +918,10 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return false;
 		}
 
-		// Updates if we should show Description
+		// Updates if we should show Type and Description
+		$ticket->show_type = isset( $ticket->show_type ) && tribe_is_truthy( $ticket->show_type ) ? 'yes' : 'no';
 		$ticket->show_description = isset( $ticket->show_description ) && tribe_is_truthy( $ticket->show_description ) ? 'yes' : 'no';
+		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_type, $ticket->show_type );
 		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_description, $ticket->show_description );
 
 		// Adds RSVP price
@@ -1238,6 +1240,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$return->provider_class   = get_class( $this );
 		$return->admin_link       = '';
 		$return->report_link      = '';
+		$return->show_type        = $return->show_type();
 		$return->show_description = $return->show_description();
 
 		$start_date               = get_post_meta( $ticket_id, '_ticket_start_date', true );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -919,8 +919,9 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		}
 
 		// Updates if we should show Type and Description.
-		$ticket->show_type = ( isset( $ticket->show_type ) && tribe_is_truthy( $ticket->show_type ) ) ? 'yes' : 'no';
-		$ticket->show_description = isset( $ticket->show_description ) && tribe_is_truthy( $ticket->show_description ) ? 'yes' : 'no';
+		$ticket->show_type        = ( isset( $ticket->show_type ) && tribe_is_truthy( $ticket->show_type ) ) ? 'yes' : 'no';
+		$ticket->show_description = ( isset( $ticket->show_description ) && tribe_is_truthy( $ticket->show_description ) ) ? 'yes' : 'no';
+
 		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_type, $ticket->show_type );
 		update_post_meta( $ticket->ID, tribe( 'tickets.handler' )->key_show_description, $ticket->show_description );
 

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -1057,7 +1057,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			 * @param boolean                       $show   Whether to show the type or not.
 			 * @param Tribe__Tickets__Ticket_Object $ticket The ticket object.
 			 */
-			$show = apply_filters( 'tribe_tickets_show_type', $show, $this );
+			$show = apply_filters( 'tribe_tickets_ticket_object_show_type', $show, $this );
 
 			// Make sure we have the correct value.
 			return tribe_is_truthy( $show );

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -1058,10 +1058,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			 * @param boolean                       $show   Whether to show the type or not.
 			 * @param Tribe__Tickets__Ticket_Object $ticket The ticket object.
 			 */
-			$show = apply_filters( 'tribe_tickets_ticket_object_show_type', $show, $this );
-
-			// Make sure we have the correct value.
-			return tribe_is_truthy( $show );
+			return (boolean) apply_filters( 'tribe_tickets_ticket_object_show_type', $show, $this );
 		}
 
 		/**

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -1045,8 +1045,9 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			$key = $tickets_handler->key_show_type;
 
 			$show = true;
+
 			if ( metadata_exists( 'post', $this->ID, $key ) ) {
-				$show = get_post_meta( $this->ID, $key, true );
+				$show = tribe_is_truthy( get_post_meta( $this->ID, $key, true ) );
 			}
 
 			/**

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -30,7 +30,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		public $description;
 
 		/**
-		 * Whether to show the type on the front end and in emails
+		 * Whether to show the type on the front end and in emails.
 		 *
 		 * @since TBD
 		 *
@@ -1036,7 +1036,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @return boolean
+		 * @return boolean Whether the ticket type should show.
 		 */
 		public function show_type() {
 			/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
@@ -1050,16 +1050,16 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			}
 
 			/**
-			 * Allows filtering of the value so we can for example, disable it for a theme/site
+			 * Allows filtering of the value so we can for example, disable it for a theme/site.
 			 *
 			 * @since TBD
 			 *
-			 * @param boolean whether to show the type or not.
-			 * @param int ticket ID.
+			 * @param boolean                       $show   Whether to show the type or not.
+			 * @param Tribe__Tickets__Ticket_Object $ticket The ticket object.
 			 */
-			$show = apply_filters( 'tribe_tickets_show_type', $show, $this->ID );
+			$show = apply_filters( 'tribe_tickets_show_type', $show, $this );
 
-			// Make sure we have the correct value
+			// Make sure we have the correct value.
 			return tribe_is_truthy( $show );
 		}
 

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -30,6 +30,15 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		public $description;
 
 		/**
+		 * Whether to show the type on the front end and in emails
+		 *
+		 * @since TBD
+		 *
+		 * @var boolean
+		 */
+		public $show_type = true;
+
+		/**
 		 * Whether to show the description on the front end and in emails
 		 *
 		 * @since 4.6
@@ -1019,6 +1028,39 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			}
 
 			return null;
+		}
+
+		/**
+		 * Returns whether the ticket type should show on
+		 * the front page and in emails. Defaults to true.
+		 *
+		 * @since TBD
+		 *
+		 * @return boolean
+		 */
+		public function show_type() {
+			/** @var Tribe__Tickets__Tickets_Handler $tickets_handler */
+			$tickets_handler = tribe( 'tickets.handler' );
+
+			$key = $tickets_handler->key_show_type;
+
+			$show = true;
+			if ( metadata_exists( 'post', $this->ID, $key ) ) {
+				$show = get_post_meta( $this->ID, $key, true );
+			}
+
+			/**
+			 * Allows filtering of the value so we can for example, disable it for a theme/site
+			 *
+			 * @since TBD
+			 *
+			 * @param boolean whether to show the type or not.
+			 * @param int ticket ID.
+			 */
+			$show = apply_filters( 'tribe_tickets_show_type', $show, $this->ID );
+
+			// Make sure we have the correct value
+			return tribe_is_truthy( $show );
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2841,6 +2841,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$ticket->name             = isset( $data['ticket_name'] ) ? esc_html( $data['ticket_name'] ) : null;
 			$ticket->description      = isset( $data['ticket_description'] ) ? sanitize_textarea_field( $data['ticket_description'] ) : '';
 			$ticket->price            = ! empty( $data['ticket_price'] ) ? filter_var( trim( $data['ticket_price'] ), FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION | FILTER_FLAG_ALLOW_THOUSAND ) : 0;
+			$ticket->show_type        = isset( $data['ticket_show_type'] ) ? 'yes' : 'no';
 			$ticket->show_description = isset( $data['ticket_show_description'] ) ? 'yes' : 'no';
 			$ticket->provider_class   = $this->class_name;
 			$ticket->start_date       = null;

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -58,6 +58,15 @@ class Tribe__Tickets__Tickets_Handler {
 	public $key_manual_updated = '_tribe_ticket_manual_updated';
 
 	/**
+	 * Meta data key we store show_type under
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public $key_show_type = '_tribe_ticket_show_type';
+
+	/**
 	 * Meta data key we store show_description under
 	 *
 	 * @since 4.6

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -58,7 +58,7 @@ class Tribe__Tickets__Tickets_Handler {
 	public $key_manual_updated = '_tribe_ticket_manual_updated';
 
 	/**
-	 * Meta data key we store show_type under
+	 * Meta data key we store show_type under.
 	 *
 	 * @since TBD
 	 *

--- a/src/admin-views/editor/fieldset/advanced.php
+++ b/src/admin-views/editor/fieldset/advanced.php
@@ -55,6 +55,24 @@ $start_date_errors = array(
 		<div class="input_block">
 			<label class="tribe_soft_note">
 				<input
+						type="checkbox"
+						id="tribe_tickets_show_type"
+						name="ticket_show_type"
+						value="1"
+						class="ticket_field ticket_form_left"
+						<?php checked( true, $ticket ? $ticket->show_type : true ); ?>
+				>
+				<?php
+				echo esc_html( sprintf(
+						__( 'Show type on front end %s form.', 'event-tickets' ),
+						tribe_get_ticket_label_singular_lowercase( 'default_ticket_provider' )
+				) );
+				?>
+			</label>
+		</div>
+		<div class="input_block">
+			<label class="tribe_soft_note">
+				<input
 					type="checkbox"
 					id="tribe_tickets_show_description"
 					name="ticket_show_description"

--- a/src/views/blocks/rsvp/details/title.php
+++ b/src/views/blocks/rsvp/details/title.php
@@ -17,5 +17,5 @@
 
 ?>
 <header class="tribe-block__rsvp__title">
-	<?php echo esc_html( $ticket->name ); ?>
+	<?php echo esc_html( ( $ticket->show_type() ? $ticket->name : '' ) ); ?>
 </header>

--- a/src/views/blocks/rsvp/details/title.php
+++ b/src/views/blocks/rsvp/details/title.php
@@ -11,7 +11,9 @@
  * @link {INSERT_ARTICLE_LINK_HERE}
  *
  * @since 4.9
- * @version 4.9.4
+ * @since TBD Added a conditional to display/hide the RSVP type..
+ *
+ * @version TBD
  *
  */
 

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -11,8 +11,9 @@
  * @since   4.11.0 Added RSVP/ticket view link to template.
  * @since   4.11.1 Corrected amount of available/remaining tickets when threshold is empty.
  * @since   4.11.5 Display total available separately from setting max allowed to purchase at once.
+ * @since   TBD Added a conditional to display/hide the RSVP type.
  *
- * @version 4.11.5
+ * @version TBD
  *
  * @var Tribe__Tickets__RSVP $this
  * @var bool                 $must_login

--- a/src/views/tickets/rsvp.php
+++ b/src/views/tickets/rsvp.php
@@ -165,7 +165,7 @@ if ( ! $already_rendered ) {
 					<?php endif; ?>
 				</td>
 				<td class="tickets_name">
-					<?php echo esc_html( $ticket->name ); ?>
+					<?php echo esc_html( ( $ticket->show_type() ? $ticket->name : '' ) ); ?>
 				</td>
 
 				<td class="tickets_description" colspan="2">


### PR DESCRIPTION
Ticket: https://moderntribe.atlassian.net/browse/ET-819

I was going to write acceptance/webdriver tests for this feature, but I decided not to, given that Juan will work on the revamp of RSVP FE right afterward.

@juanfra I will assign this ticket to you so you can add the necessary control tags in the new RSVP FE template files, such as done in  ` src/views/tickets/rsvp.php ` for the current Classic layout and ` src/views/blocks/rsvp/details/title.php` for blocks: `<?php echo esc_html( ( $ticket->show_type() ? $ticket->name : '' ) ); ?>`