### PR TITLE
[ET-986] Resolve issues with v1 template calls to dot icon in loader template

### DIFF
--- a/event-tickets.php
+++ b/event-tickets.php
@@ -3,7 +3,7 @@
 Plugin Name: Event Tickets
 Plugin URI:  http://m.tri.be/1acb
 Description: Event Tickets allows you to sell basic tickets and collect RSVPs from any post, page, or event.
-Version: 5.0.4
+Version: 5.0.4.1
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/28
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 
 = [5.0.4.1] 2020-12-16 =
 
-* Fix - Resolve fatal error from the Attendee Registration modal when calling the loading "dot" icons outside of the template context in older views. [TBD]
+* Fix - Resolve fatal error from the Attendee Registration modal when calling the loading "dot" icons outside of the template context in older views. [ET-986]
 
 = [5.0.4] 2020-12-15 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -176,6 +176,10 @@ Check out our extensive [knowledgebase](https://m.tri.be/18wm) for articles on u
 
 == Changelog ==
 
+= [5.0.4.1] 2020-12-16 =
+
+* Fix - Resolve fatal error from the Attendee Registration modal when calling the loading "dot" icons outside of the template context in older views. [TBD]
+
 = [5.0.4] 2020-12-15 =
 
 * Fix - Exclude the "RSVP" ticket provider from the providers list in the editor for tickets. [ET-953]

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: ModernTribe, brianjessee, camwynsp, paulkim, sc0ttkclark, aguseo, 
 Tags: tickets, registration, The Events Calendar, RSVP, ticket sales, attendee management
 Requires at least: 4.9.14
 Tested up to: 5.6.0
-Stable tag: 5.0.4
+Stable tag: 5.0.4.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -8,7 +8,7 @@ class Tribe__Tickets__Main {
 	/**
 	 * Current version of this plugin
 	 */
-	const VERSION = '5.0.4';
+	const VERSION = '5.0.4.1';
 
 	/**
 	 * Used to store the version history.

--- a/src/views/components/loader.php
+++ b/src/views/components/loader.php
@@ -10,8 +10,9 @@
  * @link {INSERT_ARTCILE_LINK_HERE}
  *
  * @since 5.0.4 Update template to use icons from Tribe Common.
+ * @since 5.0.4.1 Call dot views using template class to prevent issues where this template was included outside of a template class.
  *
- * @version 5.0.4
+ * @version 5.0.4.1
  *
  */
 if ( empty( $text ) ) {
@@ -32,11 +33,14 @@ if ( ! empty( $loader_classes ) ) {
 	$spinner_classes = array_merge( $spinner_classes, (array) $loader_classes );
 }
 
+// Calling this manually because the v1 calls do not all use templating classes.
+/** @var Tribe__Tickets__Editor__Template $template */
+$template = tribe( 'tickets.editor.template' );
 ?>
 <div class="tribe-common">
 	<div <?php tribe_classes( $spinner_classes ); ?> >
-		<?php $this->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--first' ] ] ); ?>
-		<?php $this->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--second' ] ] ); ?>
-		<?php $this->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--third' ] ] ); ?>
+		<?php $template->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--first' ] ] ); ?>
+		<?php $template->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--second' ] ] ); ?>
+		<?php $template->template( 'v2/components/icons/dot', [ 'classes' => [ 'tribe-common-c-loader__dot', 'tribe-common-c-loader__dot--third' ] ] ); ?>
 	</div>
 </div>


### PR DESCRIPTION
[ET-986]

This PR resolves a fatal error from the Attendee Registration modal when calling the loading "dot" icons outside of the template context in older views.

Dev Screencast: https://share.skc.dev/9Zu0Ry4D

[ET-986]: https://moderntribe.atlassian.net/browse/ET-986

Related: https://github.com/moderntribe/event-tickets/pull/1892