### PR TITLE
RSVP > Add `wp-util` dependency

### DIFF
--- a/src/Tribe/Editor/Blocks/Rsvp.php
+++ b/src/Tribe/Editor/Blocks/Rsvp.php
@@ -233,7 +233,7 @@ extends Tribe__Editor__Blocks__Abstract {
 			$plugin,
 			'tribe-tickets-rsvp-ari',
 			'v2/rsvp-ari.js',
-			[ 'jquery' ],
+			[ 'jquery', 'wp-util' ],
 			null,
 			[
 				'groups'       => 'tribe-tickets-rsvp',


### PR DESCRIPTION
ET-827

We need WP to load utils, for underscores, on the ARI library, so we can use underscores for templating.