### PR TITLE
[ET-796] [ET-797] Handle RSVP admin notice, constant, setup opt-in setting, and start handling RSVP rendering

### DIFF
--- a/src/Tribe/Admin/Display_Settings.php
+++ b/src/Tribe/Admin/Display_Settings.php
@@ -26,8 +26,8 @@ class Tribe__Tickets__Admin__Display_Settings {
 	 * @return array List of display settings.
 	 */
 	public function add_display_settings( $settings ) {
-		// @todo Remove this early return when we are ready to show the opt-in in G20.07.
-		if ( ! tribe_tickets_rsvp_new_views_is_enabled() ) {
+		// @todo Remove this in G20.07
+		if ( null === constant( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' ) ) {
 			return $settings;
 		}
 

--- a/src/Tribe/Admin/Display_Settings.php
+++ b/src/Tribe/Admin/Display_Settings.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Manages the admin settings UI in relation to display configuration.
+ *
+ * @since TBD
+ */
+class Tribe__Tickets__Admin__Display_Settings {
+
+	/**
+	 * Add display settings on the Events > Settings > Display tab.
+	 *
+	 * @since TBD
+	 */
+	public function hook() {
+		add_filter( 'tribe_display_settings_tab_fields', [ $this, 'add_display_settings' ] );
+	}
+
+	/**
+	 * Add display settings for Event Tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings List of display settings.
+	 *
+	 * @return array List of display settings.
+	 */
+	public function add_display_settings( $settings ) {
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		// @todo Remove this early return when we are ready to show the opt-in in G20.07.
+		if ( ! $rsvp->use_new_views() ) {
+			return $settings;
+		}
+
+		$plugin_path = Tribe__Tickets__Main::instance()->plugin_path;
+		include $plugin_path . 'src/admin-views/tribe-options-display.php';
+
+		return $settings;
+	}
+}

--- a/src/Tribe/Admin/Display_Settings.php
+++ b/src/Tribe/Admin/Display_Settings.php
@@ -26,11 +26,8 @@ class Tribe__Tickets__Admin__Display_Settings {
 	 * @return array List of display settings.
 	 */
 	public function add_display_settings( $settings ) {
-		/** @var Tribe__Tickets__RSVP $rsvp */
-		$rsvp = tribe( 'tickets.rsvp' );
-
 		// @todo Remove this early return when we are ready to show the opt-in in G20.07.
-		if ( ! $rsvp->use_new_views() ) {
+		if ( ! tribe_tickets_rsvp_new_views_is_enabled() ) {
 			return $settings;
 		}
 

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -50,7 +50,7 @@ class Tribe__Tickets__Admin__Notices {
 		/** @var Tribe__Settings $settings */
 		$settings = tribe( 'settings' );
 
-		// Bail if user cannot change settings
+		// Bail if user cannot change settings.
 		if ( ! current_user_can( $settings->requiredCap ) ) {
 			return;
 		}

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -68,11 +68,8 @@ class Tribe__Tickets__Admin__Notices {
 			return;
 		}
 
-		/** @var Tribe__Tickets__RSVP $rsvp */
-		$rsvp = tribe( 'tickets.rsvp' );
-
 		// Bail if the option is already in use.
-		if ( $rsvp->use_new_views() ) {
+		if ( tribe_tickets_rsvp_new_views_is_enabled() ) {
 			return;
 		}
 

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -13,7 +13,104 @@ class Tribe__Tickets__Admin__Notices {
 	 * @since 4.7
 	 */
 	public function hook() {
-		add_action( 'plugins_loaded', array( $this, 'maybe_display_plus_commerce_notice' ) );
+		add_action( 'admin_init', array( $this, 'maybe_display_notices' ) );
+	}
+
+	/**
+	 * Maybe display admin notices.
+	 *
+	 * @since TBD
+	 */
+	public function maybe_display_notices() {
+		// Bail on the unexpected
+		if (
+			! function_exists( 'tribe_installed_before' )
+			|| ! class_exists( 'Tribe__Admin__Notices' )
+		) {
+			return;
+		}
+
+		$this->maybe_display_plus_commerce_notice();
+
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		// @todo Remove this early return when we are ready to show the opt-in notice in G20.07.
+		if ( ! $rsvp->use_new_views() ) {
+			return;
+		}
+
+		$this->maybe_display_rsvp_new_views_options_notice();
+	}
+
+	/**
+	 * Display dismissible notice about new RSVP view settings.
+	 *
+	 * @since TBD
+	 */
+	public function maybe_display_rsvp_new_views_options_notice() {
+		// Bail if previously dismissed this notice.
+		if ( Tribe__Admin__Notices::instance()->has_user_dimissed( __FUNCTION__ ) ) {
+			return;
+		}
+
+		/** @var Tribe__Settings $settings */
+		$settings = tribe( 'settings' );
+
+		// Bail if user cannot change settings
+		if ( ! current_user_can( $settings->requiredCap ) ) {
+			return;
+		}
+
+		// Only show to previously existing installs.
+		if ( ! tribe_installed_before( 'Tribe__Tickets__Main', '5.0' ) ) {
+			return;
+		}
+
+		// Bail if already at wp-admin > Events > Settings > Tickets tab to avoid redundancy/confusion by linking to itself.
+		if (
+			'tribe-common' === tribe_get_request_var( 'page' )
+			&& 'display' === tribe_get_request_var( 'tab' )
+		) {
+			return;
+		}
+
+		// Get link to Display Tab.
+		$url = $settings->get_url( [
+			'page' => 'tribe-common',
+			'tab'  => 'display',
+		] );
+
+		$link = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( $url ),
+			esc_html_x( 'RSVP Display Settings', 'Admin notice link text', 'event-tickets' )
+		);
+
+		// Set heading text.
+		$heading = __( 'Event Tickets', 'event-tickets' );
+
+		// Build notice text.
+		$text = sprintf(
+			// translators: %1$s: RSVP singular text, %2$s: Link to settings page.
+			__( 'With this new version, we\'ve introduced newly redesigned %1$s frontend views. If you have customized the %1$s section, this update will likely impact your customizations.
+			
+			To upgrade to the new frontend views, please enable them in the %2$s.', 'event-tickets' ),
+			tribe_get_rsvp_label_singular( 'admin_notices' ),
+			$link
+		);
+
+		// Build notice message.
+		$message = sprintf( '<h3>%1$s</h3>%2$s', $heading, wpautop( $text ) );
+
+		tribe_notice(
+			__FUNCTION__,
+			$message,
+			[
+				'dismiss' => true,
+				'type'    => 'warning',
+			]
+		);
 	}
 
 	/**
@@ -30,26 +127,31 @@ class Tribe__Tickets__Admin__Notices {
 		}
 
 		$plus_link = add_query_arg(
-			array(
+			[
 				'utm_source'   => 'plugin-install',
 				'utm_medium'   => 'plugin-event-tickets',
 				'utm_campaign' => 'in-app',
-			),
+			],
 			'https://theeventscalendar.com/product/wordpress-event-tickets-plus/'
 		);
-		$plus      = sprintf( '<a target="_blank" href="%s">%s</a>', esc_attr( $plus_link ), esc_html( 'Event Tickets Plus', 'tribe-common' ) );
+
+		$plus = sprintf(
+			'<a target="_blank" rel="noopener nofollow" href="%s">%s</a>',
+			esc_attr( $plus_link ),
+			esc_html( 'Event Tickets Plus', 'event-tickets' )
+		);
 
 		$plus_commerce_providers = array(
 			esc_html( 'WooCommerce', 'event-tickets' )            => 'woocommerce/woocommerce.php',
 			esc_html( 'Easy Digital Downloads', 'event-tickets' ) => 'easy-digital-downloads/easy-digital-downloads.php',
 		);
+
 		foreach ( $plus_commerce_providers as $provider => $path ) {
 			if ( ! is_plugin_active( $path ) ) {
 				continue;
 			}
 
 			$message = sprintf(
-
 				__( 'Event Tickets does not support ticket sales via third party ecommerce plugins. If you want to sell tickets with %1$s, please purchase a license for %2$s.' ),
 				$provider,
 				$plus

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -32,15 +32,8 @@ class Tribe__Tickets__Admin__Notices {
 
 		$this->maybe_display_plus_commerce_notice();
 
-		/** @var Tribe__Tickets__RSVP $rsvp */
-		$rsvp = tribe( 'tickets.rsvp' );
-
-		// @todo Remove this early return when we are ready to show the opt-in notice in G20.07.
-		if ( ! $rsvp->use_new_views() ) {
-			return;
-		}
-
-		$this->maybe_display_rsvp_new_views_options_notice();
+		// @todo Uncomment this when we are ready to show the opt-in notice in G20.07.
+		// $this->maybe_display_rsvp_new_views_options_notice();
 	}
 
 	/**
@@ -72,6 +65,14 @@ class Tribe__Tickets__Admin__Notices {
 			'tribe-common' === tribe_get_request_var( 'page' )
 			&& 'display' === tribe_get_request_var( 'tab' )
 		) {
+			return;
+		}
+
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		// Bail if the option is already in use.
+		if ( $rsvp->use_new_views() ) {
 			return;
 		}
 

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -37,10 +37,7 @@ extends Tribe__Editor__Blocks__Abstract {
 	 * @return array
 	 */
 	public function default_attributes() {
-
-		$defaults = array();
-
-		return $defaults;
+		return [];
 	}
 
 	/**
@@ -54,23 +51,13 @@ extends Tribe__Editor__Blocks__Abstract {
 	 */
 	public function render( $attributes = array() ) {
 		/** @var Tribe__Tickets__Editor__Template $template */
-		$template                 = tribe( 'tickets.editor.template' );
-		$args['post_id']          = $post_id = $template->get( 'post_id', null, false );
-		$rsvps                    = $this->get_tickets( $post_id );
-		$args['attributes']       = $this->attributes( $attributes );
-		$args['active_rsvps']     = $this->get_active_tickets( $rsvps );
-		$args['has_active_rsvps'] = ! empty( $args['active_rsvps'] );
-		$args['has_rsvps']        = ! empty( $rsvps );
-		$args['all_past']         = $this->get_all_tickets_past( $rsvps );
+		$template = tribe( 'tickets.editor.template' );
 
-		// Add the rendering attributes into global context
-		$template->add_template_globals( $args );
+		$post_id = $template->get( 'post_id', null, false );
 
-		// enqueue assets
-		tribe_asset_enqueue( 'tribe-tickets-gutenberg-rsvp' );
-		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-rsvp-style' );
+		$tickets_view = Tribe__Tickets__Tickets_View::instance();
 
-		return $template->template( array( 'blocks', $this->slug() ), $args, false );
+		return $tickets_view->get_rsvp_block( $post_id );
 	}
 
 	/**
@@ -80,7 +67,7 @@ extends Tribe__Editor__Blocks__Abstract {
 	 *
 	 * @return array
 	 */
-	protected function get_tickets( $post_id ) {
+	public function get_tickets( $post_id ) {
 		$tickets = [];
 
 		// Bail if there's no event id
@@ -124,7 +111,7 @@ extends Tribe__Editor__Blocks__Abstract {
 	 *
 	 * @return array
 	 */
-	protected function get_active_tickets( $tickets ) {
+	public function get_active_tickets( $tickets ) {
 		$active_tickets = array();
 
 		foreach ( $tickets as $ticket ) {
@@ -148,7 +135,7 @@ extends Tribe__Editor__Blocks__Abstract {
 	 *
 	 * @return bool
 	 */
-	protected function get_all_tickets_past( $tickets ) {
+	public function get_all_tickets_past( $tickets ) {
 		if ( empty( $tickets ) ) {
 			return false;
 		}

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -185,6 +185,30 @@ extends Tribe__Editor__Blocks__Abstract {
 			null
 		);
 
+		tribe_asset(
+			$plugin,
+			'tribe-tickets-rsvp',
+			'v2/rsvp.js',
+			array( 'jquery' ),
+			null,
+			array(
+				'localize'     => array(
+					'name' => 'TribeRsvp',
+					'data' => array(
+						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
+					),
+				),
+			)
+		);
+
+		tribe_asset(
+			$plugin,
+			'tribe-tickets-rsvp-style',
+			'app/v2/rsvp/frontend.css',
+			array(),
+			null
+		);
+
 	}
 
 	/**

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -174,7 +174,8 @@ extends Tribe__Editor__Blocks__Abstract {
 						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 					],
 				],
-			] );
+			]
+		);
 
 		tribe_asset(
 			$plugin,
@@ -197,7 +198,8 @@ extends Tribe__Editor__Blocks__Abstract {
 						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
 					],
 				],
-			] );
+			]
+		);
 
 		tribe_asset(
 			$plugin,

--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -165,23 +165,22 @@ extends Tribe__Editor__Blocks__Abstract {
 			$plugin,
 			'tribe-tickets-gutenberg-rsvp',
 			'rsvp-block.js',
-			array( 'jquery' ),
+			[ 'jquery' ],
 			null,
-			array(
-				'localize'     => array(
+			[
+				'localize' => [
 					'name' => 'TribeRsvp',
-					'data' => array(
+					'data' => [
 						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
-					),
-				),
-			)
-		);
+					],
+				],
+			] );
 
 		tribe_asset(
 			$plugin,
 			'tribe-tickets-gutenberg-block-rsvp-style',
 			'app/rsvp/frontend.css',
-			array(),
+			[],
 			null
 		);
 
@@ -189,23 +188,22 @@ extends Tribe__Editor__Blocks__Abstract {
 			$plugin,
 			'tribe-tickets-rsvp',
 			'v2/rsvp.js',
-			array( 'jquery' ),
+			[ 'jquery' ],
 			null,
-			array(
-				'localize'     => array(
+			[
+				'localize' => [
 					'name' => 'TribeRsvp',
-					'data' => array(
+					'data' => [
 						'ajaxurl' => admin_url( 'admin-ajax.php', ( is_ssl() ? 'https' : 'http' ) ),
-					),
-				),
-			)
-		);
+					],
+				],
+			] );
 
 		tribe_asset(
 			$plugin,
 			'tribe-tickets-rsvp-style',
 			'app/v2/rsvp/frontend.css',
-			array(),
+			[],
 			null
 		);
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -22,9 +22,9 @@ class Tribe__Tickets__Query {
 	}
 
 	/**
-	 * @param array $public_query_vars The array of whitelisted query variables.
+	 * @param array $query_vars A list of allowed query variables.
 	 *
-	 * @return array $public_query_vars The array of whitelisted query variables
+	 * @return array $query_vars A list of allowed query variables.
 	 *               plus ours.
 	 */
 	public function filter_query_vars( array $query_vars = array() ) {

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1127,6 +1127,11 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return $content;
 		}
 
+		// Maybe render the new views.
+		if ( $this->use_new_views() ) {
+			return $this->tickets_view->get_rsvp_block( $post );
+		}
+
 		// Check to see if all available tickets' end-sale dates have passed, in which case no form
 		// should show on the front-end.
 		$expired_tickets = 0;
@@ -1207,7 +1212,27 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	 */
 	public function login_required() {
 		$requirements = (array) tribe_get_option( 'ticket-authentication-requirements', array() );
-		return in_array( 'event-tickets_rsvp', $requirements );
+		return in_array( 'event-tickets_rsvp', $requirements, true );
+	}
+
+	/**
+	 * Determine whether to use new RSVP views.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether to use new RSVP views.
+	 */
+	public function use_new_views() {
+		// Determine if ET was installed at version 4.12.2+.
+		$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
+
+		return (
+			(
+				defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' )
+				&& TRIBE_TICKETS_RSVP_NEW_VIEWS
+			)
+			|| (boolean) tribe_get_option( 'rsvp_use_new_views', $should_default_to_on )
+		);
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1128,7 +1128,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		}
 
 		// Maybe render the new views.
-		if ( $this->use_new_views() ) {
+		if ( tribe_tickets_rsvp_new_views_is_enabled() ) {
 			return $this->tickets_view->get_rsvp_block( $post );
 		}
 
@@ -1213,26 +1213,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	public function login_required() {
 		$requirements = (array) tribe_get_option( 'ticket-authentication-requirements', array() );
 		return in_array( 'event-tickets_rsvp', $requirements, true );
-	}
-
-	/**
-	 * Determine whether to use new RSVP views.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool Whether to use new RSVP views.
-	 */
-	public function use_new_views() {
-		// Determine if ET was installed at version 4.12.2+.
-		$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
-
-		return (
-			(
-				defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' )
-				&& TRIBE_TICKETS_RSVP_NEW_VIEWS
-			)
-			|| (boolean) tribe_get_option( 'tickets_rsvp_use_new_views', $should_default_to_on )
-		);
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -1231,7 +1231,7 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 				defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' )
 				&& TRIBE_TICKETS_RSVP_NEW_VIEWS
 			)
-			|| (boolean) tribe_get_option( 'rsvp_use_new_views', $should_default_to_on )
+			|| (boolean) tribe_get_option( 'tickets_rsvp_use_new_views', $should_default_to_on )
 		);
 	}
 

--- a/src/Tribe/Service_Provider.php
+++ b/src/Tribe/Service_Provider.php
@@ -36,6 +36,7 @@ class Tribe__Tickets__Service_Provider extends tad_DI52_ServiceProvider {
 		$this->container->singleton( 'tickets.admin.views', 'Tribe__Tickets__Admin__Views', array( 'hook' ) );
 		$this->container->singleton( 'tickets.admin.columns', 'Tribe__Tickets__Admin__Columns', array( 'hook' ) );
 		$this->container->singleton( 'tickets.admin.screen-options', 'Tribe__Tickets__Admin__Screen_Options', array( 'hook' ) );
+		$this->container->singleton( 'tickets.admin.settings.display', 'Tribe__Tickets__Admin__Display_Settings', array( 'hook' ) );
 
 		// Status Manager
 		$this->container->singleton( 'tickets.status', 'Tribe__Tickets__Status__Manager', array( 'hook' ) );
@@ -84,6 +85,7 @@ class Tribe__Tickets__Service_Provider extends tad_DI52_ServiceProvider {
 			tribe( 'tickets.admin.columns' );
 			tribe( 'tickets.admin.screen-options' );
 			tribe( 'tickets.admin.notices' );
+			tribe( 'tickets.admin.settings.display' );
 		}
 	}
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1092,6 +1092,15 @@ class Tribe__Tickets__Tickets_View {
 		// Add the rendering attributes into global context.
 		$template->add_template_globals( $args );
 
+		// Determine whether to show the previews on the page.
+		if (
+			defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS_PREVIEW' )
+			&& TRIBE_TICKETS_RSVP_NEW_VIEWS_PREVIEW
+		) {
+			// @todo Remove this after G20.07.
+			return $template->template( 'v2/rsvp-kitchen-sink', $args );
+		}
+
 		// Maybe render the new views.
 		if ( $rsvp->use_new_views() ) {
 			// Enqueue new assets.

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1092,12 +1092,15 @@ class Tribe__Tickets__Tickets_View {
 		// Add the rendering attributes into global context.
 		$template->add_template_globals( $args );
 
+		// @todo Remove this after G20.07.
 		// Determine whether to show the previews on the page.
 		if (
 			defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS_PREVIEW' )
 			&& TRIBE_TICKETS_RSVP_NEW_VIEWS_PREVIEW
 		) {
-			// @todo Remove this after G20.07.
+			// Enqueue new assets.
+			tribe_asset_enqueue( 'tribe-tickets-rsvp-style' );
+
 			return $template->template( 'v2/rsvp-kitchen-sink', $args );
 		}
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1057,7 +1057,7 @@ class Tribe__Tickets__Tickets_View {
 		}
 
 		// If password protected then do not display content.
-		if ( post_password_required() ) {
+		if ( post_password_required( $post ) ) {
 			return '';
 		}
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1105,7 +1105,7 @@ class Tribe__Tickets__Tickets_View {
 		}
 
 		// Maybe render the new views.
-		if ( $rsvp->use_new_views() ) {
+		if ( tribe_tickets_rsvp_new_views_is_enabled() ) {
 			// Enqueue new assets.
 			tribe_asset_enqueue( 'tribe-tickets-rsvp' );
 			tribe_asset_enqueue( 'tribe-tickets-rsvp-style' );

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -962,11 +962,11 @@ class Tribe__Tickets__Tickets_View {
 	}
 
 	/**
-	 * Gets the block template "out of context" and makes it useable for non-gutenberg views.
+	 * Gets the Tickets block template "out of context" and makes it usable for Classic views.
 	 *
-	 * @param WP_Post|int $post the post/event we're viewing.
+	 * @param WP_Post|int $post The post object or ID.
 	 *
-	 * @return string HTML.
+	 * @return string The block HTML.
 	 */
 	public function get_tickets_block( $post ) {
 		if ( empty( $post ) ) {
@@ -1029,5 +1029,82 @@ class Tribe__Tickets__Tickets_View {
 		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-tickets-style' );
 
 		return $template->template( 'blocks/tickets', $args );
+	}
+
+	/**
+	 * Gets the RSVP block template "out of context" and makes it usable for Classic views.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post|int $post The post object or ID.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function get_rsvp_block( $post ) {
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		if ( is_numeric( $post ) ) {
+			$post = get_post( $post );
+		}
+
+		if (
+			empty( $post )
+			|| ! ( $post instanceof WP_Post )
+		) {
+			return '';
+		}
+
+		// If password protected then do not display content.
+		if ( post_password_required() ) {
+			return '';
+		}
+
+		$post_id = $post->ID;
+
+		/** @var \Tribe__Tickets__Editor__Template $template */
+		$template = tribe( 'tickets.editor.template' );
+
+		/** @var \Tribe__Tickets__Editor__Blocks__Rsvp $blocks_rsvp */
+		$blocks_rsvp = tribe( 'tickets.editor.blocks.rsvp' );
+
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		// Load assets manually.
+		$blocks_rsvp->assets();
+
+		$tickets        = $blocks_rsvp->get_tickets( $post_id );
+		$active_tickets = $blocks_rsvp->get_active_tickets( $tickets );
+		$past_tickets   = $blocks_rsvp->get_all_tickets_past( $tickets );
+
+		$args = [
+			'post_id'          => $post_id,
+			'attributes'       => $blocks_rsvp->attributes(),
+			'active_rsvps'     => $active_tickets,
+			'all_past'         => $past_tickets,
+			'has_rsvps'        => ! empty( $tickets ),
+			'has_active_rsvps' => ! empty( $active_tickets ),
+			'must_login'       => ! is_user_logged_in() && $rsvp->login_required(),
+		];
+
+		// Add the rendering attributes into global context.
+		$template->add_template_globals( $args );
+
+		// Maybe render the new views.
+		if ( $rsvp->use_new_views() ) {
+			// Enqueue new assets.
+			tribe_asset_enqueue( 'tribe-tickets-rsvp' );
+			tribe_asset_enqueue( 'tribe-tickets-rsvp-style' );
+
+			return $template->template( 'v2/rsvp', $args );
+		}
+
+		// Enqueue assets.
+		tribe_asset_enqueue( 'tribe-tickets-gutenberg-tickets' );
+		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-tickets-style' );
+
+		return $template->template( 'blocks/rsvp', $args );
 	}
 }

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @var array $settings List of display settings.
+ */
+
+// Determine if ET was installed at version 4.12.2+.
+$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.0' );
+
+$settings = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $settings, [
+	'rsvp-display-title'       => [
+		'type' => 'html',
+		'html' => '<h3>' . __( 'RSVP Display Settings', 'event-tickets' ) . '</h3>',
+	],
+	'rsvp-display-description' => [
+		'type' => 'html',
+		'html' => '<p>' . __( 'The settings below control the display of your RSVPs.', 'event-tickets' ) . '</p>',
+	],
+	'rsvp_use_new_views'       => [
+		'type'            => 'checkbox_bool',
+		'label'           => __( 'Enable New RSVP Experience', 'event-tickets' ),
+		'tooltip'         => __( 'This setting will render the new front-end designs (styling) and user-flow for the RSVP experience.', 'event-tickets' ),
+		'validation_type' => 'boolean',
+		'default'         => $should_default_to_on,
+	],
+] );

--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -7,15 +7,15 @@
 $should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.0' );
 
 $settings = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $settings, [
-	'rsvp-display-title'       => [
+	'rsvp-display-title'         => [
 		'type' => 'html',
 		'html' => '<h3>' . __( 'RSVP Display Settings', 'event-tickets' ) . '</h3>',
 	],
-	'rsvp-display-description' => [
+	'rsvp-display-description'   => [
 		'type' => 'html',
 		'html' => '<p>' . __( 'The settings below control the display of your RSVPs.', 'event-tickets' ) . '</p>',
 	],
-	'rsvp_use_new_views'       => [
+	'tickets_rsvp_use_new_views' => [
 		'type'            => 'checkbox_bool',
 		'label'           => __( 'Enable New RSVP Experience', 'event-tickets' ),
 		'tooltip'         => __( 'This setting will render the new front-end designs (styling) and user-flow for the RSVP experience.', 'event-tickets' ),

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1552,3 +1552,41 @@ if ( ! function_exists( 'tribe_tickets_is_enabled_post_context' ) ) {
 		return apply_filters( 'tribe_tickets_is_enabled_post_context', false, $post_types, $context );
 	}
 }
+
+/**
+ * Determine whether new RSVP views are enabled.
+ *
+ * In order the function will check the `TRIBE_TICKETS_RSVP_NEW_VIEWS` constant,
+ * the `TRIBE_TICKETS_RSVP_NEW_VIEWS` environment variable and, finally, the `tickets_rsvp_use_new_views` option.
+ *
+ * @since TBD
+ *
+ * @return boolean Whether new RSVP views are enabled.
+ */
+function tribe_tickets_rsvp_new_views_is_enabled() {
+	// Check for constant.
+	if ( defined( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' ) ) {
+		return (boolean) TRIBE_TICKETS_RSVP_NEW_VIEWS;
+	}
+
+	// Check for env var.
+	$env_var = getenv( 'TRIBE_TICKETS_RSVP_NEW_VIEWS' );
+
+	if ( false !== $env_var ) {
+		return (boolean) $env_var;
+	}
+
+	// Determine if ET was installed at version 4.12.2+.
+	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
+
+	$enabled = (boolean) tribe_get_option( 'tickets_rsvp_use_new_views', $should_default_to_on );
+
+	/**
+	 * Allows filtering whether new RSVP views are enabled.
+	 *
+	 * @since TBD
+	 *
+	 * @param boolean $enabled Whether new RSVP views are enabled.
+	 */
+	return apply_filters( 'tribe_tickets_rsvp_new_views_is_enabled', $enabled );
+}

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1576,6 +1576,9 @@ function tribe_tickets_rsvp_new_views_is_enabled() {
 		return (boolean) $env_var;
 	}
 
+	// @todo Remove this in G20.07
+	return false;
+
 	// Determine if ET was installed at version 4.12.2+.
 	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
 

--- a/tests/_function-mocker-bootstrap.php
+++ b/tests/_function-mocker-bootstrap.php
@@ -36,7 +36,7 @@ if ( ! is_dir( $cache_path ) ) {
 	}
 }
 
-echo( "Function Mocker cache path: {$cache_path}\n" );
+codecept_debug( 'Function Mocker cache path: ' . $cache_path );
 
 /*
  * Let's use exclusions and inclusions to really cover only what we need; we're really interested in catching WordPress

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -11,7 +11,7 @@ modules:
         WPWebDriver:
             # We have to use a URL Chromedriver will be able to resolve.
             # See the `.env` file for more information.
-            url: 'http://%WP_CHROMEDRIVER_URL%'
+            url: %WP_CHROMEDRIVER_URL%
             # see codeception.dist.yml for the configuration
             adminUsername: %WP_ADMIN_USERNAME%
             adminPassword: %WP_ADMIN_PASSWORD%
@@ -19,10 +19,16 @@ modules:
             browser: chrome
             host: %CHROMEDRIVER_HOST%
             port: %CHROMEDRIVER_PORT%
-            window_size: false
+            window_size: 1366x768
             capabilities:
               chromeOptions:
-                args: ["--headless", "--disable-gpu", "--proxy-server='direct://'", "--proxy-bypass-list=*" ]
+                args:
+                  - "--disable-gpu"
+                  - "--proxy-server='direct://'"
+                  - "--proxy-bypass-list=*"
+                  - "--user-agent=tribe-tester"
+                  - "--high-dpi-support=1.0"
+                  - "--force-device-scale-factor=1.0"
         WPDb:
            dsn: 'mysql:host=%WP_DB_HOST%;dbname=%WP_DB_NAME%'
            user: %WP_DB_USER%


### PR DESCRIPTION
[ET-796]
[ET-797]

This PR accomplishes:

- New opt-in setting in admin area (not shown unless dev constant is enabled)
- New opt-in setting method check with support for our dev constant `TRIBE_TICKETS_RSVP_NEW_VIEWS`
- New opt-in notice (commented out from being called for now as it will ship enabled in G20.07)
- RSVP classic now renders new abstracted block render function (if opt-in enabled)
- RSVP block now renders new abstracted block render function
- RSVP abstracted block render function will render the new `v2/rsvp` view if opt-in enabled, otherwise it will render the old `blocks/rsvp` view
- RSVP abstracted block render function now supports new temporary preview constant `TRIBE_TICKETS_RSVP_NEW_VIEWS_PREVIEW` which will show static kitchen sink for themers and customers to use as a guide when preparing their view customizations

[ET-796]: https://moderntribe.atlassian.net/browse/ET-796
[ET-797]: https://moderntribe.atlassian.net/browse/ET-797