### PR TITLE
[ETP-601] Use jQuery.ready() and prevent potential event conflicts

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,7 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 * Fix - Make the "Configure Settings" link on the Welcome screen for Event Tickets open up in a new tab. [ET-958]
 * Fix - Update loader templates to use new icons from Tribe Common. [ET-588]
 * Fix - Resolve PHP notices on the Attendee Registration Page from Tribe Commerce ticket details when multiple Commerce Providers may be available. [ET-599]
+* Fix - Prevent potential conflicts with themes like Avada that manually trigger a jQuery ready event during the normal jQuery ready event. [ETP-601]
 * Tweak - Added admin notice when editing an Events Calendar Pro recurring event that has tickets in classic editor to warn about how tickets will act on recurring events. [ET-949]
 * Tweak - Show warning message within the classic ticket editor if no commerce provider is active. [ET-957]
 * Tweak - Show warning message within the classic ticket editor for recurring events about the limitations of tickets on recurring events. [ET-947]

--- a/src/resources/js/tickets-registration-page.js
+++ b/src/resources/js/tickets-registration-page.js
@@ -547,7 +547,7 @@ window.tribe.tickets.registration = {};
 				isValidfield = false;
 			}
 		}
-		
+
 		// Validation for Tribe Horizontal Date Picker
 		if ( $input.hasClass( obj.selector.horizontal_datepicker.value.replace( /^\./, '' ) ) ) {
 			const wrapper = $input.closest( obj.selector.horizontal_datepicker.container );
@@ -806,7 +806,7 @@ window.tribe.tickets.registration = {};
 		obj.initFormPrefills();
 	};
 
-	obj.document.on( 'ready', function() {
+	obj.document.ready( function() {
 		obj.init();
 	} );
 } )( jQuery, window.tribe.tickets.registration );


### PR DESCRIPTION
[ETP-601]

This prevents potential event conflicts with other scripts like Avada which manually `.trigger( 'ready' )` and cause problems for things that use `.on( 'ready', ... )`

Tested on customer staging and proven to work, this even matches the same implementation we use for the new AR page JS code that's in ET+ for the new Tickets views we revamped.

[ETP-601]: https://moderntribe.atlassian.net/browse/ETP-601