### PR TITLE
[ET-797] Enable the opt-in update notice

### DIFF
--- a/src/Tribe/Admin/Display_Settings.php
+++ b/src/Tribe/Admin/Display_Settings.php
@@ -13,8 +13,7 @@ class Tribe__Tickets__Admin__Display_Settings {
 	 * @since TBD
 	 */
 	public function hook() {
-		// @todo Uncomment this in G20.07
-		//add_filter( 'tribe_display_settings_tab_fields', [ $this, 'add_display_settings' ] );
+		add_filter( 'tribe_display_settings_tab_fields', [ $this, 'add_display_settings' ] );
 	}
 
 	/**

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -32,8 +32,7 @@ class Tribe__Tickets__Admin__Notices {
 
 		$this->maybe_display_plus_commerce_notice();
 
-		// @todo Uncomment this when we are ready to show the opt-in notice in G20.07.
-		// $this->maybe_display_rsvp_new_views_options_notice();
+		$this->maybe_display_rsvp_new_views_options_notice();
 	}
 
 	/**
@@ -60,11 +59,13 @@ class Tribe__Tickets__Admin__Notices {
 			return;
 		}
 
+		// Bail if we aren't in Events > Settings.
+		if ( 'tribe-common' !== tribe_get_request_var( 'page' ) ) {
+			return;
+		}
+
 		// Bail if already at wp-admin > Events > Settings > Tickets tab to avoid redundancy/confusion by linking to itself.
-		if (
-			'tribe-common' === tribe_get_request_var( 'page' )
-			&& 'display' === tribe_get_request_var( 'tab' )
-		) {
+		if ( 'display' === tribe_get_request_var( 'tab' ) ) {
 			return;
 		}
 

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1576,9 +1576,6 @@ function tribe_tickets_rsvp_new_views_is_enabled() {
 		return (boolean) $env_var;
 	}
 
-	// @todo Remove this in G20.07
-	return false;
-
 	// Determine if ET was installed at version 4.12.2+.
 	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
 


### PR DESCRIPTION
[ET-797]

Screencast: https://p199.p4.n0.cdn.getcloudapp.com/items/mXuAQJ9Q/Screen%20Recording%202020-07-10%20at%2005.01.51%20PM.mp4

We should hold on this PR until we know the feature will be complete in time for G20.07 to ship. If it doesn't make it, we can just put this PR forward for G20.08.

This PR is based against https://github.com/moderntribe/event-tickets/pull/1712 so the diff on this PR is specific to just showing the notice.

[ET-797]: https://moderntribe.atlassian.net/browse/ET-797