### PR TITLE
ET-2227 fix: added the attribute "role" on RSVP alerts to improve accessibility

### DIFF
--- a/changelog/fix-ET-2227-confirmation-message-is-not-announced-by-the-screen-reader-confirmation
+++ b/changelog/fix-ET-2227-confirmation-message-is-not-announced-by-the-screen-reader-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: accessibility
+
+added the attribute "role" on RSVP alerts to improve accessibility. [ET-2227]

--- a/changelog/fix-ET-2227-confirmation-message-is-not-announced-by-the-screen-reader-confirmation
+++ b/changelog/fix-ET-2227-confirmation-message-is-not-announced-by-the-screen-reader-confirmation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: accessibility
 
-added the attribute "role" on RSVP alerts to improve accessibility. [ET-2227]
+Add the attribute "role" on RSVP alerts to improve accessibility. [ET-2227]

--- a/src/views/v2/rsvp/messages/error.php
+++ b/src/views/v2/rsvp/messages/error.php
@@ -24,7 +24,7 @@ $error_messages = (array) $error_message;
 	<?php $this->template( 'v2/components/icons/error', [ 'classes' => [ 'tribe-tickets__rsvp-message--error-icon' ] ] ); ?>
 
 	<?php foreach ( $error_messages as $message ) : ?>
-		<span class="tribe-tickets__rsvp-message-text">
+		<span class="tribe-tickets__rsvp-message-text" role="alert">
 			<strong>
 				<?php echo wp_kses_post( $message ); ?>
 			</strong>

--- a/src/views/v2/rsvp/messages/must-login.php
+++ b/src/views/v2/rsvp/messages/must-login.php
@@ -27,7 +27,7 @@ if ( ! $must_login ) {
 <div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--must-login tribe-common-b3">
 	<?php $this->template( 'v2/components/icons/error', [ 'classes' => [ 'tribe-tickets__rsvp-message--must-login-icon' ] ] ); ?>
 
-	<span class="tribe-tickets__rsvp-message-text">
+	<span class="tribe-tickets__rsvp-message-text" role="alert">
 		<strong>
 			<?php
 			echo esc_html(

--- a/src/views/v2/rsvp/messages/success/going.php
+++ b/src/views/v2/rsvp/messages/success/going.php
@@ -23,7 +23,7 @@ if ( empty( $is_going ) ) {
 }
 ?>
 
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		<?php
 		echo esc_html(

--- a/src/views/v2/rsvp/messages/success/not-going.php
+++ b/src/views/v2/rsvp/messages/success/not-going.php
@@ -23,7 +23,7 @@ if ( ! empty( $is_going ) ) {
 }
 ?>
 
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		<?php esc_html_e( 'Thank you for confirming!', 'event-tickets' ); ?>
 	</strong>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/MustLoginTest__test_should_render_must_login__1.php
@@ -1,6 +1,6 @@
 <?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--must-login tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--must-login-icon"  xmlns="http://www.w3.org/2000/svg" width="18" height="18"><g fill="none" fill-rule="evenodd" transform="translate(1 1)"><circle cx="8" cy="8" r="7.467" stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><circle id="dot" cx="8" cy="11.733" r="1.067" fill="#141827" fill-rule="nonzero"/><path stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 3.733v4.8"/></g></svg>
-	<span class="tribe-tickets__rsvp-message-text">
+	<span class="tribe-tickets__rsvp-message-text" role="alert">
 		<strong>
 			You must be logged in to RSVP.
 			<a

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_going__1.php
@@ -1,7 +1,7 @@
 <?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
 	
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		Your RSVP has been received! 	</strong>
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Messages/__snapshots__/SuccessTest__test_should_render_success_message_not_going__1.php
@@ -2,7 +2,7 @@
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
 	
 	
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		Thank you for confirming!	</strong>
 

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_error__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_error__1.php
@@ -1,6 +1,6 @@
 <?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--error tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--error-icon"  xmlns="http://www.w3.org/2000/svg" width="18" height="18"><g fill="none" fill-rule="evenodd" transform="translate(1 1)"><circle cx="8" cy="8" r="7.467" stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><circle id="dot" cx="8" cy="11.733" r="1.067" fill="#141827" fill-rule="nonzero"/><path stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 3.733v4.8"/></g></svg>
-			<span class="tribe-tickets__rsvp-message-text">
+			<span class="tribe-tickets__rsvp-message-text" role="alert">
 			<strong>
 				There was an error here			</strong>
 		</span>

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_error_with_an_array__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_error_with_an_array__1.php
@@ -1,14 +1,14 @@
 <?php return '<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--error tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--error-icon"  xmlns="http://www.w3.org/2000/svg" width="18" height="18"><g fill="none" fill-rule="evenodd" transform="translate(1 1)"><circle cx="8" cy="8" r="7.467" stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/><circle id="dot" cx="8" cy="11.733" r="1.067" fill="#141827" fill-rule="nonzero"/><path stroke="#141827" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 3.733v4.8"/></g></svg>
-			<span class="tribe-tickets__rsvp-message-text">
+			<span class="tribe-tickets__rsvp-message-text" role="alert">
 			<strong>
 				There was an error here			</strong>
 		</span>
-			<span class="tribe-tickets__rsvp-message-text">
+			<span class="tribe-tickets__rsvp-message-text" role="alert">
 			<strong>
 				There was an error there too			</strong>
 		</span>
-			<span class="tribe-tickets__rsvp-message-text">
+			<span class="tribe-tickets__rsvp-message-text" role="alert">
 			<strong>
 				There was an error over on the other side too			</strong>
 		</span>

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
@@ -27,7 +27,7 @@
 	<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
 	
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		Your RSVP has been received! 	</strong>
 

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
@@ -27,7 +27,7 @@
 	<div class="tribe-tickets__rsvp-message tribe-tickets__rsvp-message--success tribe-common-b3">
 	<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-message--success-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 15 15"><defs/><path stroke="#111" d="M14 1L6.5 8.5"/><path stroke="#111" stroke-linecap="square" d="M14 1L9.14286 13 6.85714 8.14286 2 5.85714 14 1z" clip-rule="evenodd"/></svg>
 	
-<span class="tribe-tickets__rsvp-message-text">
+<span class="tribe-tickets__rsvp-message-text" role="alert">
 	<strong>
 		Your RSVP has been received! 	</strong>
 


### PR DESCRIPTION
…essibility

### 🎫 Ticket

[[ET-2227](https://stellarwp.atlassian.net/browse/ET-2227)]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Added the attribute "role" on RSVP alerts when the user confirm or "Can't go" to improve accessibility.
The check was made by using the Chrome extension "Read Aloud"

### 🎥 Artifacts <!-- if applicable-->
<img width="535" height="273" alt="Screenshot 2026-02-20 at 20 57 48" src="https://github.com/user-attachments/assets/a9f23052-c221-441a-acce-63adf39774e7" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2227]: https://stellarwp.atlassian.net/browse/ET-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ