### PR TITLE
[ET-952] Adjust Sale End time for tickets and RSVPs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -179,6 +179,7 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 = [5.0.4] TBD =
 
 * Fix - Post type settings label typo changed to plural "tickets". [ET-954]
+* Fix - RSVP/Ticket's end sale date for non-event post types now defaults to 1 year and 2 hrs+ from current date instead of 100. [ET-954]
 
 = [5.0.3.1] 2020-11-19 =
 

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -46,6 +46,13 @@ class Tribe__Tickets__Editor__Configuration implements Tribe__Editor__Configurat
 			$this->localize()
 		);
 
+		/**
+		 * Filter the default buffer duration between ticket sale start time and end time.
+		 *
+		 * @param int $buffer Number in hours to be used.
+		 */
+		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_ticket_end_sale_buffer_duration_hours', 2 );
+
 		return $editor_config;
 	}
 

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -56,11 +56,11 @@ class Tribe__Tickets__Editor__Configuration implements Tribe__Editor__Configurat
 		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_duration_hours', 2 );
 
 		/**
-		 * Filter the default buffer years between ticket sale start time and end time.
+		 * Filter the default buffer years between ticket sale start date and end date.
 		 *
 		 * @since TBD
 		 *
-		 * @param int $buffer Number in hours to be used.
+		 * @param int $buffer Number in years to be used.
 		 */
 		$editor_config['tickets']['end_sale_buffer_years'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_years', 1 );
 

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -53,7 +53,7 @@ class Tribe__Tickets__Editor__Configuration implements Tribe__Editor__Configurat
 		 *
 		 * @param int $buffer Number in hours to be used.
 		 */
-		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_duration_hours', 2 );
+		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_tickets_editor_end_sale_buffer_duration_hours', 2 );
 
 		/**
 		 * Filter the default buffer years between ticket sale start date and end date.
@@ -62,7 +62,7 @@ class Tribe__Tickets__Editor__Configuration implements Tribe__Editor__Configurat
 		 *
 		 * @param int $buffer Number in years to be used.
 		 */
-		$editor_config['tickets']['end_sale_buffer_years'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_years', 1 );
+		$editor_config['tickets']['end_sale_buffer_years'] = apply_filters( 'tribe_tickets_editor_end_sale_buffer_years', 1 );
 
 		return $editor_config;
 	}

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -49,9 +49,20 @@ class Tribe__Tickets__Editor__Configuration implements Tribe__Editor__Configurat
 		/**
 		 * Filter the default buffer duration between ticket sale start time and end time.
 		 *
+		 * @since TBD
+		 *
 		 * @param int $buffer Number in hours to be used.
 		 */
-		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_ticket_end_sale_buffer_duration_hours', 2 );
+		$editor_config['tickets']['end_sale_buffer_duration'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_duration_hours', 2 );
+
+		/**
+		 * Filter the default buffer years between ticket sale start time and end time.
+		 *
+		 * @since TBD
+		 *
+		 * @param int $buffer Number in hours to be used.
+		 */
+		$editor_config['tickets']['end_sale_buffer_years'] = apply_filters( 'tribe_ticket_editor_end_sale_buffer_years', 1 );
 
 		return $editor_config;
 	}

--- a/src/modules/data/blocks/rsvp/reducers/details.js
+++ b/src/modules/data/blocks/rsvp/reducers/details.js
@@ -11,7 +11,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone().add( 2, 'hours' );
+const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/rsvp/reducers/details.js
+++ b/src/modules/data/blocks/rsvp/reducers/details.js
@@ -11,7 +11,7 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone();
+const endMoment = currentMoment.clone().add( 2, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/rsvp/reducers/details.js
+++ b/src/modules/data/blocks/rsvp/reducers/details.js
@@ -12,7 +12,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
 const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
-const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
+const bufferYears = globals.tickets().end_sale_buffer_years ? globals.tickets().end_sale_buffer_years : 1;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' ).add( bufferYears, 'years' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -627,6 +627,7 @@ export function* setNonEventPostTypeEndDate() {
 	const tempEndMoment = yield select( selectors.getRSVPTempEndDateMoment );
 	const endMoment = yield call( [ tempEndMoment, 'clone' ] );
 	yield call( [ endMoment, 'add' ], 2, 'hours' );
+	yield call( [ endMoment, 'add' ], 1, 'years' );
 	const { date, dateInput, moment, time } = yield call( createDates, endMoment.toDate() );
 
 	yield all( [

--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -626,7 +626,7 @@ export function* setNonEventPostTypeEndDate() {
 
 	const tempEndMoment = yield select( selectors.getRSVPTempEndDateMoment );
 	const endMoment = yield call( [ tempEndMoment, 'clone' ] );
-	yield call( [ endMoment, 'add' ], 100, 'years' );
+	yield call( [ endMoment, 'add' ], 2, 'hours' );
 	const { date, dateInput, moment, time } = yield call( createDates, endMoment.toDate() );
 
 	yield all( [

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
@@ -12,7 +12,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone().add( 2, 'hours' );
+const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
@@ -13,7 +13,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
 const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
-const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
+const bufferYears = globals.tickets().end_sale_buffer_years ? globals.tickets().end_sale_buffer_years : 1;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' ).add( bufferYears, 'years' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/details.js
@@ -12,7 +12,7 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone().add( 100, 'years' );
+const endMoment = currentMoment.clone().add( 2, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
@@ -12,7 +12,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone().add( 2, 'hours' );
+const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
@@ -13,7 +13,8 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
 const bufferDuration = globals.tickets().end_sale_buffer_duration ? globals.tickets().end_sale_buffer_duration : 2;
-const endMoment = currentMoment.clone().add( bufferDuration, 'hours' );
+const bufferYears = globals.tickets().end_sale_buffer_years ? globals.tickets().end_sale_buffer_years : 1;
+const endMoment = currentMoment.clone().add( bufferDuration, 'hours' ).add( bufferYears, 'years' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )

--- a/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
+++ b/src/modules/data/blocks/ticket/reducers/tickets/ticket/temp-details.js
@@ -12,7 +12,7 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 
 const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 const currentMoment = moment();
-const endMoment = currentMoment.clone().add( 100, 'years' );
+const endMoment = currentMoment.clone().add( 2, 'hours' );
 
 const startDateInput = datePickerFormat
 	? currentMoment.format( momentUtil.toFormat( datePickerFormat ) )


### PR DESCRIPTION
[ET-952]

For the Non-event post type, we are adding 1 year + 2 hours to the ticket end date changing from the old 100 years value.

Screenshot:
<img width="1163" alt="Screen Shot 2020-12-01 at 10 40 43 PM" src="https://user-images.githubusercontent.com/7523321/100782059-14656600-3436-11eb-9ab9-b7686036107f.png">

<img width="667" alt="Screen Shot 2020-12-01 at 10 53 40 PM" src="https://user-images.githubusercontent.com/7523321/100782090-1cbda100-3436-11eb-8145-7b65fe5df684.png">



[ET-952]: https://moderntribe.atlassian.net/browse/ET-952