### PR TITLE
[ET-813] Fix view links for RSVP block render by adding logic to get_rsvp_block() method.

### DIFF
--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1130,6 +1130,24 @@ class Tribe__Tickets__Tickets_View {
 		 */
 		do_action( 'tribe_tickets_before_front_end_ticket_form' );
 
+		/**
+		 * A flag we can set via filter, e.g. at the end of this method, to ensure this template only shows once.
+		 *
+		 * @since 4.5.6
+		 *
+		 * @param boolean $already_rendered Whether the order link template has already been rendered.
+		 *
+		 * @see Tribe__Tickets__Tickets_View::inject_link_template()
+		 */
+		$already_rendered = apply_filters( 'tribe_tickets_order_link_template_already_rendered', false );
+
+		// Output order links / view link if we haven't already (for RSVPs).
+		if ( ! $already_rendered ) {
+			$template->template( 'tickets/view-link' );
+
+			add_filter( 'tribe_tickets_order_link_template_already_rendered', '__return_true' );
+		}
+
 		$before_content = ob_get_clean();
 
 		// Maybe echo the content from the action.


### PR DESCRIPTION
[ET-813]

New block view: https://p199.p4.n0.cdn.getcloudapp.com/items/YEuoORb6/Screen%20Shot%202020-08-21%20at%201.51.07%20PM.png?v=acc9e333cf760a02dc1f0758f7e2adba

Old block view: https://p199.p4.n0.cdn.getcloudapp.com/items/E0unjYNJ/Screen%20Shot%202020-08-21%20at%201.51.33%20PM.png?v=322d9cd4df52c17f8e85fa630892922c

The hook used to only run in the old RSVP view file itself, I've added the logic here which won't require a change to the old view file (for now) and won't interfere there either.

[ET-813]: https://moderntribe.atlassian.net/browse/ET-813