### PR TITLE
Fix/et 832 going not going message

### DIFF
--- a/src/views/v2/rsvp/messages/success.php
+++ b/src/views/v2/rsvp/messages/success.php
@@ -15,7 +15,7 @@
  *
  * @since 4.12.3
  *
- * @version 4.12.3
+ * @version TBD
  */
 
 if ( ! in_array( $step, [ 'success', 'opt-in' ], true ) ) {
@@ -25,27 +25,8 @@ if ( ! in_array( $step, [ 'success', 'opt-in' ], true ) ) {
 <div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
 	<?php $this->template( 'v2/components/icons/paper-plane', [ 'classes' => [ 'tribe-tickets__rsvp-message--success-icon' ] ] ); ?>
 
-	<span class="tribe-tickets__rsvp-message-text">
-		<strong>
-			<?php
-			echo esc_html(
-				sprintf(
-					/* Translators: 1: RSVP label. */
-					_x( 'Your %1$s has been received! ', 'blocks rsvp messages success', 'event-tickets' ),
-					tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
-				)
-			);
-			?>
-		</strong>
+	<?php $this->template( 'v2/rsvp/messages/success/going' ); ?>
 
-		<?php
-		echo esc_html(
-			sprintf(
-				/* Translators: 1: RSVP label. */
-				_x( 'Check your email for %1$s confirmation.', 'blocks rsvp messages success', 'event-tickets' ),
-				tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
-			)
-		);
-		?>
-	</span>
+	<?php $this->template( 'v2/rsvp/messages/success/not-going' ); ?>
+
 </div>

--- a/src/views/v2/rsvp/messages/success/going.php
+++ b/src/views/v2/rsvp/messages/success/going.php
@@ -28,7 +28,7 @@ if ( empty( $is_going ) ) {
 		<?php
 		echo esc_html(
 			sprintf(
-				/* Translators: 1: RSVP label. */
+				/* Translators: %1$s: RSVP label. */
 				_x( 'Your %1$s has been received! ', 'blocks rsvp messages success', 'event-tickets' ),
 				tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
 			)
@@ -39,7 +39,7 @@ if ( empty( $is_going ) ) {
 	<?php
 	echo esc_html(
 		sprintf(
-			/* Translators: 1: RSVP label. */
+			/* Translators: %1$s: RSVP label. */
 			_x( 'Check your email for %1$s confirmation.', 'blocks rsvp messages success', 'event-tickets' ),
 			tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
 		)

--- a/src/views/v2/rsvp/messages/success/going.php
+++ b/src/views/v2/rsvp/messages/success/going.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Block: RSVP
+ * Messages Success for Going
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/v2/rsvp/messages/success/going.php
+ *
+ * See more documentation about our Blocks Editor templating system.
+ *
+ * @link {INSERT_ARTICLE_LINK_HERE}
+ *
+ * @var Tribe__Tickets__Ticket_Object $rsvp     The rsvp ticket object.
+ * @var null|bool                     $is_going Whether the user confirmed for going or not-going.
+ *
+ * @since TBD
+ *
+ * @version TBD
+ */
+
+if ( empty( $is_going ) ) {
+	return;
+}
+?>
+
+<span class="tribe-tickets__rsvp-message-text">
+	<strong>
+		<?php
+		echo esc_html(
+			sprintf(
+				/* Translators: 1: RSVP label. */
+				_x( 'Your %1$s has been received! ', 'blocks rsvp messages success', 'event-tickets' ),
+				tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
+			)
+		);
+		?>
+	</strong>
+
+	<?php
+	echo esc_html(
+		sprintf(
+			/* Translators: 1: RSVP label. */
+			_x( 'Check your email for %1$s confirmation.', 'blocks rsvp messages success', 'event-tickets' ),
+			tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
+		)
+	);
+	?>
+</span>

--- a/src/views/v2/rsvp/messages/success/not-going.php
+++ b/src/views/v2/rsvp/messages/success/not-going.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Block: RSVP
+ * Messages Success for Going
+ *
+ * Override this template in your own theme by creating a file at:
+ * [your-theme]/tribe/tickets/v2/rsvp/messages/success/not-going.php
+ *
+ * See more documentation about our Blocks Editor templating system.
+ *
+ * @link {INSERT_ARTICLE_LINK_HERE}
+ *
+ * @var Tribe__Tickets__Ticket_Object $rsvp     The rsvp ticket object.
+ * @var null|bool                     $is_going Whether the user confirmed for going or not-going.
+ *
+ * @since TBD
+ *
+ * @version TBD
+ */
+
+if ( ! empty( $is_going ) ) {
+	return;
+}
+?>
+
+<span class="tribe-tickets__rsvp-message-text">
+	<strong>
+		<?php esc_html_e( 'Thank you for confirming!', 'event-tickets' ); ?>
+	</strong>
+
+	<?php esc_html_e( 'Your RSVP response has been received', 'event-tickets' ); ?>
+
+</span>

--- a/src/views/v2/rsvp/messages/success/not-going.php
+++ b/src/views/v2/rsvp/messages/success/not-going.php
@@ -28,6 +28,6 @@ if ( ! empty( $is_going ) ) {
 		<?php esc_html_e( 'Thank you for confirming!', 'event-tickets' ); ?>
 	</strong>
 
-	<?php esc_html_e( 'Your RSVP response has been received', 'event-tickets' ); ?>
+	<?php esc_html_e( 'Your RSVP response has been received.', 'event-tickets' ); ?>
 
 </span>

--- a/src/views/v2/rsvp/messages/success/not-going.php
+++ b/src/views/v2/rsvp/messages/success/not-going.php
@@ -28,6 +28,12 @@ if ( ! empty( $is_going ) ) {
 		<?php esc_html_e( 'Thank you for confirming!', 'event-tickets' ); ?>
 	</strong>
 
-	<?php esc_html_e( 'Your RSVP response has been received.', 'event-tickets' ); ?>
+	echo esc_html(
+		sprintf(
+			/* Translators: %1$s: RSVP label. */
+			_x( 'Your %1$s response has been received.', 'blocks rsvp messages success', 'event-tickets' ),
+			tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
+		)
+	);
 
 </span>

--- a/src/views/v2/rsvp/messages/success/not-going.php
+++ b/src/views/v2/rsvp/messages/success/not-going.php
@@ -28,6 +28,7 @@ if ( ! empty( $is_going ) ) {
 		<?php esc_html_e( 'Thank you for confirming!', 'event-tickets' ); ?>
 	</strong>
 
+	<?php
 	echo esc_html(
 		sprintf(
 			/* Translators: %1$s: RSVP label. */
@@ -35,5 +36,6 @@ if ( ! empty( $is_going ) ) {
 			tribe_get_rsvp_label_singular( 'blocks_rsvp_messages_success' )
 		)
 	);
+	?>
 
 </span>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/SuccessTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/SuccessTest.php
@@ -15,10 +15,32 @@ class SuccessTest extends WPTestCase {
 	/**
 	 * @test
 	 */
-	public function test_should_render_success_message() {
-		$template     = tribe( 'tickets.editor.template' );
+	public function test_should_render_success_message_going() {
+		$template = tribe( 'tickets.editor.template' );
 
-		$html   = $template->template( $this->partial_path, [ 'step' => 'success' ], false );
+		$args = [
+			'step'     => 'success',
+			'is_going' => true,
+		];
+
+		$html   = $template->template( $this->partial_path, $args, false );
+		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+
+		$this->assertMatchesSnapshot( $html, $driver );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_should_render_success_message_not_going() {
+		$template = tribe( 'tickets.editor.template' );
+
+		$args = [
+			'step'     => 'success',
+			'is_going' => false,
+		];
+
+		$html   = $template->template( $this->partial_path, $args, false );
 		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
 
 		$this->assertMatchesSnapshot( $html, $driver );

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
@@ -4,7 +4,7 @@
 		<strong>
 			You must be logged in to RSVP.
 			<a
-				href="http://localhost:8080/wp-login.php?tribe-tickets__rsvp-100"
+				href="http://localhost:8080/wp-login.php?tribe-tickets__rsvp-5"
 				class="tribe-tickets__rsvp-message-link"
 			>
 				Log in here			</a>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_going__1.php
@@ -1,9 +1,12 @@
 <?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
-	<span class="tribe-tickets__rsvp-message-text">
-		<strong>
-			Your RSVP has been received! 		</strong>
+	
+<span class="tribe-tickets__rsvp-message-text">
+	<strong>
+		Your RSVP has been received! 	</strong>
 
-		Check your email for RSVP confirmation.	</span>
+	Check your email for RSVP confirmation.</span>
+
+	
 </div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
@@ -6,7 +6,7 @@
 	<strong>
 		Thank you for confirming!	</strong>
 
-	Your RSVP response has been received
+	Your RSVP response has been received.
 </span>
 
 </div>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
@@ -1,0 +1,13 @@
+<?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
+	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
+	
+	
+<span class="tribe-tickets__rsvp-message-text">
+	<strong>
+		Thank you for confirming!	</strong>
+
+	Your RSVP response has been received
+</span>
+
+</div>
+';


### PR DESCRIPTION
🎫 ET-832
🎥 https://www.loom.com/share/56679a31efca40c191271570798ee644

Display different messages for Going/Can't go confirmations, like the ticket describes. Dependant on the addition of `$is_going` from the BE.