### PR TITLE
Only show the notice for connected accounts.

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/Settings.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Settings.php
@@ -150,20 +150,37 @@ class Settings extends Abstract_Settings {
 	 * @since TBD
 	 */
 	public function alert_currency_mismatch() {
-		$stripe_currency = strtoupper( tribe( Merchant::class )->get_merchant_currency() );
-		$site_currency = strtoupper( Currency::get_currency_code() );
+		$merchant = tribe( Merchant::class );
+
+		// Bail if merchant is not connected.
+		if ( ! $merchant->is_connected() ) {
+			return;
+		}
+
+		$stripe_currency = strtoupper( $merchant->get_merchant_currency() );
+		$site_currency   = strtoupper( Currency::get_currency_code() );
+
+		// Bail if no currency is set for the Stripe connection.
+		if ( empty( $stripe_currency ) ) {
+			return;
+		}
 
 		if ( $site_currency === $stripe_currency ) {
 			return;
 		}
 
-		tribe( Notice_Handler::class )->trigger_admin( 'tc-stripe-currency-mismatch', [
-			'content' =>
-				sprintf(
-				// Translators: %1$s The tickets commerce currency. %2$s: The currency from the Stripe account.
-					__( 'Tickets Commerce is configured to use %1$s as its currency but the default currency for the connected stripe account is %2$s. If you believe this is an error, you can modify the Tickets Commerce currency in the main Payments tab. Using different currencies for Tickets Commerce and Stripe may result in exchange rates and conversions being handled by Stripe.', 'event-tickets' ),
-					$site_currency, $stripe_currency ),
-		] );
+		tribe( Notice_Handler::class )->trigger_admin(
+			'tc-stripe-currency-mismatch',
+			[
+				'content' =>
+					sprintf(
+					// Translators: %1$s The tickets commerce currency. %2$s: The currency from the Stripe account.
+						__( 'Tickets Commerce is configured to use %1$s as its currency but the default currency for the connected stripe account is %2$s. If you believe this is an error, you can modify the Tickets Commerce currency in the main Payments tab. Using different currencies for Tickets Commerce and Stripe may result in exchange rates and conversions being handled by Stripe.', 'event-tickets' ),
+						$site_currency,
+						$stripe_currency
+					),
+			]
+		);
 	}
 
 	/**
@@ -185,11 +202,11 @@ class Settings extends Abstract_Settings {
 		);
 
 		$payment_methods_tooltip = sprintf(
-			// Translators: %1$s: Opening `<strong>` tag. %2$s: The currency name. %3$s: Closing `</strong>` tag. %4$s: Opening `<a>` tag for Stripe link. %5$s: Closing `</a>` tag.
-			__( 'Payment methods available for %1$s%2$s%3$s.<br /><br /> The payment methods listed here are dependent on the currency selected for Tickets Commerce and the currency each payment method support. You can review the payment methods and their availablity for each currency on %4$sStripe\'s documentation%5$s.<br /><br />', 'event-tickets' ),
-			'<strong>',
+			// Translators: %1$s: Opening `<span>` tag. %2$s: The currency name. %3$s: Closing `</span>` tag. %4$s: Opening `<a>` tag for Stripe link. %5$s: Closing `</a>` tag.
+			__( '%1$sPayment methods available for %2$s%3$s.<br /><br /> The payment methods listed here are dependent on the currency selected for Tickets Commerce and the currency each payment method support. You can review the payment methods and their availablity for each currency on %4$sStripe\'s documentation%5$s.<br /><br />', 'event-tickets' ),
+			'<span class="tec-tickets__admin-settings-tickets-commerce-gateway-currency">',
 			$currency_name,
-			'</strong>',
+			'</span>',
 			'<a href="https://stripe.com/docs/payments/payment-methods/integration-options" target="_blank" rel="noopener noreferrer">',
 			'</a>'
 		);
@@ -256,16 +273,16 @@ class Settings extends Abstract_Settings {
 				],
 			],
 			static::$option_checkout_element_card_fields   => [
-				'type'            => 'radio',
-				'label'           => esc_html__( 'Credit Card field format', 'event-tickets' ),
-				'default'         => self::COMPACT_CARD_ELEMENT_SLUG,
+				'type'                => 'radio',
+				'label'               => esc_html__( 'Credit Card field format', 'event-tickets' ),
+				'default'             => self::COMPACT_CARD_ELEMENT_SLUG,
 				'fieldset_attributes' => [
 					'data-depends'              => '#tribe-field-' . static::$option_checkout_element . '-' . self::CARD_ELEMENT_SLUG,
 					'data-condition-is-checked' => true,
 				],
-				'class'           => 'tribe-dependent',
-				'validation_type' => 'options',
-				'options'         => [
+				'class'               => 'tribe-dependent',
+				'validation_type'     => 'options',
+				'options'             => [
 					self::COMPACT_CARD_ELEMENT_SLUG  => sprintf(
 						// Translators: %1$s: Opening `<span>` tag. %2$s: Closing `</span>` tag.
 						__( 'Single field. %1$sFor streamlined checkout.%2$s', 'event-tickets' ),
@@ -281,18 +298,17 @@ class Settings extends Abstract_Settings {
 				],
 			],
 			static::$option_checkout_element_payment_methods => [
-				'type'            => 'checkbox_list',
-				'label'           => esc_html__( 'Payment methods accepted', 'event-tickets' ),
-				'tooltip'         => $payment_methods_tooltip,
-				'default'         => self::DEFAULT_PAYMENT_ELEMENT_METHODS,
+				'type'                => 'checkbox_list',
+				'label'               => esc_html__( 'Payment methods accepted', 'event-tickets' ),
+				'tooltip'             => $payment_methods_tooltip,
+				'default'             => self::DEFAULT_PAYMENT_ELEMENT_METHODS,
 				'fieldset_attributes' => [
 					'data-depends'              => '#tribe-field-' . static::$option_checkout_element . '-' . self::PAYMENT_ELEMENT_SLUG,
 					'data-condition-is-checked' => true,
 				],
-				'class'           => 'tribe-dependent',
-				'validation_type' => 'options_multi',
-				'options'         => $this->get_payment_methods_available_by_currency(),
-				'tooltip_first'   => true,
+				'class'               => 'tribe-dependent',
+				'validation_type'     => 'options_multi',
+				'options'             => $this->get_payment_methods_available_by_currency(),
 			],
 		];
 


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID] <!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

- Only show the Stripe notice for currency mismatch if Stripe is enabled, and check that we have the value. so that's not displayed when there's no value and when Stripe is not set up (new installs).

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [ ] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
