### PR TITLE
[ETP-599] ET > Prevent php notices from interacting with tickets not prepared by current commerce provider

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -186,6 +186,7 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 * Fix - Prevent PHP notices by setting up the `must_login` argument within the `registration-js/mini-cart.php` view. [ET-955]
 * Fix - Make the "Configure Settings" link on the Welcome screen for Event Tickets open up in a new tab. [ET-958]
 * Fix - Update loader templates to use new icons from Tribe Common. [ET-588]
+* Fix - Resolve PHP notices on the Attendee Registration Page from Tribe Commerce ticket details when multiple Commerce Providers may be available. [ET-599]
 * Tweak - Added admin notice when editing an Events Calendar Pro recurring event that has tickets in classic editor to warn about how tickets will act on recurring events. [ET-949]
 * Tweak - Show warning message within the classic ticket editor if no commerce provider is active. [ET-957]
 * Tweak - Show warning message within the classic ticket editor for recurring events about the limitations of tickets on recurring events. [ET-947]

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2401,6 +2401,10 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 		$commerce_tickets = $this->commerce_get_tickets_in_cart( $tickets );
 
 		foreach ( $commerce_tickets as $ticket ) {
+			if ( ! is_array( $ticket ) ) {
+				continue;
+			}
+
 			$tickets[ $ticket['ticket_id'] ] = $ticket['quantity'];
 		}
 


### PR DESCRIPTION
[ETP-599]

This PR prevents PHP notices when tickets are provided already per-formatted in ET.

[ETP-599]: https://moderntribe.atlassian.net/browse/ETP-599