### PR TITLE
ET-2620 fix: stripe input error color

### DIFF
--- a/changelog/fix-ET-2620-color-contrast-insufficient-checkout
+++ b/changelog/fix-ET-2620-color-contrast-insufficient-checkout
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fix
 
-Fix an accessibility issue where the input error color of Stripe credit card form was not passing on the contrast color validation.
+Improve accessibility by updating the Stripe credit card form input error color to meet contrast validation requirements. [ET-2620]
 The original color was #eb1c26 changed to #C00 to pass the validation and be according the brand guideline

--- a/changelog/fix-ET-2620-color-contrast-insufficient-checkout
+++ b/changelog/fix-ET-2620-color-contrast-insufficient-checkout
@@ -2,4 +2,3 @@ Significance: patch
 Type: fix
 
 Improve accessibility by updating the Stripe credit card form input error color to meet contrast validation requirements. [ET-2620]
-The original color was #eb1c26 changed to #C00 to pass the validation and be according the brand guideline

--- a/changelog/fix-ET-2620-color-contrast-insufficient-checkout
+++ b/changelog/fix-ET-2620-color-contrast-insufficient-checkout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fix
+
+Fix an accessibility issue where the input error color of Stripe credit card form was not passing on the contrast color validation.
+The original color was #eb1c26 changed to #C00 to pass the validation and be according the brand guideline

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -105,7 +105,7 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 									'color' => '#23282d',
 								],
 								'invalid' => [
-									'color' => '#c00',
+									'color' => '#c00000',
 								],
 							],
 							'cardElementOptions' => [

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -104,6 +104,9 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 								'base' => [
 									'color' => '#23282d',
 								],
+								'invalid' => [
+									'color' => '#c00',
+								],
 							],
 							'cardElementOptions' => [
 								/**


### PR DESCRIPTION
### 🎫 Ticket

[[ET-2620](https://stellarwp.atlassian.net/browse/ET-2620)]

### 🗒️ Description

Fix an accessibility issue where the input error color of Stripe credit card form was not passing on the contrast color validation.
The original color was `#eb1c26` changed to `#C00000` to pass the validation and be according the brand guideline 

### 🎥 Artifacts <!-- if applicable-->
<img width="735" height="613" alt="Screenshot 2026-02-18 at 13 48 34" src="https://github.com/user-attachments/assets/52476173-e40f-4887-bbc7-893072e77fcd" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2620]: https://stellarwp.atlassian.net/browse/ET-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ