### PR TITLE
[ET-947] Resolve CSS display conflict with Tribe Dependency for Warning notice

### DIFF
--- a/src/resources/postcss/tickets-admin.pcss
+++ b/src/resources/postcss/tickets-admin.pcss
@@ -626,6 +626,14 @@ p.description {
 		}
 	}
 
+	&.tribe-dependent {
+		display: none;
+
+		&.tribe-active {
+			display: flex;
+		}
+	}
+
 	.dashicons {
 		font-size: 20px;
 		width: 20px;


### PR DESCRIPTION
[ET-947]

The warning notice has a class that uses `display:flex` but it gets a bit messy when involving Tribe dependency and AJAX loading too. This resolves those issues.

Dev screencast: https://share.skc.dev/OAuWgl20

[ET-947]: https://moderntribe.atlassian.net/browse/ET-947