### PR TITLE
[ET-943] Prevent PHP notices about $going not being set

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ Currently, the following add-ons are available for Event Tickets:
 * Fix - Calculation fixed for attendee count percentage column while using RSVP only. [ET-876]
 * Fix - Correct specificity of checkboxes and radio buttons styles to prevent conflicts with other Modern Tribe plugins. [ET-922]
 * Fix - Ensure shared capacity stock does not reset while updating ticket. [ETP-562]
+* Fix - Prevent PHP notices about `$going` not being set in certain template views which would prevent the "Not Going" text from showing up. [ET-943]
 * Tweak - Add help section update notice texts for updated directory structure. [ET-929]
 
 = [5.0.2] 2020-10-19 =

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -1202,6 +1202,7 @@ class Tribe__Tickets__Tickets_View {
 			'opt_in_nonce'        => '',
 			'doing_shortcode'     => $doing_shortcode,
 			'block_html_id'       => $block_html_id,
+			'going'               => tribe_get_request_var( 'going', '' ),
 		];
 
 		/**


### PR DESCRIPTION
[ET-943]

Dev screenshot: https://p199.p4.n0.cdn.getcloudapp.com/items/geuqLROk/Screen%20Shot%202020-11-12%20at%207.23.42%20PM.png?v=11304a0b7bace2b3564b652616941b0a

$going wasn't set and isn't passed to any of the main areas of the v1 templates, this adds it so it can be utilized further down in the templates without modifying any views

[ET-943]: https://moderntribe.atlassian.net/browse/ET-943