### PR TITLE
[ET-599] Fix one more AR page notice appearing

### DIFF
--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -694,7 +694,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = __METHOD__ . '-' . $this->orm_provider . '-' . $post_id;
 
-			if ( isset( $cache[ $key ] ) ) {
+			if ( isset( $cache[ $key ] ) && is_array( $cache[ $key ] ) ) {
 				return $cache[ $key ];
 			}
 


### PR DESCRIPTION
[ET-599]

This fixes one more PHP notice happening on the AR page, some sites experience the cache value to not be an array in certain circumstances.

This goes towards the pre-existing ET-599 changelog

[ET-599]: https://moderntribe.atlassian.net/browse/ET-599