### PR TITLE
[ET-841] Default RSVP FE to enabled for new installs and don't show the opt-in option

### DIFF
--- a/src/admin-views/tribe-options-display.php
+++ b/src/admin-views/tribe-options-display.php
@@ -3,8 +3,13 @@
  * @var array $settings List of display settings.
  */
 
-// Determine if ET was installed at version 4.12.2+.
+// Determine if ET was installed at version 5.0+.
 $should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.0' );
+
+// Do not show the option for new installs.
+if ( $should_default_to_on ) {
+	return;
+}
 
 $settings = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $settings, [
 	'rsvp-display-title'         => [
@@ -20,6 +25,6 @@ $settings = Tribe__Main::array_insert_before_key( 'tribe-form-content-end', $set
 		'label'           => __( 'Enable New RSVP Experience', 'event-tickets' ),
 		'tooltip'         => __( 'This setting will render the new front-end designs (styling) and user-flow for the RSVP experience.', 'event-tickets' ),
 		'validation_type' => 'boolean',
-		'default'         => $should_default_to_on,
+		'default'         => false,
 	],
 ] );

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1582,8 +1582,8 @@ function tribe_tickets_rsvp_new_views_is_enabled() {
 		return (boolean) $env_var;
 	}
 
-	// Determine if ET was installed at version 4.12.2+.
-	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '4.12.2' );
+	// Determine if ET was installed at version 5.0+.
+	$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets__Main', '5.0' );
 
 	$enabled = (boolean) tribe_get_option( 'tickets_rsvp_use_new_views', $should_default_to_on );
 


### PR DESCRIPTION
[ET-841]

Per Jeff's strategy, we're enabling RSVP FE 2020 views for new installs by default and not showing the opt-in option.

[ET-841]: https://moderntribe.atlassian.net/browse/ET-841