### PR TITLE
PHP 8.3 adjustments for `func_get_args`

### DIFF
--- a/src/Tickets/Commerce/Gateways/PayPal/Client.php
+++ b/src/Tickets/Commerce/Gateways/PayPal/Client.php
@@ -167,6 +167,9 @@ class Client {
 	 * @return array|\WP_Error
 	 */
 	public function request( $method, $url, array $query_args = [], array $request_arguments = [], $raw = false, $retries = 0 ) {
+		// Capture original arguments before any modifications for potential recursive calls.
+		$original_arguments = func_get_args();
+
 		$method = strtoupper( $method );
 
 		// If the endpoint passed is a full URL don't try to append anything.
@@ -251,7 +254,7 @@ class Client {
 
 			// If we properly saved, just re-try the request.
 			if ( $saved ) {
-				$arguments = func_get_args();
+				$arguments = $original_arguments;
 				array_pop( $arguments );
 				$arguments[] = $retries + 1;
 

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -2315,10 +2315,6 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		update_post_meta( $attendee_id, $this->checkin_key, 1 );
 
-		if ( func_num_args() > 1 && $qr = func_get_arg( 1 ) ) {
-			update_post_meta( $attendee_id, '_tribe_qr_status', 1 );
-		}
-
 		$checkin_details = [
 			'date'      => (string) ! empty( $details['timestamp'] ) ? $details['timestamp'] : current_time( 'mysql' ),
 			'source'    => ! empty( $qr ) ? 'app' : 'site',

--- a/src/Tribe/Templates.php
+++ b/src/Tribe/Templates.php
@@ -15,8 +15,10 @@ class Tribe__Tickets__Templates extends Tribe__Templates {
 	 * @return string
 	 **/
 	public static function get_template_hierarchy( $template, $args = array() ) {
+		// Get all arguments at the very beginning to avoid PHP 8.3 compatibility issues.
+		$passed = func_get_args();
+
 		if ( ! is_array( $args ) ) {
-			$passed        = func_get_args();
 			$args          = array();
 			$backwards_map = array( 'namespace', 'plugin_path', 'disable_view_check' );
 			$count = count( $passed );

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -4684,7 +4684,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return void This module is removed from the list of active modules, if it was active.
 		 */
 		public function deactivate(): void {
-			unset( self::$active_modules[ get_class( $this ) ] );
+			$class_name = get_class( $this );
+			unset( self::$active_modules[ $class_name ] );
 		}
 
 		/**


### PR DESCRIPTION
### 🎫 Ticket

[ET-2535]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This PR attempts to corrects the production code getting flagged for PHP 8.3 incompaitability related to `func_get_args()` no longer reporting the original value as passed to a parameter, but will instead provide the current value. 

### 🎥 Artifacts 
Before: 
```
Samis-MacBook-Pro:stable-dev samidokus$ ~/.composer/vendor/bin/phpcs -d xdebug.mode=off -d memory_limit=512M --standard=PHPCompatibility --runtime-set testVersion 8.3 --extensions=php wp-content/plugins/event-tickets/src/ | head -50

FILE: ...p-content/plugins/event-tickets/src/Tickets/Commerce/Gateways/PayPal/Client.php
-------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------
 254 | ERROR | Since PHP 7.0, functions inspecting arguments, like func_get_args(),
     |       | no longer report the original value as passed to a parameter, but
     |       | will instead provide the current value. The parameter "$method" was
     |       | changed on line 170.
-------------------------------------------------------------------------------------


FILE: ...dokus/sites/stable-dev/wp-content/plugins/event-tickets/src/Tribe/Templates.php
-------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-------------------------------------------------------------------------------------
 19 | WARNING | Since PHP 7.0, functions inspecting arguments, like func_get_args(),
    |         | no longer report the original value as passed to a parameter, but
    |         | will instead provide the current value. The parameter "$args" was
    |         | used, and possibly changed (by reference), on line 18.
-------------------------------------------------------------------------------------


FILE: ...midokus/sites/stable-dev/wp-content/plugins/event-tickets/src/Tribe/Tickets.php
-------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------
 4687 | ERROR | "$this" can no longer be unset since PHP 7.1.
-------------------------------------------------------------------------------------


FILE: .../samidokus/sites/stable-dev/wp-content/plugins/event-tickets/src/Tribe/RSVP.php
-------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------
 2318 | ERROR | Since PHP 7.0, functions inspecting arguments, like func_get_arg(),
      |       | no longer report the original value as passed to a parameter, but
      |       | will instead provide the current value. The parameter "$qr" was
      |       | changed on line 2304.
-------------------------------------------------------------------------------------

Time: 34.43 secs; Memory: 34MB
```

After:
```
📝 Report saved to: /Users/samidokus/sites/stable-dev/compatibility-reports/php83-report-src-2025-08-18T21-41-34.md

📊 Summary:
   Checked: 1337 PHP files across 1 directory
   Issues found: 0 errors, 0 warnings
   Reports saved: /Users/samidokus/sites/stable-dev/compatibility-reports
```


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2535]: https://stellarwp.atlassian.net/browse/ET-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ