### PR TITLE
ET-2229 fix: enhance accessibility by synchronizing aria-expanded att…

### DIFF
--- a/changelog/fix-ET-2229-state-of-the-button-is-not-programmatically-set-popup
+++ b/changelog/fix-ET-2229-state-of-the-button-is-not-programmatically-set-popup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: accessibility
 
-Added aria-expanded to the toggle description button [ET-2229]
+Set the toggle description button state programmatically with aria-expanded in the checkout modal. [ET-2229]

--- a/changelog/fix-ET-2229-state-of-the-button-is-not-programmatically-set-popup
+++ b/changelog/fix-ET-2229-state-of-the-button-is-not-programmatically-set-popup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: accessibility
+
+Added aria-expanded to the toggle description button [ET-2229]

--- a/src/resources/js/v2/tickets-block.js
+++ b/src/resources/js/v2/tickets-block.js
@@ -671,6 +671,16 @@ tribe.tickets.block = {
 		$parent.toggleClass( 'tribe__details--open', onOff );
 		$target.toggleClass( 'tribe__details--open', onOff );
 		$target.toggleClass( obj.selectors.hiddenElement.className() );
+
+		// Keep aria-expanded in sync for accessibility (show/hide state).
+		const $summary = $trigger.closest( '.tribe-tickets__tickets-item-details-summary' );
+		if ( $summary.length ) {
+			$summary
+				.find(
+					obj.selectors.itemDescriptionButtonMore + ', ' + obj.selectors.itemDescriptionButtonLess
+				)
+				.attr( 'aria-expanded', onOff );
+		}
 	};
 
 	/**

--- a/src/views/v2/tickets/item/content/description-toggle.php
+++ b/src/views/v2/tickets/item/content/description-toggle.php
@@ -63,6 +63,7 @@ $ticket_details_id .= '--' . $ticket->ID;
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="<?php echo esc_attr( $ticket_details_id ); ?>"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide"><?php esc_html_e( 'Open the ticket description.', 'event-tickets' ); ?></span>
 		<?php echo esc_html_x( 'More', 'Opens the ticket description', 'event-tickets' ); ?>
@@ -72,6 +73,7 @@ $ticket_details_id .= '--' . $ticket->ID;
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="<?php echo esc_attr( $ticket_details_id ); ?>"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide"><?php esc_html_e( 'Close the ticket description.', 'event-tickets' ); ?></span>
 		<?php echo esc_html_x( 'Less', 'Closes the ticket description', 'event-tickets' ); ?>

--- a/src/views/v2/tickets/item/extra/description-toggle.php
+++ b/src/views/v2/tickets/item/extra/description-toggle.php
@@ -64,6 +64,7 @@ $toggle_id = 'tribe__details__content--' . $ticket->ID;
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="<?php echo esc_attr( $toggle_id ); ?>"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">
 			<?php esc_html_e( 'Open the ticket description.', 'event-tickets' ); ?>
@@ -75,6 +76,7 @@ $toggle_id = 'tribe__details__content--' . $ticket->ID;
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="<?php echo esc_attr( $toggle_id ); ?>"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide"><?php esc_html_e( 'Close the ticket description.', 'event-tickets' ); ?></span>
 		<?php echo esc_html_x( 'Less', 'Closes the ticket description', 'event-tickets' ); ?>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/Content/__snapshots__/DescriptionTest__test_should_render_if_it_is_modal_and_valid_ticket__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/Content/__snapshots__/DescriptionTest__test_should_render_if_it_is_modal_and_valid_ticket__1.php
@@ -5,6 +5,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="tribe__details__content__modal--127"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
 		More	</button>
@@ -13,6 +14,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="tribe__details__content__modal--127"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
 		Less	</button>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/Content/__snapshots__/Description_ToggleTest__test_should_render_if_is_modal_and_valid_ticket__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/Content/__snapshots__/Description_ToggleTest__test_should_render_if_is_modal_and_valid_ticket__1.php
@@ -4,6 +4,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="tribe__details__content__modal--137"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
 		More	</button>
@@ -12,6 +13,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="tribe__details__content__modal--137"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
 		Less	</button>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
@@ -82,6 +82,21 @@ class ContentTest extends V2TestCase {
 		$html = $template->template( $this->partial_path, $args, false );
 
 		$driver = $this->get_html_output_driver();
+
+		$driver->setTolerableDifferences( [
+				$args['post_id'],
+				$args['ticket']->price,
+				$args['ticket']->ID,
+			]
+		);
+
+		$driver->setTolerableDifferencesPrefixes( [
+			'post-',
+			'Test ticket for ',
+			'Test ticket description for ',
+			'tribe__details__content--',
+		] );
+
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
 }

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
@@ -81,13 +81,6 @@ class ContentTest extends V2TestCase {
 		$args = $this->get_default_args();
 		$html = $template->template( $this->partial_path, $args, false );
 
-		// Normalize variable IDs so snapshot is stable (avoids driver fragment alignment issues).
-		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], '{{ID}}', $html );
-		// Normalize price in amount span only (avoid replacing digits inside class names).
-		$html = preg_replace( '/<span class="tribe-amount">[^<]+<\/span>/', '<span class="tribe-amount">{{PRICE}}</span>', $html );
-		// Normalize whitespace (tabs to newlines) so snapshot matches across environments.
-		$html = preg_replace( '/\t+/', "\n", $html );
-
 		$driver = $this->get_html_output_driver();
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/ContentTest.php
@@ -2,8 +2,8 @@
 
 namespace Tribe\Tickets\Partials\V2\Tickets\Item;
 
-use Tribe\Tickets\Test\Partials\V2TestCase;
 use Tribe\Tickets\Test\Commerce\PayPal\Ticket_Maker as PayPal_Ticket_Maker;
+use Tribe\Tickets\Test\Partials\V2TestCase;
 
 class ContentTest extends V2TestCase {
 
@@ -81,22 +81,14 @@ class ContentTest extends V2TestCase {
 		$args = $this->get_default_args();
 		$html = $template->template( $this->partial_path, $args, false );
 
+		// Normalize variable IDs so snapshot is stable (avoids driver fragment alignment issues).
+		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], '{{ID}}', $html );
+		// Normalize price in amount span only (avoid replacing digits inside class names).
+		$html = preg_replace( '/<span class="tribe-amount">[^<]+<\/span>/', '<span class="tribe-amount">{{PRICE}}</span>', $html );
+		// Normalize whitespace (tabs to newlines) so snapshot matches across environments.
+		$html = preg_replace( '/\t+/', "\n", $html );
+
 		$driver = $this->get_html_output_driver();
-
-		$driver->setTolerableDifferences( [
-				$args['post_id'],
-				$args['ticket']->price,
-				$args['ticket']->ID,
-			]
-		);
-
-		$driver->setTolerableDifferencesPrefixes( [
-			'post-',
-			'Test ticket for ',
-			'Test ticket description for ',
-			'tribe__details__content--',
-		] );
-
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
 }

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
@@ -1,32 +1,32 @@
 <?php return '<div  class="tribe-tickets__tickets-item-content-title-container" >
 		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-				Test ticket for {{ID}}	</div>
+				Test ticket for 8	</div>
 </div>
 
 
 <div
-	id="tribe__details__content--{{POST_ID}}"
+	id="tribe__details__content--12953"
 	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
-	Test ticket description for {{ID}}</div>
+	Test ticket description for 8</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
 	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
 		<span class="tribe-tickets__tickets-sale-price">
-
+		
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">{{PRICE}}</span>
+					<span class="tribe-amount">6.00</span>
 				</span>
 						</span>
 </div>
 
-
+	
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-
+	
 	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-
+	
 </div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
@@ -1,32 +1,50 @@
 <?php return '<div  class="tribe-tickets__tickets-item-content-title-container" >
-		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-				Test ticket for 8	</div>
+
+<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+
+Test ticket for {{ID}}
+</div>
 </div>
 
 
 <div
-	id="tribe__details__content--12953"
-	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
-	Test ticket description for 8</div>
+
+id="tribe__details__content--{{ID}}"
+
+ class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
+
+Test ticket description for {{ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
-	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-		<span class="tribe-tickets__tickets-sale-price">
-		
-				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">5.00</span>
-				</span>
-						</span>
+
+<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+
+<span class="tribe-tickets__tickets-sale-price">
+
+
+
+<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+
+<span class="tribe-currency-symbol">$</span>
+
+<span class="tribe-amount">{{PRICE}}</span>
+
+</span>
+
+</span>
 </div>
 
-	
+
+
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-	
-	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+
+
+
+<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-	
+
+
 </div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
@@ -1,49 +1,31 @@
 <?php return '<div  class="tribe-tickets__tickets-item-content-title-container" >
-
-<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-
-Test ticket for {{ID}}
-</div>
+		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+				Test ticket for {{ID}}	</div>
 </div>
 
 
 <div
-
-id="tribe__details__content--{{ID}}"
-
- class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
-
-Test ticket description for {{ID}}</div>
+	id="tribe__details__content--{{POST_ID}}"
+	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
+	Test ticket description for {{ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
+	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+		<span class="tribe-tickets__tickets-sale-price">
 
-<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-
-<span class="tribe-tickets__tickets-sale-price">
-
-
-
-<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-
-<span class="tribe-currency-symbol">$</span>
-
-<span class="tribe-amount">{{PRICE}}</span>
-
-</span>
-
-</span>
+				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+					<span class="tribe-currency-symbol">$</span>
+					<span class="tribe-amount">{{PRICE}}</span>
+				</span>
+						</span>
 </div>
-
 
 
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
 
-
-
-<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
-
 
 
 </div>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/TicketsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tribe\Tickets\Partials\V2;
 
-use Tribe\Tickets\Test\Partials\V2TestCase;
 use Tribe\Tickets\Test\Commerce\PayPal\Ticket_Maker as PayPal_Ticket_Maker;
+use Tribe\Tickets\Test\Partials\V2TestCase;
 
 class TicketsTest extends V2TestCase {
 
@@ -221,8 +221,6 @@ class TicketsTest extends V2TestCase {
 		$driver->setTolerableDifferences( $this->tolerables );
 
 		$html = str_replace( $this->tolerables, '{{POST_TICKET_ID}}', $html );
-		// Normalize whitespace (tabs to newlines) so snapshot matches across environments.
-		$html = preg_replace( '/\t+/', "\n", $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/TicketsTest.php
@@ -221,6 +221,8 @@ class TicketsTest extends V2TestCase {
 		$driver->setTolerableDifferences( $this->tolerables );
 
 		$html = str_replace( $this->tolerables, '{{POST_TICKET_ID}}', $html );
+		// Normalize whitespace (tabs to newlines) so snapshot matches across environments.
+		$html = preg_replace( '/\t+/', "\n", $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
@@ -1,217 +1,382 @@
 <?php return '<div  class="tribe-common event-tickets tribe-tickets__tickets-wrapper" >
-	<form
-		id="tribe-tickets__tickets-form"
-		action=""
-		class="tribe-tickets__tickets-form tribe-tickets__form"
-		method="post"
-		enctype=\'multipart/form-data\'
-		data-provider="Tribe__Tickets__Commerce__PayPal__Main"
-		autocomplete="off"
-		data-provider-id="tribe-commerce"
-		data-post-id="{{POST_TICKET_ID}}"
-		novalidate
-	>
 
-		<input type="hidden" name="tribe_tickets_saving_attendees" value="1"/>
-		<input type="hidden" name="tribe_tickets_ar" value="1"/>
-		<input type="hidden" name="tribe_tickets_ar_data" value="" id="tribe_tickets_block_ar_data"/>
+<form
 
-		<input
-	type="hidden"
-	id="add"
-	name="add"
-	value="1"
+id="tribe-tickets__tickets-form"
+
+action=""
+
+class="tribe-tickets__tickets-form tribe-tickets__form"
+
+method="post"
+
+enctype=\'multipart/form-data\'
+
+data-provider="Tribe__Tickets__Commerce__PayPal__Main"
+
+autocomplete="off"
+
+data-provider-id="tribe-commerce"
+
+data-post-id="{{POST_TICKET_ID}}"
+
+novalidate
+
+>
+
+
+<input type="hidden" name="tribe_tickets_saving_attendees" value="1"/>
+
+<input type="hidden" name="tribe_tickets_ar" value="1"/>
+
+<input type="hidden" name="tribe_tickets_ar_data" value="" id="tribe_tickets_block_ar_data"/>
+
+
+<input
+
+type="hidden"
+
+id="add"
+
+name="add"
+
+value="1"
 />
 <input name="provider" value="Tribe__Tickets__Commerce__PayPal__Main" class="tribe-tickets-provider" type="hidden">
 
-		<h2 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__tickets-title">
-	Tickets</h2>
 
-		<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
+<h2 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__tickets-title">
 
-	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
-		The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.	</div>
+Tickets</h2>
+
+
+<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
+
+
+
+<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
+
+The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.
+</div>
 </div>
 
-		<div
-	id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
-	 class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
 
-	<div  class="tribe-tickets__tickets-item-content-title-container" >
-		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-				Test ticket for {{POST_TICKET_ID}}	</div>
+<div
+
+id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
+
+ class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 
+ data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
+
+
+<div  class="tribe-tickets__tickets-item-content-title-container" >
+
+<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+
+Test ticket for {{POST_TICKET_ID}}
+</div>
 </div>
 
 <div class="tribe-tickets__tickets-item-details-summary">
-	<button
-		type="button"
-		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
-		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-		tabindex="0"
-		aria-expanded="false"
-	>
-		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
-		More	</button>
-	<button
-		type="button"
-		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
-		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-		tabindex="0"
-		aria-expanded="true"
-	>
-		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
-		Less	</button>
+
+<button
+
+type="button"
+
+class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
+
+aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+tabindex="0"
+
+aria-expanded="false"
+
+>
+
+<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
+
+More
+</button>
+
+<button
+
+type="button"
+
+class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
+
+aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+tabindex="0"
+
+aria-expanded="true"
+
+>
+
+<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
+
+Less
+</button>
 </div>
 
 <div
-	id="tribe__details__content__modal--{{POST_TICKET_ID}}"
-	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
-	Test ticket description for {{POST_TICKET_ID}}</div>
+
+id="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+ class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
+
+Test ticket description for {{POST_TICKET_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
-	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-		<span class="tribe-tickets__tickets-sale-price">
 
-				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">99.00</span>
-				</span>
-						</span>
+<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+
+<span class="tribe-tickets__tickets-sale-price">
+
+
+
+<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+
+<span class="tribe-currency-symbol">$</span>
+
+<span class="tribe-amount">99.00</span>
+
+</span>
+
+</span>
 </div>
+
 
 
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
 
-	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+
+
+<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
 
+
 </div>
 
-	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
-			<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
-	Sold Out</div>
-	</div>
+
+<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
+
+<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
+
+Sold Out</div>
+
+</div>
+
+
 
 
 
 </div>
 <div
-	id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
-	 class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
 
-	<div  class="tribe-tickets__tickets-item-content-title-container" >
-		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-				Test ticket for {{POST_TICKET_ID}}	</div>
+id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
+
+ class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 
+ data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
+
+
+<div  class="tribe-tickets__tickets-item-content-title-container" >
+
+<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+
+Test ticket for {{POST_TICKET_ID}}
+</div>
 </div>
 
 <div class="tribe-tickets__tickets-item-details-summary">
-	<button
-		type="button"
-		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
-		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-		tabindex="0"
-		aria-expanded="false"
-	>
-		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
-		More	</button>
-	<button
-		type="button"
-		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
-		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-		tabindex="0"
-		aria-expanded="true"
-	>
-		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
-		Less	</button>
+
+<button
+
+type="button"
+
+class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
+
+aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+tabindex="0"
+
+aria-expanded="false"
+
+>
+
+<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
+
+More
+</button>
+
+<button
+
+type="button"
+
+class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
+
+aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+tabindex="0"
+
+aria-expanded="true"
+
+>
+
+<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
+
+Less
+</button>
 </div>
 
 <div
-	id="tribe__details__content__modal--{{POST_TICKET_ID}}"
-	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
-	Test ticket description for {{POST_TICKET_ID}}</div>
+
+id="tribe__details__content__modal--{{POST_TICKET_ID}}"
+
+ class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
+
+Test ticket description for {{POST_TICKET_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
-	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-		<span class="tribe-tickets__tickets-sale-price">
 
-				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">99.00</span>
-				</span>
-						</span>
+<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+
+<span class="tribe-tickets__tickets-sale-price">
+
+
+
+<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+
+<span class="tribe-currency-symbol">$</span>
+
+<span class="tribe-amount">99.00</span>
+
+</span>
+
+</span>
 </div>
+
 
 
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
 
-	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+
+
+<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
-
-
-</div>
-
-	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
-			<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
-	Sold Out</div>
-	</div>
 
 
 
 </div>
 
-		<div class="tribe-tickets__tickets-footer">
 
+<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
 
-	<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
-	<span class="tribe-tickets__tickets-footer-quantity-label">
-		Quantity:	</span>
-	<span class="tribe-tickets__tickets-footer-quantity-number">0</span>
+<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
+
+Sold Out</div>
+
 </div>
 
-	<div class="tribe-common-b2 tribe-tickets__tickets-footer-total">
-	<span class="tribe-tickets__tickets-footer-total-label">
-		Total:	</span>
-	<span class="tribe-tickets__tickets-footer-total-wrap">
 
-				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">0.00</span>
-				</span>
-				</span>
-</div>
+
 
 
 </div>
 
 
-		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-common-c-loader__dot tribe-common-c-loader__dot--third" >
-	<svg
-	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 	aria-hidden="true"
-	viewBox="0 0 15 15"
-	xmlns="http://www.w3.org/2000/svg"
+<div class="tribe-tickets__tickets-footer">
+
+
+
+
+<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
+
+<span class="tribe-tickets__tickets-footer-quantity-label">
+
+Quantity:
+</span>
+
+<span class="tribe-tickets__tickets-footer-quantity-number">0</span>
+</div>
+
+
+<div class="tribe-common-b2 tribe-tickets__tickets-footer-total">
+
+<span class="tribe-tickets__tickets-footer-total-label">
+
+Total:
+</span>
+
+<span class="tribe-tickets__tickets-footer-total-wrap">
+
+
+
+<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+
+<span class="tribe-currency-symbol">$</span>
+
+<span class="tribe-amount">0.00</span>
+
+</span>
+
+</span>
+</div>
+
+
+
+</div>
+
+
+
+
+<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-common-c-loader__dot tribe-common-c-loader__dot--third" >
+
+<svg
+
+ class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 
+aria-hidden="true"
+
+viewBox="0 0 15 15"
+
+xmlns="http://www.w3.org/2000/svg"
 >
-	<circle cx="7.5" cy="7.5" r="7.5"/>
+
+<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
-	<svg
-	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 	aria-hidden="true"
-	viewBox="0 0 15 15"
-	xmlns="http://www.w3.org/2000/svg"
+
+<svg
+
+ class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 
+aria-hidden="true"
+
+viewBox="0 0 15 15"
+
+xmlns="http://www.w3.org/2000/svg"
 >
-	<circle cx="7.5" cy="7.5" r="7.5"/>
+
+<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
-	<svg
-	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 	aria-hidden="true"
-	viewBox="0 0 15 15"
-	xmlns="http://www.w3.org/2000/svg"
+
+<svg
+
+ class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 
+aria-hidden="true"
+
+viewBox="0 0 15 15"
+
+xmlns="http://www.w3.org/2000/svg"
 >
-	<circle cx="7.5" cy="7.5" r="7.5"/>
+
+<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
 </div>
 
-			</form>
 
-	</div>
+</form>
+
+
+</div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
@@ -1,382 +1,217 @@
 <?php return '<div  class="tribe-common event-tickets tribe-tickets__tickets-wrapper" >
+	<form
+		id="tribe-tickets__tickets-form"
+		action=""
+		class="tribe-tickets__tickets-form tribe-tickets__form"
+		method="post"
+		enctype=\'multipart/form-data\'
+		data-provider="Tribe__Tickets__Commerce__PayPal__Main"
+		autocomplete="off"
+		data-provider-id="tribe-commerce"
+		data-post-id="{{POST_TICKET_ID}}"
+		novalidate
+	>
 
-<form
+		<input type="hidden" name="tribe_tickets_saving_attendees" value="1"/>
+		<input type="hidden" name="tribe_tickets_ar" value="1"/>
+		<input type="hidden" name="tribe_tickets_ar_data" value="" id="tribe_tickets_block_ar_data"/>
 
-id="tribe-tickets__tickets-form"
-
-action=""
-
-class="tribe-tickets__tickets-form tribe-tickets__form"
-
-method="post"
-
-enctype=\'multipart/form-data\'
-
-data-provider="Tribe__Tickets__Commerce__PayPal__Main"
-
-autocomplete="off"
-
-data-provider-id="tribe-commerce"
-
-data-post-id="{{POST_TICKET_ID}}"
-
-novalidate
-
->
-
-
-<input type="hidden" name="tribe_tickets_saving_attendees" value="1"/>
-
-<input type="hidden" name="tribe_tickets_ar" value="1"/>
-
-<input type="hidden" name="tribe_tickets_ar_data" value="" id="tribe_tickets_block_ar_data"/>
-
-
-<input
-
-type="hidden"
-
-id="add"
-
-name="add"
-
-value="1"
+		<input
+	type="hidden"
+	id="add"
+	name="add"
+	value="1"
 />
 <input name="provider" value="Tribe__Tickets__Commerce__PayPal__Main" class="tribe-tickets-provider" type="hidden">
 
+		<h2 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__tickets-title">
+	Tickets</h2>
 
-<h2 class="tribe-common-h4 tribe-common-h--alt tribe-tickets__tickets-title">
-
-Tickets</h2>
-
-
-<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
-
-
-
-<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
-
-The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.
-</div>
+		<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
+	
+	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
+		The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.	</div>
 </div>
 
+		<div
+	id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
+	 class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
 
-<div
-
-id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
-
- class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 
- data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
-
-
-<div  class="tribe-tickets__tickets-item-content-title-container" >
-
-<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-
-Test ticket for {{POST_TICKET_ID}}
-</div>
+	<div  class="tribe-tickets__tickets-item-content-title-container" >
+		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+				Test ticket for {{POST_TICKET_ID}}	</div>
 </div>
 
 <div class="tribe-tickets__tickets-item-details-summary">
-
-<button
-
-type="button"
-
-class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
-
-aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
-tabindex="0"
-
-aria-expanded="false"
-
->
-
-<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
-
-More
-</button>
-
-<button
-
-type="button"
-
-class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
-
-aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
-tabindex="0"
-
-aria-expanded="true"
-
->
-
-<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
-
-Less
-</button>
+	<button
+		type="button"
+		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
+		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+		tabindex="0"
+		aria-expanded="false"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
+		More	</button>
+	<button
+		type="button"
+		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
+		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+		tabindex="0"
+		aria-expanded="true"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
+		Less	</button>
 </div>
 
 <div
-
-id="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
- class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
-
-Test ticket description for {{POST_TICKET_ID}}</div>
+	id="tribe__details__content__modal--{{POST_TICKET_ID}}"
+	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
+	Test ticket description for {{POST_TICKET_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
-
-<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-
-<span class="tribe-tickets__tickets-sale-price">
-
-
-
-<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-
-<span class="tribe-currency-symbol">$</span>
-
-<span class="tribe-amount">99.00</span>
-
-</span>
-
-</span>
+	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+		<span class="tribe-tickets__tickets-sale-price">
+		
+				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+					<span class="tribe-currency-symbol">$</span>
+					<span class="tribe-amount">99.00</span>
+				</span>
+						</span>
 </div>
 
-
-
+	
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-
-
-
-<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+	
+	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-
-
+	
 </div>
 
+	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
+			<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
+	Sold Out</div>
+	</div>
 
-<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
-
-<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
-
-Sold Out</div>
-
-</div>
-
-
-
-
-
+	
+	
 </div>
 <div
+	id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
+	 class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
 
-id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
-
- class="tribe-tickets__tickets-item post-{{POST_TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 
- data-ticket-id="{{POST_TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" >
-
-
-<div  class="tribe-tickets__tickets-item-content-title-container" >
-
-<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
-
-Test ticket for {{POST_TICKET_ID}}
-</div>
+	<div  class="tribe-tickets__tickets-item-content-title-container" >
+		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
+				Test ticket for {{POST_TICKET_ID}}	</div>
 </div>
 
 <div class="tribe-tickets__tickets-item-details-summary">
-
-<button
-
-type="button"
-
-class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
-
-aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
-tabindex="0"
-
-aria-expanded="false"
-
->
-
-<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
-
-More
-</button>
-
-<button
-
-type="button"
-
-class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
-
-aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
-tabindex="0"
-
-aria-expanded="true"
-
->
-
-<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
-
-Less
-</button>
+	<button
+		type="button"
+		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
+		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+		tabindex="0"
+		aria-expanded="false"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
+		More	</button>
+	<button
+		type="button"
+		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
+		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
+		tabindex="0"
+		aria-expanded="true"
+	>
+		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
+		Less	</button>
 </div>
 
 <div
-
-id="tribe__details__content__modal--{{POST_TICKET_ID}}"
-
- class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
-
-Test ticket description for {{POST_TICKET_ID}}</div>
+	id="tribe__details__content__modal--{{POST_TICKET_ID}}"
+	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content tribe-common-a11y-hidden" >
+	Test ticket description for {{POST_TICKET_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >
 
-
-<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
-
-<span class="tribe-tickets__tickets-sale-price">
-
-
-
-<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-
-<span class="tribe-currency-symbol">$</span>
-
-<span class="tribe-amount">99.00</span>
-
-</span>
-
-</span>
+	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
+		<span class="tribe-tickets__tickets-sale-price">
+		
+				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+					<span class="tribe-currency-symbol">$</span>
+					<span class="tribe-amount">99.00</span>
+				</span>
+						</span>
 </div>
 
-
-
+	
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-
-
-
-<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
+	
+	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-
-
+	
 </div>
 
+	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
+			<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
+	Sold Out</div>
+	</div>
 
-<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
-
-<div class="tribe-common-b2 tribe-common-b2--bold tribe-tickets__tickets-item-quantity-unavailable">
-
-Sold Out</div>
-
+	
+	
 </div>
 
+		<div class="tribe-tickets__tickets-footer">
 
-
-
-
+	
+	<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
+	<span class="tribe-tickets__tickets-footer-quantity-label">
+		Quantity:	</span>
+	<span class="tribe-tickets__tickets-footer-quantity-number">0</span>
 </div>
 
-
-<div class="tribe-tickets__tickets-footer">
-
-
-
-
-<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
-
-<span class="tribe-tickets__tickets-footer-quantity-label">
-
-Quantity:
-</span>
-
-<span class="tribe-tickets__tickets-footer-quantity-number">0</span>
+	<div class="tribe-common-b2 tribe-tickets__tickets-footer-total">
+	<span class="tribe-tickets__tickets-footer-total-label">
+		Total:	</span>
+	<span class="tribe-tickets__tickets-footer-total-wrap">
+		
+				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
+					<span class="tribe-currency-symbol">$</span>
+					<span class="tribe-amount">0.00</span>
+				</span>
+				</span>
 </div>
 
-
-<div class="tribe-common-b2 tribe-tickets__tickets-footer-total">
-
-<span class="tribe-tickets__tickets-footer-total-label">
-
-Total:
-</span>
-
-<span class="tribe-tickets__tickets-footer-total-wrap">
-
-
-
-<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
-
-<span class="tribe-currency-symbol">$</span>
-
-<span class="tribe-amount">0.00</span>
-
-</span>
-
-</span>
+	
 </div>
 
-
-
-</div>
-
-
-
-
-<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-common-c-loader__dot tribe-common-c-loader__dot--third" >
-
-<svg
-
- class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 
-aria-hidden="true"
-
-viewBox="0 0 15 15"
-
-xmlns="http://www.w3.org/2000/svg"
+		
+		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-common-c-loader__dot tribe-common-c-loader__dot--third" >
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
 >
-
-<circle cx="7.5" cy="7.5" r="7.5"/>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
-
-<svg
-
- class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 
-aria-hidden="true"
-
-viewBox="0 0 15 15"
-
-xmlns="http://www.w3.org/2000/svg"
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
 >
-
-<circle cx="7.5" cy="7.5" r="7.5"/>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
-
-<svg
-
- class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 
-aria-hidden="true"
-
-viewBox="0 0 15 15"
-
-xmlns="http://www.w3.org/2000/svg"
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
 >
-
-<circle cx="7.5" cy="7.5" r="7.5"/>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
 </svg>
 </div>
 
+			</form>
 
-</form>
-
-
-</div>
+	</div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/__snapshots__/TicketsTest__test_should_render_ticket_block_for_is_modal__1.php
@@ -28,7 +28,7 @@
 	Tickets</h2>
 
 		<div id="tribe-tickets__notice__tickets-in-cart"  class="tribe-tickets__notice tribe-tickets__notice--barred tribe-tickets__notice--barred-left" >
-	
+
 	<div  class="tribe-common-b2 tribe-tickets-notice__content tribe-common-b3" >
 		The numbers below include tickets for this event already in your cart. Clicking "Get Tickets" will allow you to edit any existing attendee information as well as change ticket quantities.	</div>
 </div>
@@ -48,6 +48,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
 		More	</button>
@@ -56,6 +57,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
 		Less	</button>
@@ -69,7 +71,7 @@
 
 	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
 		<span class="tribe-tickets__tickets-sale-price">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">99.00</span>
@@ -77,14 +79,14 @@
 						</span>
 </div>
 
-	
+
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-	
+
 	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-	
+
 </div>
 
 	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
@@ -92,8 +94,8 @@
 	Sold Out</div>
 	</div>
 
-	
-	
+
+
 </div>
 <div
 	id="tribe-modal-tickets-item-{{POST_TICKET_ID}}"
@@ -110,6 +112,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--more"
 		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
 		tabindex="0"
+		aria-expanded="false"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Open the ticket description.</span>
 		More	</button>
@@ -118,6 +121,7 @@
 		class="tribe-common-b3 tribe-tickets__tickets-item-details-summary-button--less"
 		aria-controls="tribe__details__content__modal--{{POST_TICKET_ID}}"
 		tabindex="0"
+		aria-expanded="true"
 	>
 		<span class="screen-reader-text tribe-common-a11y-visual-hide">Close the ticket description.</span>
 		Less	</button>
@@ -131,7 +135,7 @@
 
 	<div  class="tribe-common-b2 tribe-common-b1--min-medium tribe-tickets__tickets-item-extra-price" >
 		<span class="tribe-tickets__tickets-sale-price">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">99.00</span>
@@ -139,14 +143,14 @@
 						</span>
 </div>
 
-	
+
 <div class="tribe-common-b3 tribe-tickets__tickets-item-extra-available">
 
-	
+
 	<span class="tribe-tickets__tickets-item-extra-available-quantity"> 100 </span> available
 </div>
 
-	
+
 </div>
 
 	<div  class="tribe-common-h4 tribe-tickets__tickets-item-quantity" >
@@ -154,13 +158,13 @@
 	Sold Out</div>
 	</div>
 
-	
-	
+
+
 </div>
 
 		<div class="tribe-tickets__tickets-footer">
 
-	
+
 	<div class="tribe-common-b2 tribe-tickets__tickets-footer-quantity">
 	<span class="tribe-tickets__tickets-footer-quantity-label">
 		Quantity:	</span>
@@ -171,7 +175,7 @@
 	<span class="tribe-tickets__tickets-footer-total-label">
 		Total:	</span>
 	<span class="tribe-tickets__tickets-footer-total-wrap">
-		
+
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
 					<span class="tribe-amount">0.00</span>
@@ -179,10 +183,10 @@
 				</span>
 </div>
 
-	
+
 </div>
 
-		
+
 		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden tribe-common-c-loader__dot tribe-common-c-loader__dot--third" >
 	<svg
 	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 	aria-hidden="true"


### PR DESCRIPTION
### 🎫 Ticket

[ET-2229](https://stellarwp.atlassian.net/browse/ET-2229)

### 🗒️ Description

The buttons responsible to show/hide the ticket description was missing its state, we added the attribute `aria-expanded` to tell the screen readers the current state 

### 🎥 Artifacts <!-- if applicable-->
<img width="467" height="77" alt="Screenshot 2026-02-27 at 12 13 12" src="https://github.com/user-attachments/assets/c7c398aa-ea78-413d-b79a-39fb10294d35" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2229]: https://stellarwp.atlassian.net/browse/ET-2229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ