### PR TITLE
[ET-955] Remove extraneous "Save and checkout" heading from the registration-js/content.php view

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,8 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 * Fix - Exclude the "RSVP" ticket provider from the providers list in the editor for tickets. [ET-953]
 * Fix - Post type settings label typo changed to plural "tickets". [ET-954]
 * Fix - RSVP/Ticket's end sale date for non-event post types now defaults to 1 year and 2 hrs from current date instead of 100 years. [ET-954]
+* Fix - Remove extraneous "Save and checkout" heading from the `registration-js/content.php` view. [ET-955]
+* Fix - Prevent PHP notices by setting up the `must_login` argument within the `registration-js/mini-cart.php` view. [ET-955]
 * Tweak - Added admin notice when editing an Events Calendar Pro recurring event that has tickets in classic editor to warn about how tickets will act on recurring events. [ET-949]
 * Tweak - Show warning message within the classic ticket editor if no commerce provider is active. [ET-957]
 * Tweak - Show warning message within the classic ticket editor for recurring events about the limitations of tickets on recurring events. [ET-947]

--- a/src/views/registration-js/content.php
+++ b/src/views/registration-js/content.php
@@ -15,8 +15,9 @@
  *              Retrieve $is_meta_up_to_date in a manner consistent with other template variables. Moved `novalidate` from
  *              div to form, as it used to be. Implement short array syntax.
  * @since 5.0.3 Add `event-tickets` class to the wrapper.
+ * @since TBD Remove extraneous "Save and checkout" heading.
  *
- * @version 5.0.3
+ * @version TBD
  *
  * @var Tribe__Tickets__Attendee_Registration__View $this
  */
@@ -173,10 +174,6 @@ $classes        = [
 										</h3>
 									</div>
 							<?php endforeach; ?>
-
-							<?php if ( $has_tpp ) : ?>
-								<button type="submit"><?php esc_html_e( 'Save and Checkout', 'event-tickets' ); ?></button>
-							<?php endif; ?>
 						</div>
 					</div>
 				</div>

--- a/src/views/registration-js/mini-cart.php
+++ b/src/views/registration-js/mini-cart.php
@@ -57,6 +57,7 @@ $cart_url            = $this->get( 'cart_url' );
 						'ticket'          => $cart_provider->get_ticket( $event_id, $ticket['id'] ),
 						'key'             => $key,
 						'is_mini'         => true,
+						'must_login'      => ! is_user_logged_in() && $cart_provider->login_required(),
 						'currency_symbol' => $currency_symbol,
 						'provider'        => $cart_provider,
 						'post_id'         => $event_id,


### PR DESCRIPTION
[ET-955]

This fixes a php notice and removes the save and checkout text based on the ticket needs.

Screenshot: https://p199.p4.n0.cdn.getcloudapp.com/items/2Nu0XkQ4/Screen%20Shot%202020-12-03%20at%204.03.35%20PM.png?v=19c123d5f7d268d4509b1c9c8ff1243b

[ET-955]: https://moderntribe.atlassian.net/browse/ET-955