### PR TITLE
[ETP-473] Abstract WPHtmlOutputDriver usage for most cases

### DIFF
--- a/src/views/v2/tickets/commerce/fields.php
+++ b/src/views/v2/tickets/commerce/fields.php
@@ -17,7 +17,7 @@
  * @var string                  $provider_id The tickets provider class name.
  */
 
-$this->template( 'v2/tickets/commerce/fields/' . $provider_id );
+$this->template( 'v2/tickets/commerce/fields/' . $provider->orm_provider );
 
 ?>
 <input name="provider" value="<?php echo esc_attr( $provider->class_name ); ?>" class="tribe-tickets-provider" type="hidden">

--- a/tests/_support/Partials/V2TestCase.php
+++ b/tests/_support/Partials/V2TestCase.php
@@ -3,6 +3,7 @@
 namespace Tribe\Tickets\Test\Partials;
 
 use Codeception\TestCase\WPTestCase;
+use tad\WP\Snapshots\WPHtmlOutputDriver;
 use Spatie\Snapshots\MatchesSnapshots;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
 
@@ -12,9 +13,32 @@ use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
  */
 abstract class V2TestCase extends WPTestCase {
 
-	use MatchesSnapshots;
+	use MatchesSnapshots {
+		assertMatchesSnapshot as _assertMatchesSnapshot;
+	}
+
 	use With_Post_Remapping;
 
 	/** @var string Test site home URL (not HTTPS). */
 	public $base_url = 'http://wordpress.test/';
+
+	/**
+	 * Get the HTML Driver.
+	 *
+	 * @return WPHtmlOutputDriver
+	 */
+	public function get_html_output_driver() {
+		return new WPHtmlOutputDriver( home_url(), $this->base_url );
+	}
+
+	/**
+	 * Override snapshot assertion with support for default driver
+	 *
+	 * @param $html
+	 * @param WPHtmlOutputDriver|null $driver
+	 */
+	public function assertMatchesSnapshot( $html, WPHtmlOutputDriver $driver = null ) {
+		$driver = $driver ? $driver : $this->get_html_output_driver();
+		$this->_assertMatchesSnapshot( $html, $driver );
+	}
 }


### PR DESCRIPTION
[ETP-473]

Updated abstract V2Testcase class to simplify calling 

`
$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );                                                                             
$this->assertMatchesSnapshot( $html, $driver );
` 

to only:

`$this->assertMatchesSnapshot( $html );`




[ETP-473]: https://moderntribe.atlassian.net/browse/ETP-473