### PR TITLE
[ETP-436] Abstract the security code generation

### DIFF
--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -3085,21 +3085,6 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		tribe_exit();
 	}
 
-    /**
-     * Generates the validation code that will be printed in the ticket.
-     *
-     * Its purpose is to be used to validate the ticket at the door of an event.
-     *
-     * @since 4.7
-     *
-     * @param int $attendee_id
-     *
-     * @return string
-     */
-    public function generate_security_code( $attendee_id ) {
-        return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
-    }
-
 	/**
 	 * If other modules are active, we should deprioritize this one (we want other commerce
 	 * modules to take priority over this one).

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -2764,21 +2764,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 	}
 
 	/**
-	 * Generates the validation code that will be printed in the ticket.
-	 *
-	 * Its purpose is to be used to validate the ticket at the door of an event.
-	 *
-	 * @since 4.7
-	 *
-	 * @param int $attendee_id
-	 *
-	 * @return string
-	 */
-	public function generate_security_code( $attendee_id ) {
-		return substr( md5( rand() . '_' . $attendee_id ), 0, 10 );
-	}
-
-	/**
 	 * Ensure we update the stock when deleting attendees from the admin side
 	 * @since 4.7.4
 	 *

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -291,6 +291,15 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		public $email = '_tribe_tickets_email';
 
 		/**
+		 * Meta key that holds the security code that is used for printed tickets and QR codes.
+		 *
+		 * @since TBD
+		 *
+		 * @var string
+		 */
+		public $security_code = '_tribe_tickets_security_code';
+
+		/**
 		 * The provider used for Attendees and Tickets ORM.
 		 *
 		 * @var string
@@ -3685,6 +3694,19 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			 * @param string|false $provider        Current ticket provider or false if not set.
 			 */
 			return (array) apply_filters( 'tribe_tickets_tickets_in_cart', [], $provider );
+		}
+
+		/**
+		 * Generates the security code that will be used for printed tickets and QR codes.
+		 *
+		 * @since 4.7
+		 *
+		 * @param string $attendee_id The attendee ID or another string to based the security code off of.
+		 *
+		 * @return string The generated security code.
+		 */
+		public function generate_security_code( $attendee_id ) {
+			return substr( md5( wp_rand() . '_' . $attendee_id ), 0, 10 );
 		}
 
 		/**


### PR DESCRIPTION
[ETP-436]

Dev screencast in use: https://share.skc.dev/GGur1rRj

This abstracts the security code generation and the security code meta key property so that it can better be reused. Right now, all providers have their own implementation and this makes sure they get generated more randomly and secured.

[ETP-436]: https://moderntribe.atlassian.net/browse/ETP-436