### PR TITLE
[ET-809] Ensure content for RSVP action is returned and not output

### DIFF
--- a/src/Tribe/Events/Attendees_List.php
+++ b/src/Tribe/Events/Attendees_List.php
@@ -291,7 +291,7 @@ class Attendees_List {
 	 *
 	 * @return bool Whether we are showing the attendee list with the block editor.
 	 */
-	private function is_showing_attendee_list_with_blocks( WP_Post $post ) {
+	protected function is_showing_attendee_list_with_blocks( WP_Post $post ) {
 		$has_attendee_list_block     = function_exists( 'has_block' ) ? has_block( 'tribe/attendees', $post ) : false;
 		$has_attendee_list_shortcode = has_shortcode( $post->post_content, 'tribe_attendees_list' );
 
@@ -307,7 +307,7 @@ class Attendees_List {
 	 *
 	 * @return bool Whether we are showing the attendee list with the block editor.
 	 */
-	private function is_showing_attendee_list_with_classical_editor( WP_Post $post ) {
+	protected function is_showing_attendee_list_with_classical_editor( WP_Post $post ) {
 		$is_visible_by_meta          = ! static::is_hidden_on( $post );
 		$has_attendee_list_shortcode = has_shortcode( $post->post_content, 'tribe_attendees_list' );
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1121,12 +1121,16 @@ class Tribe__Tickets__Tickets_View {
 			return $template->template( 'v2/rsvp-kitchen-sink', $args, $echo );
 		}
 
+		ob_start();
+
 		/**
 		 * Allow for the addition of content (namely the "Who's Attending?" list) above the ticket form.
 		 *
 		 * @since 4.5.5
 		 */
 		do_action( 'tribe_tickets_before_front_end_ticket_form' );
+
+		$before_content = ob_get_clean();
 
 		// Maybe render the new views.
 		if ( tribe_tickets_rsvp_new_views_is_enabled() ) {
@@ -1137,13 +1141,13 @@ class Tribe__Tickets__Tickets_View {
 			// @todo: Remove this once we solve the common breakpoints vs container based.
 			tribe_asset_enqueue( 'tribe-common-responsive' );
 
-			return $template->template( 'v2/rsvp', $args, $echo );
+			return $before_content . $template->template( 'v2/rsvp', $args, $echo );
 		}
 
 		// Enqueue assets.
 		tribe_asset_enqueue( 'tribe-tickets-gutenberg-rsvp' );
 		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-rsvp-style' );
 
-		return $template->template( 'blocks/rsvp', $args, $echo );
+		return $before_content . $template->template( 'blocks/rsvp', $args, $echo );
 	}
 }


### PR DESCRIPTION
[ET-809]

Screenshot: https://p199.p4.n0.cdn.getcloudapp.com/items/2NuyEDXJ/Screen%20Shot%202020-08-18%20at%209.44.54%20PM.png?v=90c7323246a06cb816b10d343240cb86

Typo intentional, to show it's using the block even though the event had the classic attendees showing option enabled.

[ET-809]: https://moderntribe.atlassian.net/browse/ET-809