### PR TITLE
[GTRIA-275] Fix/modal button props

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,10 @@ Currently, the following add-ons are available for Event Tickets:
 * Tweak - Removed unused HTML files in the plugin root folder that were there for your reference to our plugin's data collection transparency. This information is included within WordPress' Privacy Guide at /wp-admin/privacy-policy-guide.php [ET-854]
 * Fix - Event Tickets Plus' `[tribe_tickets]` shortcode no longer double-renders the Tickets block when using Classic Editor. The issue was caused by _setting_ `global $post` within `\Tribe\Tickets\Events\Attendees_List::should_hide_optout()`, which was called via the `tribe_tickets_plus_hide_attendees_list_optout` filter. [ET-889]
 
+= [TBD] TBD =
+
+* Fix - Prevent attendee registration modal in block editor from closing when clicking into the modal. [GTRIA-275]
+
 = [4.12.3] 2020-07-28 =
 
 * Feature - Notify promoter for actions (RSVP going, RSVP not going, Event Checkin, Attendee Registered) for RSVP and Tribe Commerce. [ET-860]

--- a/src/modules/blocks/rsvp/attendee-registration/template.js
+++ b/src/modules/blocks/rsvp/attendee-registration/template.js
@@ -43,6 +43,7 @@ const RSVPAttendeeRegistration = ( {
 			onClose={ onClose }
 			onIframeLoad={ onIframeLoad }
 			showHelperText={ ! isCreated }
+			shouldCloseOnClickOutside={ false } // @todo: @paulmskim this is a fix until we can figure out modal closing issue in WP 5.5.
 		/>
 	);
 };

--- a/src/modules/elements/attendees-registration/element.js
+++ b/src/modules/elements/attendees-registration/element.js
@@ -48,6 +48,7 @@ class AttendeesRegistration extends PureComponent {
 			onClose,
 			onIframeLoad,
 			showHelperText,
+			...restProps
 		} = this.props;
 
 		const modalContent = (
@@ -78,6 +79,7 @@ class AttendeesRegistration extends PureComponent {
 					modalTitle={ modalTitle }
 					onClick={ onClick }
 					onClose={ onClose }
+					{ ...restProps }
 				/>
 				{ showHelperText && (
 					<span className="tribe-editor__attendee-registration__helper-text">


### PR DESCRIPTION
**Ticket:** [GTRIA-275]

This PR passes the `shouldCloseOnClickOutside` property down to the WordPress modal component which disables closing by clicking outside.

**Screencast:** https://drive.google.com/file/d/10EeJFXlGK3ahvDx3LGVQI1XEHl5Rilo9/view?usp=sharing

[GTRIA-275]: https://moderntribe.atlassian.net/browse/GTRIA-275