### PR TITLE
Add 4th arg (__CLASS__) to hook which is now required by IAC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ cache:
     - $HOME/.composer/cache
 
 before_install:
+  # Install version 1 of Composer.
+  - composer self-update --rollback
+
   # Sourcing the .env file will make sure we use, in the environment configuration, the same variables the tests are using.
   - set -o allexport; source .env; set +o allexport;
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [5.0.3] TBD =
 
-
+* Tweak - Added the calling class as a string to the list of arguments passed in the `tribe_tickets_ticket_add` action. [ETP-389]
 
 = [5.0.2] 2020-10-19 =
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2981,8 +2981,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 * @param int $post_id ID of parent "event" post
 			 * @param Tribe__Tickets__Ticket_Object $ticket Ticket object
 			 * @param array $data Submitted post data
+			 * @param string $class Commerce engine class.
 			 */
-			do_action( 'tribe_tickets_ticket_add', $post_id, $ticket, $data );
+			do_action( 'tribe_tickets_ticket_add', $post_id, $ticket, $data, __CLASS__ );
 
 			$tickets_handler->toggle_manual_update_flag( false );
 


### PR DESCRIPTION
This requirement was added in [this PR](https://github.com/moderntribe/event-tickets-plus/pull/1058). The addition does not require an artifact other than the passing tests of the aforementioned PR.

See: https://github.com/moderntribe/event-tickets-plus/pull/1058