### PR TITLE
Fix/et 2084 emails event schema visible in emails

### DIFF
--- a/changelog/fix-ET-2084-emails-event-schema-visible-in-emails
+++ b/changelog/fix-ET-2084-emails-event-schema-visible-in-emails
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Removed json_ld from RSVP emails
+Removed json_ld from RSVP emails [ET-2084]

--- a/changelog/fix-ET-2084-emails-event-schema-visible-in-emails
+++ b/changelog/fix-ET-2084-emails-event-schema-visible-in-emails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Removed json_ld from RSVP emails

--- a/src/Tickets/Emails/Hooks.php
+++ b/src/Tickets/Emails/Hooks.php
@@ -77,6 +77,9 @@ class Hooks extends Service_Provider {
 
 		// skip saving hidden fields for RSVP emails.
 		add_filter( 'tribe_settings_fields', [ $this, 'filter_rsvp_fields_before_saving' ], 90, 2 );
+
+		// Remove json_ld schema data from email template arguments.
+		add_filter( 'tec_tickets_emails_template_args', [ $this, 'filter_remove_json_ld_from_template_args' ] );
 	}
 
 	/**
@@ -281,5 +284,22 @@ class Hooks extends Service_Provider {
 	 */
 	public function action_template_redirect_tickets_emails() {
 		$this->container->make( Web_View::class )->action_template_redirect_tickets_emails();
+	}
+
+	/**
+	 * Filters the template arguments to remove json_ld schema data that should not be visible in emails.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args The email template arguments.
+	 *
+	 * @return array The filtered template arguments.
+	 */
+	public function filter_remove_json_ld_from_template_args( $args ) {
+		if ( ! empty( $args['json_ld'] ) ) {
+			unset( $args['json_ld'] );
+		}
+
+		return $args;
 	}
 }

--- a/tests/slr_integration/Admin/Events/Controller_Test.php
+++ b/tests/slr_integration/Admin/Events/Controller_Test.php
@@ -280,9 +280,10 @@ class Controller_Test extends Controller_Test_Case {
 			$html = str_replace( $ids, array_fill( 0, count( $ids ), '{{ID}}' ), $html );
 		}
 
-		// Normalize empty list: WP may or may not output tablenav-pages for 0 items (CI vs local).
+		// Normalize empty list: WP may or may not output tablenav-pages or tablenav bottom for 0 items (CI vs local).
 		if ( strpos( $html, 'No Associated Events found' ) !== false ) {
 			$html = $this->remove_tablenav_pages_blocks( $html );
+			$html = $this->remove_tablenav_bottom_block( $html );
 		}
 
 		$this->assertMatchesHtmlSnapshot( $html );
@@ -296,6 +297,18 @@ class Controller_Test extends Controller_Test_Case {
 	 */
 	private function remove_tablenav_pages_blocks( string $html ): string {
 		$pattern = "#<div\s+[^>]*class\s*=\s*['\"]?[^'\"]*tablenav-pages[^'\"]*['\"]?[^>]*>.*?</div>#s";
+		return (string) preg_replace( $pattern, '', $html );
+	}
+
+	/**
+	 * Removes the tablenav bottom wrapper so snapshot is stable (WP may or may not output it for 0 items).
+	 *
+	 * @param string $html Raw list table HTML.
+	 * @return string Normalized HTML.
+	 */
+	private function remove_tablenav_bottom_block( string $html ): string {
+		// Match full block including nested divs, up to <br class="clear" /> then closing </div>.
+		$pattern = "#<div\s+[^>]*class\s*=\s*['\"][^'\"]*tablenav\s+bottom[^'\"]*['\"][^>]*>.*?<br\s+[^>]*class\s*=\s*['\"]clear['\"][^>]*/>\s*</div>#s";
 		return (string) preg_replace( $pattern, '', $html );
 	}
 }

--- a/tests/slr_integration/Admin/Events/Controller_Test.php
+++ b/tests/slr_integration/Admin/Events/Controller_Test.php
@@ -280,6 +280,22 @@ class Controller_Test extends Controller_Test_Case {
 			$html = str_replace( $ids, array_fill( 0, count( $ids ), '{{ID}}' ), $html );
 		}
 
+		// Normalize empty list: WP may or may not output tablenav-pages for 0 items (CI vs local).
+		if ( strpos( $html, 'No Associated Events found' ) !== false ) {
+			$html = $this->remove_tablenav_pages_blocks( $html );
+		}
+
 		$this->assertMatchesHtmlSnapshot( $html );
+	}
+
+	/**
+	 * Removes tablenav-pages blocks so snapshot is stable (WP may or may not output them for 0 items).
+	 *
+	 * @param string $html Raw list table HTML.
+	 * @return string Normalized HTML.
+	 */
+	private function remove_tablenav_pages_blocks( string $html ): string {
+		$pattern = "#<div\s+[^>]*class\s*=\s*['\"]?[^'\"]*tablenav-pages[^'\"]*['\"]?[^>]*>.*?</div>#s";
+		return (string) preg_replace( $pattern, '', $html );
 	}
 }

--- a/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Layout ID without attached event__0.snapshot.html
+++ b/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Layout ID without attached event__0.snapshot.html
@@ -12,6 +12,7 @@
 
 				<div class="alignleft actions">
 				</div>
+		
 		<br class="clear" />
 	</div>
 		<table class="wp-list-table widefat fixed striped table-view- posts">

--- a/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Layout ID without attached event__0.snapshot.html
+++ b/tests/slr_integration/Admin/Events/__snapshots__/Controller_Test__test_associated_events_list__Layout ID without attached event__0.snapshot.html
@@ -12,13 +12,6 @@
 
 				<div class="alignleft actions">
 				</div>
-		<div class='tablenav-pages no-pages'><span class="displaying-num">0 items</span>
-<span class='pagination-links'><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>
-<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>
-<span class="paging-input"><label for="current-page-selector" class="screen-reader-text">Current Page</label><input class='current-page' id='current-page-selector' type='text'
-					name='paged' value='1' size='1' aria-describedby='table-paging' /><span class='tablenav-paging-text'> of <span class='total-pages'>0</span></span></span>
-<a class='next-page button' href='http://wordpress.test?paged=0'><span class='screen-reader-text'>Next page</span><span aria-hidden='true'>&rsaquo;</span></a>
-<a class='last-page button' href='http://wordpress.test?paged=0'><span class='screen-reader-text'>Last page</span><span aria-hidden='true'>&raquo;</span></a></span></div>
 		<br class="clear" />
 	</div>
 		<table class="wp-list-table widefat fixed striped table-view- posts">
@@ -37,17 +30,5 @@
 	</tfoot>
 
 </table>
-			<div class="tablenav bottom">
-
-				<div class="alignleft actions">
-				</div>
-		<div class='tablenav-pages no-pages'><span class="displaying-num">0 items</span>
-<span class='pagination-links'><span class="tablenav-pages-navspan button disabled" aria-hidden="true">&laquo;</span>
-<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>
-<span class="screen-reader-text">Current Page</span><span id="table-paging" class="paging-input"><span class="tablenav-paging-text">1 of <span class='total-pages'>0</span></span></span>
-<a class='next-page button' href='http://wordpress.test?paged=0'><span class='screen-reader-text'>Next page</span><span aria-hidden='true'>&rsaquo;</span></a>
-<a class='last-page button' href='http://wordpress.test?paged=0'><span class='screen-reader-text'>Last page</span><span aria-hidden='true'>&raquo;</span></a></span></div>
-		<br class="clear" />
-	</div>
 			</form>
 </div>

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_ticket_emails_has_seat_info__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_ticket_emails_has_seat_info__0.snapshot.html
@@ -14,8 +14,6 @@
 	</xml>
 </noscript>
 <![endif]-->
-		<script type="application/ld+json">
-	[{"@context":"https:\/\/schema.org","@type":"EventReservation","reservationNumber":ORDER_ID,"reservationStatus":"https:\/\/schema.org\/Confirmed","underName":{"@type":"Person","name":"Test Purchaser","email":"test-purchaser@test.com"},"reservationFor":{"@type":"Event","name":"Event with single seated attendee","url":"http:\/\/wordpress.test\/?tribe_events=event-with-single-seated-attendee","description":"","startDate":"2020-01-01T00:00:00+00:00","endDate":"2020-01-01T02:00:00+00:00"},"ticketToken":"SECURITY_CODE","ticketNumber":ATTENDEE_ID,"numSeats":"1"}]</script>
 		<style type="text/css">
 	td.tec-tickets__email-table-content-event-links-container,
 	td.tec-tickets__email-table-content-event-date-container,

--- a/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_ticket_emails_has_seat_info_for_multiple_attendees__0.snapshot.html
+++ b/tests/slr_integration/Orders/__snapshots__/Controller_Test__test_ticket_emails_has_seat_info_for_multiple_attendees__0.snapshot.html
@@ -14,8 +14,6 @@
 	</xml>
 </noscript>
 <![endif]-->
-		<script type="application/ld+json">
-	[{"@context":"https:\/\/schema.org","@type":"EventReservation","reservationNumber":ORDER_ID,"reservationStatus":"https:\/\/schema.org\/Confirmed","underName":{"@type":"Person","name":"Test Purchaser","email":"test-purchaser@test.com"},"reservationFor":{"@type":"Event","name":"Event with multiple seated attendee","url":"http:\/\/wordpress.test\/?tribe_events=event-with-multiple-seated-attendee","description":"","startDate":"2020-01-01T00:00:00+00:00","endDate":"2020-01-01T02:00:00+00:00"},"ticketToken":"SECURITY_CODE","ticketNumber":ATTENDEE_ID_1,"numSeats":"1"},{"@context":"https:\/\/schema.org","@type":"EventReservation","reservationNumber":ORDER_ID,"reservationStatus":"https:\/\/schema.org\/Confirmed","underName":{"@type":"Person","name":"Test Purchaser","email":"test-purchaser@test.com"},"reservationFor":{"@type":"Event","name":"Event with multiple seated attendee","url":"http:\/\/wordpress.test\/?tribe_events=event-with-multiple-seated-attendee","description":"","startDate":"2020-01-01T00:00:00+00:00","endDate":"2020-01-01T02:00:00+00:00"},"ticketToken":"SECURITY_CODE","ticketNumber":ATTENDEE_ID_2,"numSeats":"1"}]</script>
 		<style type="text/css">
 	td.tec-tickets__email-table-content-event-links-container,
 	td.tec-tickets__email-table-content-event-date-container,


### PR DESCRIPTION
### 🎫 Ticket

[ET-2084](https://stellarwp.atlassian.net/browse/ET-2084)

### 🗒️ Description

We had an issue where the confirmation email was going with `json_ld` code when using TEC + ET

### 🎥 Artifacts <!-- if applicable-->

#### Before
<img width="654" height="677" alt="Screenshot 2026-03-02 at 12 24 22" src="https://github.com/user-attachments/assets/12d87192-0249-428c-8a6d-dea12d9e7082" />

#### After
<img width="664" height="678" alt="Screenshot 2026-03-02 at 12 25 24" src="https://github.com/user-attachments/assets/ee28e752-5bcd-4192-a89a-45f5013deb5a" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2084]: https://stellarwp.atlassian.net/browse/ET-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ