### PR TITLE
Enables disabling select elements in Square checkout

### DIFF
--- a/src/resources/js/commerce/gateway/square/checkout.js
+++ b/src/resources/js/commerce/gateway/square/checkout.js
@@ -387,7 +387,8 @@ window.tec.tickets.commerce.square.checkout = window.tec.tickets.commerce.square
 		editLink.on( 'click', ( e ) => {
 			e.preventDefault();
 
-			formContainer.find( 'input, select' ).prop( 'readonly', false );
+			formContainer.find( 'input' ).prop( 'readonly', false );
+			formContainer.find( 'select' ).prop( 'disabled', false );
 			formContainer.find( '#tec-tc-gateway-stripe-render-payment' ).show();
 
 			formContainer.find( obj.selectors.editLink ).hide();
@@ -400,7 +401,8 @@ window.tec.tickets.commerce.square.checkout = window.tec.tickets.commerce.square
 		formContainer.on( 'submit', ( e ) => {
 			e.preventDefault();
 
-			formContainer.find( 'input, select' ).prop( 'readonly', true );
+			formContainer.find( 'input' ).prop( 'readonly', true );
+			formContainer.find( 'select' ).prop( 'disabled', true );
 			formContainer.find( '#tec-tc-gateway-stripe-render-payment' ).hide();
 
 			formContainer.find( obj.selectors.editLink ).css( 'display', 'inline-block' );


### PR DESCRIPTION
Addresses an issue where select elements were not being properly disabled during the Square checkout process.

- Updates the JavaScript logic to use `disabled` property for `select` elements instead of `readonly`.
- Ensures that select elements cannot be modified by the user when the form is in a read-only state