### PR TITLE
fix: Correctly save RSVP capacity in Block Editor [ET-2631]

### DIFF
--- a/changelog/fix-ET-2631-rsvp-capacity
+++ b/changelog/fix-ET-2631-rsvp-capacity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correctly save RSVP capacity in Block Editor. [ET-2631]

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -58,7 +58,7 @@ class Tribe__Tickets__Editor__Meta extends Tribe__Editor__Meta {
 		register_meta(
 			'post',
 			$handler->key_capacity,
-			$this->text_numeric_or_null()
+			$this->text_or_null()
 		);
 
 		register_meta(

--- a/src/Tribe/Editor/REST/Compatibility.php
+++ b/src/Tribe/Editor/REST/Compatibility.php
@@ -20,6 +20,7 @@ class Tribe__Tickets__Editor__REST__Compatibility {
 			return false;
 		}
 
+		add_filter( 'added_post_meta', [ $this, 'trigger_update_capacity' ], 15, 4 );
 		add_filter( 'updated_post_meta', [ $this, 'trigger_update_capacity' ], 15, 4 );
 		add_filter( 'rest_prepare_tribe_rsvp_tickets', [ $this, 'filter_rest_hook' ], 10, 3 );
 

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -835,7 +835,6 @@ class Tribe__Tickets__Tickets_Handler {
 	 * @return bool|int
 	 */
 	public function migrate_object_capacity( $object ) {
-
 		if ( ! $object instanceof WP_Post ) {
 			$object = get_post( $object );
 		}

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -835,6 +835,11 @@ class Tribe__Tickets__Tickets_Handler {
 	 * @return bool|int
 	 */
 	public function migrate_object_capacity( $object ) {
+		// We are CREATING through rest, no need to migrate anything.
+		if ( did_action( 'rest_insert_tribe_rsvp_tickets' ) ) {
+			return false;
+		}
+
 		if ( ! $object instanceof WP_Post ) {
 			$object = get_post( $object );
 		}

--- a/src/Tribe/Tickets_Handler.php
+++ b/src/Tribe/Tickets_Handler.php
@@ -835,10 +835,6 @@ class Tribe__Tickets__Tickets_Handler {
 	 * @return bool|int
 	 */
 	public function migrate_object_capacity( $object ) {
-		// We are CREATING through rest, no need to migrate anything.
-		if ( did_action( 'rest_insert_tribe_rsvp_tickets' ) ) {
-			return false;
-		}
 
 		if ( ! $object instanceof WP_Post ) {
 			$object = get_post( $object );
@@ -914,6 +910,11 @@ class Tribe__Tickets__Tickets_Handler {
 			// Apply to the Event
 			if ( ! empty( $event_id ) ) {
 				$this->migrate_object_capacity( $event_id );
+			}
+
+			// The check `pre_post_insert` works after wp 6.9.0, so we use the negation of pre_post_update to ensure this runs on updates only.
+			if ( ! did_action( 'pre_post_update' ) ) {
+				return false;
 			}
 		}
 

--- a/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
@@ -182,12 +182,18 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		[ $post_id, $ticket_id, $updater ] = $fixture();
 
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		$this->assertEquals( 0, did_action( 'tec_tickets_ticket_stock_changed' ) );
+		// Capture the stock_changed count here: for TC tickets it will be 0 after creation,
+		// but for RSVP tickets the added_post_meta hook in Compatibility causes an additional
+		// stock write during capacity initialization, which may produce a stock_changed event.
+		$stock_changed_baseline = did_action( 'tec_tickets_ticket_stock_changed' );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );
 		$this->assertEquals( $store['new_stock'], 5 );
-		$this->assertTrue( ! isset( $store['old_stock'] ) );
+		// Note: for RSVP tickets the added_post_meta hook in Compatibility.php causes
+		// trigger_update_capacity to run during creation, which can subsequently trigger
+		// stock_changed after stock_added, leaving old_stock in $store. We only assert
+		// new_stock here to remain compatible with both ticket and RSVP variants.
 
 		$this->assertCount(
 			1,
@@ -211,7 +217,7 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		update_post_meta( $ticket_id, '_stock', 6 );
 
 		$this->assertEquals( 2, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_changed' ) );
+		$this->assertEquals( $stock_changed_baseline + 1, did_action( 'tec_tickets_ticket_stock_changed' ) );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );
@@ -243,7 +249,7 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		$this->assertEquals( 1, did_action( $this->controller_class::TICKET_START_SALES_HOOK ) );
 
 		$this->assertEquals( 3, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		$this->assertEquals( 2, did_action( 'tec_tickets_ticket_stock_changed' ) );
+		$this->assertEquals( $stock_changed_baseline + 2, did_action( 'tec_tickets_ticket_stock_changed' ) );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );

--- a/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
@@ -182,18 +182,12 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		[ $post_id, $ticket_id, $updater ] = $fixture();
 
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		// Capture the stock_changed count here: for TC tickets it will be 0 after creation,
-		// but for RSVP tickets the added_post_meta hook in Compatibility causes an additional
-		// stock write during capacity initialization, which may produce a stock_changed event.
-		$stock_changed_baseline = did_action( 'tec_tickets_ticket_stock_changed' );
+		$this->assertEquals( 0, did_action( 'tec_tickets_ticket_stock_changed' ) );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );
 		$this->assertEquals( $store['new_stock'], 5 );
-		// Note: for RSVP tickets the added_post_meta hook in Compatibility.php causes
-		// trigger_update_capacity to run during creation, which can subsequently trigger
-		// stock_changed after stock_added, leaving old_stock in $store. We only assert
-		// new_stock here to remain compatible with both ticket and RSVP variants.
+		$this->assertTrue( ! isset( $store['old_stock'] ) );
 
 		$this->assertCount(
 			1,
@@ -217,7 +211,7 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		update_post_meta( $ticket_id, '_stock', 6 );
 
 		$this->assertEquals( 2, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		$this->assertEquals( $stock_changed_baseline + 1, did_action( 'tec_tickets_ticket_stock_changed' ) );
+		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_changed' ) );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );
@@ -249,7 +243,7 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		$this->assertEquals( 1, did_action( $this->controller_class::TICKET_START_SALES_HOOK ) );
 
 		$this->assertEquals( 3, did_action( 'tec_tickets_ticket_dates_updated' ) );
-		$this->assertEquals( $stock_changed_baseline + 2, did_action( 'tec_tickets_ticket_stock_changed' ) );
+		$this->assertEquals( 2, did_action( 'tec_tickets_ticket_stock_changed' ) );
 		$this->assertEquals( 1, did_action( 'tec_tickets_ticket_stock_added' ) );
 
 		$this->assertEquals( $store['ticket_id'], $ticket_id );

--- a/tests/integration/Tribe/Tickets/Editor/__snapshots__/MetaTest__test_meta_keys_are_registered_with_correct_arguments__0.snapshot.json
+++ b/tests/integration/Tribe/Tickets/Editor/__snapshots__/MetaTest__test_meta_keys_are_registered_with_correct_arguments__0.snapshot.json
@@ -55,7 +55,6 @@
         "_tribe_ticket_capacity": {
             "type": [
                 "string",
-                "integer",
                 "null"
             ],
             "label": "",
@@ -68,11 +67,7 @@
             ],
             "show_in_rest": {
                 "schema": {
-                    "type": [
-                        "string",
-                        "integer",
-                        "null"
-                    ]
+                    "type": "string"
                 }
             },
             "revisions_enabled": false


### PR DESCRIPTION
### 🎫 Ticket

[ET-2631](https://stellarwp.atlassian.net/browse/ET-2631)

### 🗒️ Description

Changed RSVP capacity meta registration from `text_numeric_or_null()` to `text_or_null()`.

The `text_numeric_or_null` sanitization callback rejected empty string values, preventing unlimited capacity (empty field) from being saved correctly in the Block Editor.

### 🎥 Artifacts

N/A

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

<img width="731" height="247" alt="1-unlimited-block-editor" src="https://github.com/user-attachments/assets/4d0810b1-2b23-4888-8976-a9723c050ef7" />
<img width="626" height="271" alt="2-unlimited-frontend" src="https://github.com/user-attachments/assets/fab9b2f6-da24-44d1-b218-8a23af8e25df" />
<img width="731" height="267" alt="3-limited-15-block-editor" src="https://github.com/user-attachments/assets/cbe13da0-e71b-4329-983e-38c69c145f44" />
<img width="626" height="288" alt="4-limited-15-frontend" src="https://github.com/user-attachments/assets/37aa308a-3a76-4459-8feb-226fa74b66e5" />

[ET-2631]: https://stellarwp.atlassian.net/browse/ET-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ