### PR TITLE
[ET-907] Remove duplicate `button_id`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 * Fix - Use the correct file path for the modal overrides. It's now correctly using the `your-theme/tribe/tickets/` path. [ETP-432]
 * Fix - More thorough validity checking for post IDs, such as to account for a BuddyPress page having a Post ID of zero. [ET-899]
+* Fix - Remove duplicate `button_id` from the `$args` in `src/blocks/tickets/submit-button-modal.php`. Props @justlevine for the fix! [ET-907]
 
 = [5.0.0.1] 2020-08-31 =
 

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -58,7 +58,6 @@ $args = [
 	'button_disabled'         => true,
 	'button_id'               => 'tribe-tickets__submit',
 	'button_name'             => $provider_id . '_get_tickets',
-	'button_id'               => 'tribe-tickets__submit',
 	'button_text'             => $button_text,
 	'button_type'             => 'submit',
 	'close_event'             => 'tribe_dialog_close_ar_modal',

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -15,9 +15,9 @@
  * @since 4.11.3 Allow filtering of the button classes.
  * @since 4.11.3 Added button ID for better JS targeting.
  * @since 4.12.1 Add support for custom label for "Tickets" plural.
+ * @since TBD Removed duplicate button ID from `$args`.
  *
- * @version 4.12.1
- *
+ * @version TBD
  */
 
 /* translators: %1$s: Event name, %2$s: Tickets label */

--- a/src/views/blocks/tickets/submit-button-modal.php
+++ b/src/views/blocks/tickets/submit-button-modal.php
@@ -50,7 +50,7 @@ $button_classes = apply_filters(
  * @param string $content a string of default content.
  * @param Tribe__Tickets__Editor__Template $template_obj the Template object.
  */
-$content     = apply_filters( 'tribe_events_tickets_attendee_registration_modal_content', '<p>Ticket Modal</p>', $this );
+$content = apply_filters( 'tribe_events_tickets_attendee_registration_modal_content', '<p>Ticket Modal</p>', $this );
 
 $args = [
 	'append_target'           => '#tribe-tickets__modal_target',


### PR DESCRIPTION
🎫 https://moderntribe.atlassian.net/browse/ET-907
🎥 not-required.

Thanks @justlevine for the fix! This is a follow-up of https://github.com/moderntribe/event-tickets/pull/1733, where we couldn't push more changes because the head ref was unknown.