### PR TITLE
Revert changed class name to keep compatibility with V1 templates

### DIFF
--- a/src/resources/postcss/tickets-registration-page.pcss
+++ b/src/resources/postcss/tickets-registration-page.pcss
@@ -186,7 +186,7 @@ body.page-tribe-attendee-registration {
 				-ms-grid-columns: 6fr 1fr 2fr 2fr;
 				grid-template-columns: 6fr 1fr 2fr 2fr;
 
-				&.tribe-tickets__item--price-suffix {
+				&.tribe-tickets__item--price-sufix {
 					-ms-grid-columns: 4fr 3fr 2fr 2fr;
 					grid-template-columns: 4fr 3fr 2fr 2fr;
 				}


### PR DESCRIPTION
[ET-916]

### **Before the fix:**
<img width="1194" alt="Markup 2020-10-23 at 23 06 52" src="https://user-images.githubusercontent.com/7523321/97033711-95068c00-1585-11eb-9624-9dc7d579e2e9.png">

### After the fix:

<img width="1399" alt="Markup 2020-10-23 at 22 50 44" src="https://user-images.githubusercontent.com/7523321/97033877-d4cd7380-1585-11eb-850b-ebf5e8d12ec9.png">


[ET-916]: https://moderntribe.atlassian.net/browse/ET-916

### 📹 🗒️ Screencast with Testing instructions: http://p.tri.be/TquaPf

