### PR TITLE
[ET-964] Require Event Tickets Plus 5.1.0.1+

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
 Plugin Name: Event Tickets
 Plugin URI:  http://m.tri.be/1acb
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 5.0.3
+Version: 5.0.3.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: ModernTribe, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, bordoni, borkweb, cliffpaulick, GeoffBel, geoffgraham, jentheo, leahkoerper, lucatume, neillmcshea, patriciahillebrandt, peterchester, reid.peifer, shane.pearlman, vicskf, zbtirrell, juanfra
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 4.9.14
-Tested up to: 5.5.1
+Tested up to: 5.5.3
 Stable tag: 5.0.3.1
 Requires PHP: 5.6
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -121,6 +121,7 @@ Currently, the following add-ons are available for Event Tickets:
 = [5.0.3.1] 2020-11-19 =
 
 * Fix - Require Event Tickets Plus 5.1+ for compatibility purposes on certain areas in Event Tickets that have direct calls to Event Tickets Plus functionality. [ET-964]
+* Tweak - Changed views: `blocks/tickets/submit`
 
 = [5.0.3] 2020-11-19 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Currently, the following add-ons are available for Event Tickets:
 
 = [5.0.3.1] 2020-11-19 =
 
-* Fix - Require Event Tickets Plus 5.1+ for compatibility purposes on certain areas in Event Tickets that have direct calls to Event Tickets Plus functionality.
+* Fix - Require Event Tickets Plus 5.1+ for compatibility purposes on certain areas in Event Tickets that have direct calls to Event Tickets Plus functionality. [ET-964]
 
 = [5.0.3] 2020-11-19 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, 
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 4.9.14
 Tested up to: 5.5.1
-Stable tag: 5.0.3
+Stable tag: 5.0.3.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -117,6 +117,10 @@ Currently, the following add-ons are available for Event Tickets:
 * [Eventbrite Tickets](http://m.tri.be/2e), for selling tickets to your event directly through Eventbrite.
 
 == Changelog ==
+
+= [5.0.3.1] 2020-11-19 =
+
+* Fix - Require Event Tickets Plus 5.1+ for compatibility purposes on certain areas in Event Tickets that have direct calls to Event Tickets Plus functionality.
 
 = [5.0.3] 2020-11-19 =
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -301,6 +301,11 @@ class Tribe__Tickets__Assets {
 	public function should_enqueue_frontend() {
 		$is_on_valid_post_type = tribe_tickets_is_enabled_post_context();
 
+		/**
+		 * This Try/Catch is present to deal with a problem on Autoloading from version 5.1.0 ET+ with ET 5.0.3.
+		 *
+		 * @todo Needs to be revised once proper autoloading rules are done for Common, ET and ET+.
+		 */
 		try {
 			/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
 			$ar_reg = tribe( 'tickets.attendee_registration' );

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -301,10 +301,14 @@ class Tribe__Tickets__Assets {
 	public function should_enqueue_frontend() {
 		$is_on_valid_post_type = tribe_tickets_is_enabled_post_context();
 
-		/** @var Tribe__Tickets__Attendee_Registration__Main $ar */
-		$ar = tribe( 'tickets.attendee_registration' );
+		try {
+			/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
+			$ar_reg = tribe( 'tickets.attendee_registration' );
+		} catch ( \Exception $exception ) {
+			return false;
+		}
 
-		return $is_on_valid_post_type || $ar->is_on_page();
+		return $is_on_valid_post_type || $ar_reg->is_on_page();
 	}
 
 	/**

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -309,11 +309,13 @@ class Tribe__Tickets__Assets {
 		try {
 			/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
 			$ar_reg = tribe( 'tickets.attendee_registration' );
+
+			$is_on_ar_page = $ar_reg->is_on_page();
 		} catch ( \Exception $exception ) {
-			return false;
+			$is_on_ar_page = false;
 		}
 
-		return $is_on_valid_post_type || $ar_reg->is_on_page();
+		return $is_on_valid_post_type || $is_on_ar_page;
 	}
 
 	/**

--- a/src/Tribe/Attendee_Registration/Service_Provider.php
+++ b/src/Tribe/Attendee_Registration/Service_Provider.php
@@ -16,8 +16,7 @@ class Tribe__Tickets__Attendee_Registration__Service_Provider extends tad_DI52_S
 		$this->container->singleton( 'tickets.attendee_registration.shortcode', Tribe__Tickets__Attendee_Registration__Shortcode::class );
 		$this->container->singleton( 'tickets.attendee_registration.modal', Tribe__Tickets__Attendee_Registration__Modal::class );
 
-		// Priority 45 to be before priority 50 used on the same action in hooks().
-		add_action( 'tribe_plugins_loaded', [ $this, 'hooks' ], 45 );
+		$this->hooks();
 	}
 
 	/**
@@ -32,8 +31,7 @@ class Tribe__Tickets__Attendee_Registration__Service_Provider extends tad_DI52_S
 			return;
 		}
 
-		// After priority 45 from register() using this same action.
-		add_action( 'tribe_plugins_loaded', [ $this, 'add_attendee_registration_template_hook' ], 50 );
+		$this->add_attendee_registration_template_hook();
 
 		add_action( 'init', [ $this, 'add_attendee_registration_shortcode_hook' ] );
 		add_action( 'init', [ $this, 'add_attendee_registration_modal_hook' ] );

--- a/src/Tribe/Editor/Attendee_Registration.php
+++ b/src/Tribe/Editor/Attendee_Registration.php
@@ -34,7 +34,17 @@ class Tribe__Tickets__Editor__Attendee_Registration {
 	 * @return string
 	 */
 	public function filter_admin_body_class( $classes ) {
-		$ar_page_slug = tribe( 'tickets.attendee_registration' )->get_slug();
+		/**
+		 * This Try/Catch is present to deal with a problem on Autoloading from version 5.1.0 ET+ with ET 5.0.3.
+		 *
+		 * @todo Needs to be revised once proper autoloading rules are done for Common, ET and ET+.
+		 */
+		try {
+			$ar_page_slug = tribe( 'tickets.attendee_registration' )->get_slug();
+		} catch( RuntimeException $error ) {
+			return $classes;
+		}
+
 
 		// if not on attendee registration page
 		if ( tribe_get_request_var( 'page', '' ) !== $ar_page_slug ) {

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -42,11 +42,8 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 		$this->container->singleton( 'tickets.editor.rest.compatibility', 'Tribe__Tickets__Editor__REST__Compatibility', array( 'hook' ) );
 		$this->container->singleton( 'tickets.editor.attendees_table', 'Tribe__Tickets__Attendees_Table' );
 
-		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
-			$this->container->singleton( 'tickets.editor.attendee_registration', 'Tribe__Tickets__Editor__Attendee_Registration' );
-		}
-
 		$this->hook();
+
 		/**
 		 * Lets load all compatibility related methods
 		 *
@@ -88,10 +85,6 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 
 		// Setup the Rest compatibility layer for WP
 		tribe( 'tickets.editor.rest.compatibility' );
-
-		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
-			tribe( 'tickets.editor.attendee_registration' )->hook();
-		}
 
 		// Register blocks
 		add_action(

--- a/src/Tribe/Editor/Provider.php
+++ b/src/Tribe/Editor/Provider.php
@@ -40,9 +40,11 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 
 		$this->container->singleton( 'tickets.editor.meta', 'Tribe__Tickets__Editor__Meta' );
 		$this->container->singleton( 'tickets.editor.rest.compatibility', 'Tribe__Tickets__Editor__REST__Compatibility', array( 'hook' ) );
-		$this->container->singleton( 'tickets.editor.attendee_registration', 'Tribe__Tickets__Editor__Attendee_Registration' );
 		$this->container->singleton( 'tickets.editor.attendees_table', 'Tribe__Tickets__Attendees_Table' );
 
+		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
+			$this->container->singleton( 'tickets.editor.attendee_registration', 'Tribe__Tickets__Editor__Attendee_Registration' );
+		}
 
 		$this->hook();
 		/**
@@ -87,7 +89,9 @@ class Tribe__Tickets__Editor__Provider extends tad_DI52_ServiceProvider {
 		// Setup the Rest compatibility layer for WP
 		tribe( 'tickets.editor.rest.compatibility' );
 
-		tribe( 'tickets.editor.attendee_registration' )->hook();
+		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
+			tribe( 'tickets.editor.attendee_registration' )->hook();
+		}
 
 		// Register blocks
 		add_action(

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -353,8 +353,10 @@ class Tribe__Tickets__Main {
 
 		tribe_singleton( 'tickets.theme-compatibility', 'Tribe__Tickets__Theme_Compatibility' );
 
-		// Attendee Registration Page.
-		tribe_register_provider( 'Tribe__Tickets__Attendee_Registration__Service_Provider' );
+		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
+			// Attendee Registration Page.
+			tribe_register_provider( 'Tribe__Tickets__Attendee_Registration__Service_Provider' );
+		}
 
 		// Event Tickets Provider to manage Events.
 		tribe_register_provider( Events_Service_Provider::class );
@@ -724,8 +726,12 @@ class Tribe__Tickets__Main {
 	 * @since 4.11.0
 	 */
 	public function maybe_set_options_for_old_installs() {
-		/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
-		$ar_reg = tribe( 'tickets.attendee_registration' );
+		try {
+			/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
+			$ar_reg = tribe( 'tickets.attendee_registration' );
+		} catch ( \Exception $exception ) {
+			return;
+		}
 
 		// If the (boolean) option is not set, and this install predated the modal, let's set the option to false.
 		$modal_option = $ar_reg->is_modal_enabled();

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -726,6 +726,11 @@ class Tribe__Tickets__Main {
 	 * @since 4.11.0
 	 */
 	public function maybe_set_options_for_old_installs() {
+		/**
+		 * This Try/Catch is present to deal with a problem on Autoloading from version 5.1.0 ET+ with ET 5.0.3.
+		 *
+		 * @todo Needs to be revised once proper autoloading rules are done for Common, ET and ET+.
+		 */
 		try {
 			/** @var \Tribe__Tickets__Attendee_Registration__Main $ar_reg */
 			$ar_reg = tribe( 'tickets.attendee_registration' );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -8,7 +8,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '5.0.3';
+	const VERSION = '5.0.3.1';
 
 	/**
 	 * Used to store the version history.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -353,11 +353,6 @@ class Tribe__Tickets__Main {
 
 		tribe_singleton( 'tickets.theme-compatibility', 'Tribe__Tickets__Theme_Compatibility' );
 
-		if ( class_exists( 'Tribe__Tickets_Plus__Meta__Storage' ) ) {
-			// Attendee Registration Page.
-			tribe_register_provider( 'Tribe__Tickets__Attendee_Registration__Service_Provider' );
-		}
-
 		// Event Tickets Provider to manage Events.
 		tribe_register_provider( Events_Service_Provider::class );
 

--- a/src/Tribe/Plugin_Register.php
+++ b/src/Tribe/Plugin_Register.php
@@ -8,7 +8,7 @@ class Tribe__Tickets__Plugin_Register extends Tribe__Abstract_Plugin_Register {
 	protected $main_class   = 'Tribe__Tickets__Main';
 	protected $dependencies = array(
 		'addon-dependencies' => array(
-			'Tribe__Tickets_Plus__Main'               => '5.1.0-dev',
+			'Tribe__Tickets_Plus__Main'               => '5.1.0.1-dev',
 			'Tribe__Events__Community__Tickets__Main' => '4.7.2-dev',
 		),
 	);

--- a/src/Tribe/Plugin_Register.php
+++ b/src/Tribe/Plugin_Register.php
@@ -8,7 +8,7 @@ class Tribe__Tickets__Plugin_Register extends Tribe__Abstract_Plugin_Register {
 	protected $main_class   = 'Tribe__Tickets__Main';
 	protected $dependencies = array(
 		'addon-dependencies' => array(
-			'Tribe__Tickets_Plus__Main'               => '4.12.0-dev',
+			'Tribe__Tickets_Plus__Main'               => '5.1.0-dev',
 			'Tribe__Events__Community__Tickets__Main' => '4.7.2-dev',
 		),
 	);

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -3590,8 +3590,17 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				return;
 			}
 
-			/** @var \Tribe__Tickets__Attendee_Registration__Main $attendee_registration */
-			$attendee_registration = tribe( 'tickets.attendee_registration' );
+			/**
+			 * This Try/Catch is present to deal with a problem on Autoloading from version 5.1.0 ET+ with ET 5.0.3.
+			 *
+			 * @todo Needs to be revised once proper autoloading rules are done for Common, ET and ET+.
+			 */
+			try {
+				/** @var \Tribe__Tickets__Attendee_Registration__Main $attendee_registration */
+				$attendee_registration = tribe( 'tickets.attendee_registration' );
+			} catch( RuntimeException $error ) {
+				return;
+			}
 
 			if (
 				$attendee_registration->is_on_page()

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1763,7 +1763,7 @@ if ( ! function_exists( 'tribe_tickets_new_views_is_enabled' ) ) {
 		}
 
 		// If ETP was installed on or after version 5.1, default to enabled.
-		$should_default_to_on = ! tribe_installed_before( 'Tribe__Tickets_Plus__Main', '5.1' );
+		$should_default_to_on = class_exists( 'Tribe__Tickets_Plus__Main' ) && ! tribe_installed_before( 'Tribe__Tickets_Plus__Main', '5.1' );
 
 		// Check for settings UI option.
 		$enabled = (bool) tribe_get_option( 'tickets_use_new_views', $should_default_to_on );

--- a/src/views/blocks/tickets/submit.php
+++ b/src/views/blocks/tickets/submit.php
@@ -11,8 +11,9 @@
  * @link https://m.tri.be/1amp Help article for RSVP & Ticket template files.
  *
  * @since 4.9
+ * @since 5.0.3.1 Fix call to class that may not be active if ET+ has not fully met it's requirements.
  *
- * @version 4.11.0
+ * @version 5.0.3.1
  *
  */
 $provider   = $this->get( 'provider' );
@@ -20,12 +21,16 @@ $must_login = ! is_user_logged_in() && $provider->login_required();
 $event_id   = $this->get( 'event_id' );
 $event      = get_post( $event_id );
 
-/** @var \Tribe__Tickets__Attendee_Registration__Main $attendee_registration */
-$attendee_registration = tribe( 'tickets.attendee_registration' );
+try {
+	/** @var \Tribe__Tickets__Attendee_Registration__Main $attendee_registration */
+	$attendee_registration = tribe( 'tickets.attendee_registration' );
+} catch ( RuntimeException $exception ) {
+	$attendee_registration = null;
+}
 
 if ( $must_login ) {
 	$this->template( 'blocks/tickets/submit-login' );
-} elseif ( $attendee_registration->is_modal_enabled() ) {
+} elseif ( $attendee_registration && $attendee_registration->is_modal_enabled() ) {
 	$this->template( 'blocks/tickets/submit-button-modal' );
 } else {
 	$this->template( 'blocks/tickets/submit-button' );


### PR DESCRIPTION
[ET-964]

Require Event Tickets Plus 5.1.0.1+ for compatibility purposes on certain areas in Event Tickets that have direct calls to Event Tickets Plus functionality

[ET-964]: https://moderntribe.atlassian.net/browse/ET-964