### PR TITLE
[ET-952] Fixed showing 2 years buffer for RSVP block

### DIFF
--- a/src/modules/data/blocks/rsvp/sagas.js
+++ b/src/modules/data/blocks/rsvp/sagas.js
@@ -626,8 +626,6 @@ export function* setNonEventPostTypeEndDate() {
 
 	const tempEndMoment = yield select( selectors.getRSVPTempEndDateMoment );
 	const endMoment = yield call( [ tempEndMoment, 'clone' ] );
-	yield call( [ endMoment, 'add' ], 2, 'hours' );
-	yield call( [ endMoment, 'add' ], 1, 'years' );
 	const { date, dateInput, moment, time } = yield call( createDates, endMoment.toDate() );
 
 	yield all( [


### PR DESCRIPTION
[ET-952]
<img width="1130" alt="Screen Shot 2020-12-11 at 1 08 37 AM" src="https://user-images.githubusercontent.com/7523321/101819325-44f08280-3b4f-11eb-96db-880c8324c67d.png">

<img width="1116" alt="Screen Shot 2020-12-11 at 1 16 31 AM" src="https://user-images.githubusercontent.com/7523321/101819082-f93dd900-3b4e-11eb-82c6-ded9a7b75e1e.png">


[ET-952]: https://moderntribe.atlassian.net/browse/ET-952