### PR TITLE
tests/ETP-471-snapshots-url-constant

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -12,6 +12,7 @@ if( ! defined( 'TRIBE_TESTS_HOME_URL' ) ) {
 	 * Snapshots URL to compare to home_url().
 	 *
 	 * Added to reduce complexity and avoid having to regenerate snapshots simply from switching testing environments.
+	 * If value ever changes, keep in sync with `tests/data/restv1-dump.sql`.
 	 */
 	define( 'TRIBE_TESTS_HOME_URL', 'http://wordpress.test/' );
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -7,6 +7,15 @@ Codeception\Util\Autoload::addNamespace( 'Tribe__Events__WP_UnitTestCase', __DIR
 Codeception\Util\Autoload::addNamespace( 'Tribe\Events\Test', __DIR__ . '/_support' );
 Codeception\Util\Autoload::addNamespace( 'Tribe\Tickets\Test', __DIR__ . '/_support' );
 
+if( ! defined( 'TRIBE_TESTS_HOME_URL' ) ) {
+	/**
+	 * Snapshots URL to compare to home_url().
+	 *
+	 * Added to reduce complexity and avoid having to regenerate snapshots simply from switching testing environments.
+	 */
+	define( 'TRIBE_TESTS_HOME_URL', 'http://wordpress.test/' );
+}
+
 /**
  * Codeception will regenerate snapshots on `--debug`, while the `spatie/snapshot-assertions`
  * library will do the same on `--update-snapshots`.

--- a/tests/_data/restv1-dump.sql
+++ b/tests/_data/restv1-dump.sql
@@ -54,8 +54,8 @@ CREATE TABLE `wp_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-(1, 'siteurl', 'http://test.tribe.dev', 'yes'),
-(2, 'home', 'http://test.tribe.dev', 'yes'),
+(1, 'siteurl', TRIBE_TESTS_HOME_URL, 'yes'),
+(2, 'home', TRIBE_TESTS_HOME_URL, 'yes'),
 (3, 'blogname', 'Tribe Commerce', 'yes'),
 (4, 'blogdescription', 'Just another WordPress site', 'yes'),
 (5, 'users_can_register', '0', 'yes'),

--- a/tests/_data/restv1-dump.sql
+++ b/tests/_data/restv1-dump.sql
@@ -54,8 +54,8 @@ CREATE TABLE `wp_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`) VALUES
-(1, 'siteurl', TRIBE_TESTS_HOME_URL, 'yes'),
-(2, 'home', TRIBE_TESTS_HOME_URL, 'yes'),
+(1, 'siteurl', 'http://wordpress.test/', 'yes'),
+(2, 'home', 'http://wordpress.test/', 'yes'),
 (3, 'blogname', 'Tribe Commerce', 'yes'),
 (4, 'blogdescription', 'Just another WordPress site', 'yes'),
 (5, 'users_can_register', '0', 'yes'),

--- a/tests/_support/Partials/V2TestCase.php
+++ b/tests/_support/Partials/V2TestCase.php
@@ -20,7 +20,7 @@ abstract class V2TestCase extends WPTestCase {
 	use With_Post_Remapping;
 
 	/**
-	 * Get the HTML Driver.
+	 * Get an HTML Driver.
 	 *
 	 * @return WPHtmlOutputDriver
 	 */
@@ -29,9 +29,9 @@ abstract class V2TestCase extends WPTestCase {
 	}
 
 	/**
-	 * Override snapshot assertion with support for default driver
+	 * Override snapshot assertion with support for default driver.
 	 *
-	 * @param $html
+	 * @param string                  $html
 	 * @param WPHtmlOutputDriver|null $driver
 	 */
 	public function assertMatchesSnapshot( $html, WPHtmlOutputDriver $driver = null ) {

--- a/tests/_support/Partials/V2TestCase.php
+++ b/tests/_support/Partials/V2TestCase.php
@@ -19,16 +19,13 @@ abstract class V2TestCase extends WPTestCase {
 
 	use With_Post_Remapping;
 
-	/** @var string Test site home URL (not HTTPS). */
-	public $base_url = 'http://wordpress.test/';
-
 	/**
 	 * Get the HTML Driver.
 	 *
 	 * @return WPHtmlOutputDriver
 	 */
 	public function get_html_output_driver() {
-		return new WPHtmlOutputDriver( home_url(), $this->base_url );
+		return new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 	}
 
 	/**

--- a/tests/_support/Testcases/RSVPBlock_TestCase.php
+++ b/tests/_support/Testcases/RSVPBlock_TestCase.php
@@ -67,7 +67,7 @@ class RSVPBlock_TestCase extends TicketsBlock_TestCase {
 
 		$html = $rsvp_block->render();
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $post_id ] );
 		$driver->setTimeDependentAttributes( [
@@ -105,7 +105,7 @@ class RSVPBlock_TestCase extends TicketsBlock_TestCase {
 
 		$html = $rsvp_block->render();
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $post_id ] );
 		$driver->setTimeDependentAttributes( [

--- a/tests/_support/Testcases/TicketsBlock_TestCase.php
+++ b/tests/_support/Testcases/TicketsBlock_TestCase.php
@@ -167,7 +167,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 		] );
 
 		// Remove the URL + port so it doesn't conflict with URL tolerances.
-		$html = str_replace( 'http://localhost:8080', TRIBE_TESTS_HOME_URL, $html );
+		$html = str_replace( home_url(), TRIBE_TESTS_HOME_URL, $html );
 
 		$this->assertNotEmpty( $html, 'Tickets block is not rendering' );
 		$this->assertMatchesSnapshot( $html, $driver );
@@ -227,7 +227,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 		] );
 
 		// Remove the URL + port so it doesn't conflict with URL tolerances.
-		$html = str_replace( 'http://localhost:8080', TRIBE_TESTS_HOME_URL, $html );
+		$html = str_replace( home_url(), TRIBE_TESTS_HOME_URL, $html );
 
 		$this->assertNotEmpty( $html, 'Tickets block is not rendering' );
 		$this->assertMatchesSnapshot( $html, $driver );

--- a/tests/_support/Testcases/TicketsBlock_TestCase.php
+++ b/tests/_support/Testcases/TicketsBlock_TestCase.php
@@ -138,7 +138,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 
 		$html = $tickets_view->get_tickets_block( get_post( $post_id ) );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [
 			$ticket_id,
@@ -163,7 +163,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 		] );
 
 		// Remove the URL + port so it doesn't conflict with URL tolerances.
-		$html = str_replace( 'http://localhost:8080', 'http://test.tribe.dev', $html );
+		$html = str_replace( 'http://localhost:8080', TRIBE_TESTS_HOME_URL, $html );
 
 		$this->assertNotEmpty( $html, 'Tickets block is not rendering' );
 		$this->assertMatchesSnapshot( $html, $driver );
@@ -200,7 +200,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 
 		$html = $tickets_view->get_tickets_block( get_post( $post_id ) );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [
 			$ticket_id,
@@ -223,7 +223,7 @@ class TicketsBlock_TestCase extends WPTestCase {
 		] );
 
 		// Remove the URL + port so it doesn't conflict with URL tolerances.
-		$html = str_replace( 'http://localhost:8080', 'http://test.tribe.dev', $html );
+		$html = str_replace( 'http://localhost:8080', TRIBE_TESTS_HOME_URL, $html );
 
 		$this->assertNotEmpty( $html, 'Tickets block is not rendering' );
 		$this->assertMatchesSnapshot( $html, $driver );

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/Frontend/Tickets_FormTest.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/Frontend/Tickets_FormTest.php
@@ -26,7 +26,7 @@ class Tickets_FormTest extends \Codeception\TestCase\WPTestCase {
 			return [ 'post' ];
 		} );
 		add_filter( 'tribe_tickets_commerce_paypal_is_active', '__return_true' );
-		$this->driver = new WPHtmlOutputDriver( home_url(), 'http://commerce.dev' );
+		$this->driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 	}
 
 	public function tearDown() {

--- a/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/PayPal/LinksTest.php
@@ -14,7 +14,7 @@ class LinksTest extends \Codeception\TestCase\WPTestCase {
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
-		self::$driver = new WPHtmlOutputDriver( home_url(), 'http://commerce.dev' );
+		self::$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/Partials/RSVP/ContentTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/RSVP/ContentTest.php
@@ -44,7 +44,7 @@ class Content extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -85,7 +85,7 @@ class Content extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -124,7 +124,7 @@ class Content extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/RSVP/Details/DescriptionTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/RSVP/Details/DescriptionTest.php
@@ -36,7 +36,7 @@ class Description extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 
@@ -59,7 +59,7 @@ class Description extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/RSVP/Details/TitleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/RSVP/Details/TitleTest.php
@@ -33,7 +33,7 @@ class Title extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/RSVP/FormTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/RSVP/FormTest.php
@@ -38,7 +38,7 @@ class Form extends WPTestCase {
 
 		$html = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/RSVP/StatusTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/RSVP/StatusTest.php
@@ -42,7 +42,7 @@ class Status extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTimeDependentAttributes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/Tickets/ContentDescriptionTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/Tickets/ContentDescriptionTest.php
@@ -62,7 +62,7 @@ class ContentDescription extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -100,7 +100,7 @@ class ContentDescription extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -138,7 +138,7 @@ class ContentDescription extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/Tickets/ExtraTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/Tickets/ExtraTest.php
@@ -64,7 +64,7 @@ class Extra extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -104,7 +104,7 @@ class Extra extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -144,7 +144,7 @@ class Extra extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -184,7 +184,7 @@ class Extra extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/Tickets/SubmitTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/Tickets/SubmitTest.php
@@ -27,7 +27,7 @@ class SubmitTest extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -60,7 +60,7 @@ class SubmitTest extends WPTestCase {
 
 		$html     = $template->template( $this->partial_path, $args, false );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [

--- a/tests/wpunit/Tribe/Tickets/Partials/Tickets/__snapshots__/SubmitTest__test_should_render_must_login__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/Tickets/__snapshots__/SubmitTest__test_should_render_must_login__1.php
@@ -1,3 +1,3 @@
-<?php return '<a class="tribe-common-c-btn tribe-common-c-btn--small" href="http://test.tribe.dev/wp-login.php">
+<?php return '<a class="tribe-common-c-btn tribe-common-c-btn--small" href="http://wordpress.test/wp-login.php">
 	Log in to purchase</a>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
@@ -2,7 +2,6 @@
 
 namespace Tribe\Tickets\Partials\V2\Attendee_Registration\Button;
 
-use tad\WP\Snapshots\WPHtmlOutputDriver;
 use Tribe\Tickets\Test\Partials\V2TestCase;
 use Tribe__Tickets__Editor__Template;
 
@@ -28,10 +27,9 @@ class Back_To_CartTest extends V2TestCase {
 			'provider'     => 'any-provider',
 		];
 
-		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
+		$html = $template->template( $this->partial_path, $args, false );
 
-		$this->assertMatchesSnapshot( $html, $driver );
+		$this->assertMatchesSnapshot( $html );
 	}
 
 	/**
@@ -47,10 +45,9 @@ class Back_To_CartTest extends V2TestCase {
 			'provider'     => 'any-provider',
 		];
 
-		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
+		$html = $template->template( $this->partial_path, $args, false );
 
-		$this->assertMatchesSnapshot( $html, $driver );
+		$this->assertMatchesSnapshot( $html );
 	}
 
 	/**
@@ -66,9 +63,8 @@ class Back_To_CartTest extends V2TestCase {
 			'provider'     => 'any-provider',
 		];
 
-		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
+		$html = $template->template( $this->partial_path, $args, false );
 
-		$this->assertMatchesSnapshot( $html, $driver );
+		$this->assertMatchesSnapshot( $html );
 	}
 }

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
@@ -24,12 +24,12 @@ class Back_To_CartTest extends V2TestCase {
 
 		$args = [
 			'cart_url'     => '',
-			'checkout_url' => $this->base_url . 'checkout/?anything',
+			'checkout_url' => TRIBE_TESTS_HOME_URL . 'checkout/?anything',
 			'provider'     => 'any-provider',
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), $this->base_url );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -42,13 +42,13 @@ class Back_To_CartTest extends V2TestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$args = [
-			'cart_url'     => $this->base_url . 'checkout/?anything',
-			'checkout_url' => $this->base_url . 'checkout/?anything',
+			'cart_url'     => TRIBE_TESTS_HOME_URL . 'checkout/?anything',
+			'checkout_url' => TRIBE_TESTS_HOME_URL . 'checkout/?anything',
 			'provider'     => 'any-provider',
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), $this->base_url );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -61,13 +61,13 @@ class Back_To_CartTest extends V2TestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$args = [
-			'cart_url'     => $this->base_url . 'cart/?anything',
-			'checkout_url' => $this->base_url . 'checkout/?something-else',
+			'cart_url'     => TRIBE_TESTS_HOME_URL . 'cart/?anything',
+			'checkout_url' => TRIBE_TESTS_HOME_URL . 'checkout/?something-else',
 			'provider'     => 'any-provider',
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), $this->base_url );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
@@ -67,4 +67,13 @@ class Back_To_CartTest extends V2TestCase {
 
 		$this->assertMatchesSnapshot( $html );
 	}
+
+	/**
+	 * @test
+	 */
+	public function test_see_values() {
+		$x = sprintf( '%s__%s__%s', getenv( 'WP_URL' ), home_url(), TRIBE_TESTS_HOME_URL );
+
+		$this->assertMatchesSnapshot( $x );
+	}
 }

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/Back_To_CartTest.php
@@ -53,6 +53,15 @@ class Back_To_CartTest extends V2TestCase {
 	/**
 	 * @test
 	 */
+	public function test_see_values() {
+		$x = sprintf( '%s__%s__%s', getenv( 'WP_URL' ), home_url(), TRIBE_TESTS_HOME_URL );
+
+		$this->assertMatchesSnapshot( $x );
+	}
+
+	/**
+	 * @test
+	 */
 	public function test_should_render_successfully() {
 		/** @var Tribe__Tickets__Editor__Template $template */
 		$template = tribe( 'tickets.editor.template' );
@@ -66,14 +75,5 @@ class Back_To_CartTest extends V2TestCase {
 		$html = $template->template( $this->partial_path, $args, false );
 
 		$this->assertMatchesSnapshot( $html );
-	}
-
-	/**
-	 * @test
-	 */
-	public function test_see_values() {
-		$x = sprintf( '%s__%s__%s', getenv( 'WP_URL' ), home_url(), TRIBE_TESTS_HOME_URL );
-
-		$this->assertMatchesSnapshot( $x );
 	}
 }

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/SubmitTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/SubmitTest.php
@@ -23,7 +23,7 @@ class SubmitTest extends V2TestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$html   = $template->template( $this->partial_path, [], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/__snapshots__/Back_To_CartTest__test_see_values__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Attendee_Registration/Button/__snapshots__/Back_To_CartTest__test_see_values__1.php
@@ -1,0 +1,1 @@
+<?php return 'http://wordpress.test__http://wordpress.test__http://wordpress.test/';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/ErrorTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/ErrorTest.php
@@ -19,7 +19,7 @@ class ErrorTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -31,7 +31,7 @@ class ErrorTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [ 'css-test-class' ] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/GuestTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/GuestTest.php
@@ -19,7 +19,7 @@ class GuestTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -31,7 +31,7 @@ class GuestTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [ 'css-test-class' ] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/PaperPlaneTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Icons/PaperPlaneTest.php
@@ -19,7 +19,7 @@ class PaperPlaneTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -31,7 +31,7 @@ class PaperPlaneTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [ 'css-test-class' ] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Loader/LoaderTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Components/Loader/LoaderTest.php
@@ -19,7 +19,7 @@ class LoaderTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -31,7 +31,7 @@ class LoaderTest extends WPTestCase {
 
 		$template = tribe( 'tickets.editor.template' );
 		$html     = $template->template( $this->partial_path, [ 'classes' => [ 'css-test-class' ] ], false );
-		$driver   = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver   = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/GuestListTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/GuestListTest.php
@@ -43,7 +43,7 @@ class GuestListTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[
@@ -77,7 +77,7 @@ class GuestListTest extends WPTestCase {
 			]
 		);
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		// Note: The tolerable differences for prefix/postfix are not working as expected here, this is a hack.
 		$html = str_replace(

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/QuantityTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/QuantityTest.php
@@ -42,7 +42,7 @@ class QuantityTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
 			'quantity_',

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/TitleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/Sidebar/TitleTest.php
@@ -41,7 +41,7 @@ class TitleTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/SidebarTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ARI/SidebarTest.php
@@ -42,7 +42,7 @@ class SidebarTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes(
 			[

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/FullTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/FullTest.php
@@ -20,7 +20,7 @@ class FullTest extends WPTestCase {
 		$_GET['step'] = 'success';
 
 		$html   = $template->template( $this->partial_path, [], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/RsvpTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/RsvpTest.php
@@ -44,7 +44,7 @@ class RsvpTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -76,7 +76,7 @@ class RsvpTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/TitleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/TitleTest.php
@@ -19,7 +19,7 @@ class TitleTest extends WPTestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$html   = $template->template( $this->partial_path, [ 'is_going' => true ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -31,7 +31,7 @@ class TitleTest extends WPTestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$html   = $template->template( $this->partial_path, [ 'is_going' => false ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/ToggleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/ToggleTest.php
@@ -48,7 +48,7 @@ class ToggleTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[
@@ -110,7 +110,7 @@ class ToggleTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/TooltipTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/Success/TooltipTest.php
@@ -36,7 +36,7 @@ class TooltipTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/SuccessTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/SuccessTest.php
@@ -50,7 +50,7 @@ class SuccessTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		/*$html = str_replace(
 			[

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ActionsTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/ActionsTest.php
@@ -51,7 +51,7 @@ class ActionsTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[
@@ -102,7 +102,7 @@ class ActionsTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[
@@ -151,7 +151,7 @@ class ActionsTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[
@@ -202,7 +202,7 @@ class ActionsTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences(
 			[

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/AttendanceTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/AttendanceTest.php
@@ -47,7 +47,7 @@ class AttendanceTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -81,7 +81,7 @@ class AttendanceTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/AvailabilityTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/AvailabilityTest.php
@@ -71,7 +71,7 @@ class AvailabilityTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -101,7 +101,7 @@ class AvailabilityTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -135,7 +135,7 @@ class AvailabilityTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -166,7 +166,7 @@ class AvailabilityTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/DescriptionTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/DescriptionTest.php
@@ -36,7 +36,7 @@ class DescriptionTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 
@@ -59,7 +59,7 @@ class DescriptionTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/TitleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Details/TitleTest.php
@@ -33,7 +33,7 @@ class TitleTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/ButtonsTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/ButtonsTest.php
@@ -46,7 +46,7 @@ class ButtonsTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/FormTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/FormTest.php
@@ -45,7 +45,7 @@ class FormTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes(
 			[
@@ -89,7 +89,7 @@ class FormTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 		$driver->setTolerableDifferences( [ $ticket_id, $event_id ] );
 		$driver->setTolerableDifferencesPrefixes(
 			[

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/TitleTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Form/TitleTest.php
@@ -20,7 +20,7 @@ class TitleTest extends WPTestCase {
 		$_GET['step'] = 'going';
 
 		$html   = $template->template( $this->partial_path, [ 'going' => 'going' ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -33,7 +33,7 @@ class TitleTest extends WPTestCase {
 		$_GET['step'] = 'going';
 
 		$html   = $template->template( $this->partial_path, [ 'going' => 'not-going' ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/MustLoginTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/MustLoginTest.php
@@ -44,8 +44,8 @@ class MustLoginTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
-		$driver->setTolerableDifferences( [ $ticket_id, $event_id, home_url(), 'http://wordpress.test' ] );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
+		$driver->setTolerableDifferences( [ $ticket_id, $event_id, home_url(), TRIBE_TESTS_HOME_URL ] );
 
 		$driver->setTolerableDifferencesPrefixes(
 			[
@@ -63,7 +63,7 @@ class MustLoginTest extends WPTestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$html   = $template->template( $this->partial_path, [ 'must_login' => false ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://wordpress.test' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/MustLoginTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/MustLoginTest.php
@@ -39,7 +39,7 @@ class MustLoginTest extends WPTestCase {
 
 		$args = [
 			'must_login' => true,
-			'login_url'  => 'http://localhost:8080/wp-login.php',
+			'login_url'  => home_url( 'wp-login.php' ),
 			'rsvp'       => $ticket,
 		];
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/SuccessTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/SuccessTest.php
@@ -24,7 +24,7 @@ class SuccessTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -41,7 +41,7 @@ class SuccessTest extends WPTestCase {
 		];
 
 		$html   = $template->template( $this->partial_path, $args, false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -53,7 +53,7 @@ class SuccessTest extends WPTestCase {
 		$template = tribe( 'tickets.editor.template' );
 
 		$html   = $template->template( $this->partial_path, [ 'step' => null ], false );
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
@@ -4,7 +4,7 @@
 		<strong>
 			You must be logged in to RSVP.
 			<a
-				href="http://localhost:8080/wp-login.php?tribe-tickets__rsvp-5"
+				href="http://wordpress.test/wp-login.php?tribe-tickets__rsvp-192"
 				class="tribe-tickets__rsvp-message-link"
 			>
 				Log in here			</a>

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -692,7 +692,7 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 			return;
 		}
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$driver->setTolerableDifferences( [ $post_id, $ticket_id ] );
 		$driver->setTolerableDifferencesPrefixes( [
@@ -930,7 +930,7 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 
 		$html = $sut->render_rsvp_error( 'There was an error here' );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -949,7 +949,7 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 			'There was an error over on the other side too',
 		] );
 
-		$driver = new WPHtmlOutputDriver( home_url(), 'http://test.tribe.dev' );
+		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}


### PR DESCRIPTION
🎫 [ETP-471]

Just changing constant:

![image](https://user-images.githubusercontent.com/1812179/94517115-e02eb880-01ec-11eb-8972-4d359b65e133.png)

Then changing to use parent class' driver:

![image](https://user-images.githubusercontent.com/1812179/94517586-e3767400-01ed-11eb-9c47-399e0aa464da.png)

After standardizing _all_ snapshot URLs to use the new constant, I expected more than just one to fail:

![image](https://user-images.githubusercontent.com/1812179/94518103-eb82e380-01ee-11eb-9765-16923b203ac8.png)

But regenerating just that one made it work...

![image](https://user-images.githubusercontent.com/1812179/94518188-14a37400-01ef-11eb-9b7f-72277c3d0814.png)


...as well as _all_ the Partials tests:

![image](https://user-images.githubusercontent.com/1812179/94518339-5df3c380-01ef-11eb-828d-579240a22bab.png)


[ETP-471]: https://moderntribe.atlassian.net/browse/ETP-471