### PR TITLE
Move AR page JS to ET+ for V2.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -98,6 +98,26 @@ class Tribe__Tickets__Assets {
 					],
 				]
 			);
+		} else {
+
+			// Tickets registration page scripts.
+			tribe_asset(
+				$tickets_main,
+				'tribe-tickets-registration-page-scripts',
+				'tickets-registration-page.js',
+				[
+					'jquery',
+					'wp-util',
+					'tribe-common',
+				],
+				null,
+				[
+					'groups' => [
+						'tribe-tickets-registration-page',
+					],
+				]
+			);
+
 		}
 
 		// Tickets registration page styles.
@@ -113,25 +133,6 @@ class Tribe__Tickets__Assets {
 				],
 			]
 		);
-
-		// Tickets registration page scripts.
-		tribe_asset(
-			$tickets_main,
-			'tribe-tickets-registration-page-scripts',
-			'tickets-registration-page.js',
-			[
-				'jquery',
-				'wp-util',
-				'tribe-common',
-			],
-			null,
-			[
-				'groups' => [
-					'tribe-tickets-registration-page',
-				],
-			]
-		);
-
 	}
 
 	/**


### PR DESCRIPTION
🎫 ETP-457
🎥 not required.

Only use the v1 JS for the v1 views. Scripts for v2 will live in ET+.