### PR TITLE
Fix/et 2228 empty buttons popup

### DIFF
--- a/changelog/fix-ET-2228-empty-buttons-popup
+++ b/changelog/fix-ET-2228-empty-buttons-popup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: accessibility
+
+Added aria-label to the close button on ticket list modal [ET-2228]

--- a/lang/event-tickets.pot
+++ b/lang/event-tickets.pot
@@ -16077,3 +16077,8 @@ msgstr ""
 msgctxt "block keyword"
 msgid "events-gutenberg"
 msgstr ""
+
+#: src/views/modal/item-remove.php
+msgctxt "Remove item button label"
+msgid "Remove item"
+msgstr ""

--- a/src/views/modal/item-remove.php
+++ b/src/views/modal/item-remove.php
@@ -18,6 +18,7 @@
 	<button
 		type="button"
 		class="tribe-tickets__item__remove"
+		aria-label="<?php esc_attr_e( 'Remove item', 'event-tickets' ); ?>"
 	>
 	</button>
 </div>


### PR DESCRIPTION
### 🎫 Ticket
[ET-2228](https://stellarwp.atlassian.net/browse/ET-2228)

### 🗒️ Description

On screen readers the close button wasn't being read because it was empty without any aria.
The `aria-label` has been added and fixed the problem.

### 🎥 Artifacts <!-- if applicable-->
<img width="1142" height="754" alt="et2228-item-code" src="https://github.com/user-attachments/assets/1b97affb-1499-4127-8c17-93c3c99597b9" />

<img width="443" height="171" alt="Screenshot 2026-02-26 at 18 44 29" src="https://github.com/user-attachments/assets/0e478cfa-303d-4fee-a5ee-83f1041915a1" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2228]: https://stellarwp.atlassian.net/browse/ET-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ