### PR TITLE
ET2629 fix: enhance ticket stock management and display logic for shared capacity

### DIFF
--- a/changelog/fix-ET-2629-incorrect-ticket-availability-on-calendar-viewss
+++ b/changelog/fix-ET-2629-incorrect-ticket-availability-on-calendar-viewss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Change the way that the available tickets was being calculated on event list [ET-2629]

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -532,12 +532,13 @@ class Tickets implements ArrayAccess, Serializable {
 			$text                           = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
 			$this->data['stock']->available = esc_html( sprintf( $text, $number ) );
 		} else {
-		$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
-		$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
-		$ticket_label          = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
-		/* translators: %1$s: Number of stock, %2$s: Ticket label */
-		$text                           = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
-		$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label ) );
+			$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
+			$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
+			$ticket_label          = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
+			/* translators: %1$s: Number of stock, %2$s: Ticket label */
+			$text                           = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
+			$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label ) );
+		}
 	}
 
 	/**

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -515,10 +515,10 @@ class Tickets implements ArrayAccess, Serializable {
 			return;
 		}
 
-		$stock = (int) $stock;
+		$stock            = (int) $stock;
 		$settings_manager = tribe( 'settings.manager' );
-		$threshold = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
-		$threshold = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
+		$threshold        = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
+		$threshold        = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
 
 		if ( $threshold && $stock > $threshold ) {
 			$this->data['stock']->available = '';
@@ -527,12 +527,14 @@ class Tickets implements ArrayAccess, Serializable {
 
 		$number = number_format_i18n( $stock );
 		if ( 'rsvp' === $type ) {
-			$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
+			/* translators: %1$s: Number of stock */
+			$text                           = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
 			$this->data['stock']->available = esc_html( sprintf( $text, $number ) );
 		} else {
 			$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
 			$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
-			$text = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
+			/* translators: %1$s: Number of stock, %2$s: Ticket label, %3$s: Tickets label */
+			$text                           = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
 			$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label_singular, $ticket_label_plural ) );
 		}
 	}

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -317,13 +317,14 @@ class Tickets implements ArrayAccess, Serializable {
 							/* translators: %1$s: Number of stock */
 							$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
 						} else {
-							// phpcs:disable -- to suppress WordPress.WP.I18n.MismatchedPlaceholders incorrect warning.
-							/* translators: %1$s: Number of stock, %2$s: Ticket label, %3$s: Tickets label */
-							$text = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
-							// phpcs:enable
+							//Respecting the phpcs warning for WordPress.WP.I18n.MismatchedPlaceholders.
+
+							$ticket_label = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
+							/* translators: %1$s: Number of stock, %2$s: Ticket label */
+							$text = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
 						}
 
-						$stock_html = esc_html( sprintf( $text, $number, $ticket_label_singular, $ticket_label_plural ) );
+						$stock_html = esc_html( sprintf( $text, $number, $ticket_label ) );
 					}
 				}
 
@@ -531,12 +532,12 @@ class Tickets implements ArrayAccess, Serializable {
 			$text                           = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
 			$this->data['stock']->available = esc_html( sprintf( $text, $number ) );
 		} else {
-			$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
-			$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
-			/* translators: %1$s: Number of stock, %2$s: Ticket label, %3$s: Tickets label */
-			$text                           = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
-			$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label_singular, $ticket_label_plural ) );
-		}
+		$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
+		$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
+		$ticket_label          = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
+		/* translators: %1$s: Number of stock, %2$s: Ticket label */
+		$text                           = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
+		$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label ) );
 	}
 
 	/**

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -317,7 +317,7 @@ class Tickets implements ArrayAccess, Serializable {
 							/* translators: %1$s: Number of stock */
 							$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
 						} else {
-							//Respecting the phpcs warning for WordPress.WP.I18n.MismatchedPlaceholders.
+							// Respecting the phpcs warning for WordPress.WP.I18n.MismatchedPlaceholders.
 
 							$ticket_label = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
 							/* translators: %1$s: Number of stock, %2$s: Ticket label */

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -219,6 +219,7 @@ class Tickets implements ArrayAccess, Serializable {
 	 *
 	 * @since 5.6.3 Add support for the updated anchor link from new ticket templates.
 	 * @since 5.26.7 Fixed issue where empty arrays were being returned when data existed but was empty.
+	 * @since TBD Fixed issue where the stock display was not being refreshed from the current availability.
 	 *
 	 * @return array Ticket data or empty array.
 	 */
@@ -290,42 +291,7 @@ class Tickets implements ArrayAccess, Serializable {
 				}
 
 				if ( $stock ) {
-					/** @var Tribe__Settings_Manager $settings_manager */
-					$settings_manager = tribe( 'settings.manager' );
-
-					$threshold = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
-
-					/**
-					 * Overwrites the threshold to display "# tickets left".
-					 *
-					 * @param int   $threshold Stock threshold to trigger display of "# tickets left"
-					 * @param array $data      Ticket data.
-					 * @param int   $event_id  Event ID.
-					 *
-					 * @since 4.10.1
-					 */
-					$threshold = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
-
-					if ( ! $threshold || $stock <= $threshold ) {
-
-						$number = number_format_i18n( $stock );
-
-						$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
-						$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
-
-						if ( 'rsvp' === $type ) {
-							/* translators: %1$s: Number of stock */
-							$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
-						} else {
-							// Respecting the phpcs warning for WordPress.WP.I18n.MismatchedPlaceholders.
-
-							$ticket_label = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
-							/* translators: %1$s: Number of stock, %2$s: Ticket label */
-							$text = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
-						}
-
-						$stock_html = esc_html( sprintf( $text, $number, $ticket_label ) );
-					}
+					$stock_html = $this->build_stock_html( $stock, $type, $data );
 				}
 
 				$html['stock']             = $stock_html;
@@ -516,29 +482,7 @@ class Tickets implements ArrayAccess, Serializable {
 			return;
 		}
 
-		$stock            = (int) $stock;
-		$settings_manager = tribe( 'settings.manager' );
-		$threshold        = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
-		$threshold        = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
-
-		if ( $threshold && $stock > $threshold ) {
-			$this->data['stock']->available = '';
-			return;
-		}
-
-		$number = number_format_i18n( $stock );
-		if ( 'rsvp' === $type ) {
-			/* translators: %1$s: Number of stock */
-			$text                           = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
-			$this->data['stock']->available = esc_html( sprintf( $text, $number ) );
-		} else {
-			$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
-			$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
-			$ticket_label          = ( 1 === $stock ) ? $ticket_label_singular : $ticket_label_plural;
-			/* translators: %1$s: Number of stock, %2$s: Ticket label */
-			$text                           = _n( '%1$s %2$s left', '%1$s %2$s left', $stock, 'event-tickets' );
-			$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label ) );
-		}
+		$this->data['stock']->available = $this->build_stock_html( (int) $stock, $type, $data );
 	}
 
 	/**
@@ -567,6 +511,59 @@ class Tickets implements ArrayAccess, Serializable {
 		$data = $this->fetch_data();
 
 		return ! empty( $data['stock']->sold_out );
+	}
+
+	/**
+	 * Builds the "X tickets/spots left" HTML string for a given stock count and type.
+	 *
+	 * Applies the threshold filter and returns an empty string when the stock is above
+	 * the configured threshold so the display is hidden.
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $stock The number of tickets/spots remaining.
+	 * @param string $type  The ticket type ('rsvp' or 'tickets').
+	 * @param array  $data  The ticket-count data array forwarded to the threshold filter.
+	 *
+	 * @return string The escaped HTML string, or an empty string when hidden by threshold.
+	 */
+	private function build_stock_html( int $stock, string $type, array $data ): string {
+		/** @var Tribe__Settings_Manager $settings_manager */
+		$settings_manager = tribe( 'settings.manager' );
+		$threshold        = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
+
+		/**
+		 * Overwrites the threshold to display "# tickets left".
+		 *
+		 * @since 4.10.1
+		 *
+		 * @param int   $threshold Stock threshold to trigger display of "# tickets left".
+		 * @param array $data      Ticket data.
+		 * @param int   $event_id  Event ID.
+		 */
+		$threshold = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
+
+		if ( $threshold && $stock > $threshold ) {
+			return '';
+		}
+
+		$number = number_format_i18n( $stock );
+
+		if ( 'rsvp' === $type ) {
+			/* translators: %1$s: Number of stock */
+			$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
+			return esc_html( sprintf( $text, $number ) );
+		}
+
+		$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
+		$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
+
+		// phpcs:disable -- to suppress WordPress.WP.I18n.MismatchedPlaceholders incorrect warning.
+		/* translators: %1$s: Number of stock, %2$s: Ticket label, %3$s: Tickets label */
+		$text = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
+		// phpcs:enable
+
+		return esc_html( sprintf( $text, $number, $ticket_label_singular, $ticket_label_plural ) );
 	}
 
 	/**

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -16,8 +16,8 @@ use InvalidArgumentException;
 use ReturnTypeWillChange;
 use Serializable;
 use Tribe\Utils\Lazy_Events;
-use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use Tribe__Events__Main as TEC;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use Tribe__Tickets__Tickets as Tickets_Tickets;
 use WP_Post;
 
@@ -228,6 +228,9 @@ class Tickets implements ArrayAccess, Serializable {
 		}
 
 		if ( null !== $this->data && ! empty( $this->data ) ) {
+			// Refresh stock display from current availability so list/archive views stay correct
+			// when event or ticket model is served from cache (e.g. tribe_get_event memoization).
+			$this->refresh_cached_stock_display();
 			return $this->data;
 		}
 
@@ -279,6 +282,7 @@ class Tickets implements ArrayAccess, Serializable {
 					$sold_out      = $parts[ $type . '_stock' ];
 				}
 			} else {
+				// Use get_ticket_counts() so shared capacity shows pool remaining (one number), not sum of per-ticket.
 				$stock = $data['stock'];
 				if ( $data['unlimited'] || ! $data['stock'] ) {
 					// If unlimited tickets, tickets with no stock and rsvp, or no tickets and rsvp unlimited - hide the remaining count.
@@ -472,6 +476,65 @@ class Tickets implements ArrayAccess, Serializable {
 		}
 
 		return $this->exists;
+	}
+
+	/**
+	 * Updates cached data's stock display (X tickets/spots left) from current counts.
+	 * Uses get_ticket_counts() so shared capacity shows the pool remaining (one number), not the sum of per-ticket.
+	 * Called when serving from cache so the number stays correct despite tribe_get_event or model cache.
+	 *
+	 * @since TBD
+	 */
+	protected function refresh_cached_stock_display(): void {
+		if ( ! isset( $this->data['stock'] ) || ! is_object( $this->data['stock'] ) ) {
+			return;
+		}
+
+		$types = Tickets_Tickets::get_ticket_counts( $this->post_id );
+		if ( ! $types ) {
+			return;
+		}
+
+		// Use the same type that would "win" in fetch_data (last with count): prefer tickets over rsvp.
+		$data = null;
+		if ( ! empty( $types['tickets']['count'] ) ) {
+			$data = $types['tickets'];
+			$type = 'tickets';
+		} elseif ( ! empty( $types['rsvp']['count'] ) ) {
+			$data = $types['rsvp'];
+			$type = 'rsvp';
+		}
+
+		if ( ! $data || ! $data['available'] ) {
+			return;
+		}
+
+		$stock = $data['stock'];
+		if ( $data['unlimited'] || ! $stock ) {
+			$this->data['stock']->available = '';
+			return;
+		}
+
+		$stock = (int) $stock;
+		$settings_manager = tribe( 'settings.manager' );
+		$threshold = $settings_manager::get_option( 'ticket-display-tickets-left-threshold', 0 );
+		$threshold = absint( apply_filters( 'tribe_display_tickets_left_threshold', $threshold, $data, $this->post_id ) );
+
+		if ( $threshold && $stock > $threshold ) {
+			$this->data['stock']->available = '';
+			return;
+		}
+
+		$number = number_format_i18n( $stock );
+		if ( 'rsvp' === $type ) {
+			$text = _n( '%1$s spot left', '%1$s spots left', $stock, 'event-tickets' );
+			$this->data['stock']->available = esc_html( sprintf( $text, $number ) );
+		} else {
+			$ticket_label_singular = tribe_get_ticket_label_singular_lowercase( 'event-tickets' );
+			$ticket_label_plural   = tribe_get_ticket_label_plural_lowercase( 'event-tickets' );
+			$text = _n( '%1$s %2$s left', '%1$s %3$s left', $stock, 'event-tickets' );
+			$this->data['stock']->available = esc_html( sprintf( $text, $number, $ticket_label_singular, $ticket_label_plural ) );
+		}
 	}
 
 	/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2148,19 +2148,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					$types['tickets']['global'] = 1;
 					continue;
 				}
-
-				$stock_level = $ticket->available();
-
-				// whether the stock level is negative because it represents unlimited stock (`-1`)
-				// or because it's oversold we normalize to `0` for the sake of displaying
-				$stock_level = max( 0, (int) $stock_level );
-
-				$types['tickets']['stock'] += $stock_level;
-
-				// If current availability is unlimited (available = -1) and the ticket has stock, set it to 0.
-				if ( $types['tickets']['available'] < 0 && 0 !== $types['tickets']['stock'] ) {
-					$types['tickets']['available'] = 0;
-				}
 			}
 
 			/*

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2140,13 +2140,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					continue;
 				}
 
-				// flag if we have any shared capacity tickets.
-				if ( Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE === $global_stock_mode ) {
+				// flag if we have any shared capacity tickets (global or capped).
+				// For both modes we rely on the event's global stock level (remaining) added in the loop below,
+				// not each ticket's cap/total, so we skip adding here to avoid showing total capacity instead of remaining.
+				if ( Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE === $global_stock_mode
+					|| Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE === $global_stock_mode ) {
 					$types['tickets']['global'] = 1;
 					continue;
 				}
 
-				$stock_level = Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE === $global_stock_mode ? $ticket->global_stock_cap() : $ticket->available();
+				$stock_level = $ticket->available();
 
 				// whether the stock level is negative because it represents unlimited stock (`-1`)
 				// or because it's oversold we normalize to `0` for the sake of displaying
@@ -2175,16 +2178,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			}, [] );
 
 			foreach ( $ticket_post_ids as $ticket_post_id ) {
-				$global_stock                  = new Tribe__Tickets__Global_Stock( $ticket_post_id );
-				$global_stock                  = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
+			$global_stock = new Tribe__Tickets__Global_Stock( $ticket_post_id );
+			$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
+
+			// If there's at least one ticket with shared capacity, add the global stock to both available and stock totals.
+			// Only add global stock if tickets don't manage their own stock to prevent double-counting.
+			if ( ! self::tickets_own_stock( $ticket_post_id ) ) {
 				$types['tickets']['available'] += $global_stock;
-
-				// If there's at least one ticket with shared capacity add the global stock to the stock total.
-				if ( ! self::tickets_own_stock( $ticket_post_id ) ) {
-					$types['tickets']['stock'] += $global_stock;
-				}
+				$types['tickets']['stock'] += $global_stock;
 			}
-
+		}
 			/**
 			 * Allow filtering of ticket counts by event.
 			 *

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2178,16 +2178,17 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			}, [] );
 
 			foreach ( $ticket_post_ids as $ticket_post_id ) {
-			$global_stock = new Tribe__Tickets__Global_Stock( $ticket_post_id );
-			$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
+				$global_stock = new Tribe__Tickets__Global_Stock( $ticket_post_id );
+				$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
 
-			// If there's at least one ticket with shared capacity, add the global stock to both available and stock totals.
-			// Only add global stock if tickets don't manage their own stock to prevent double-counting.
-			if ( ! self::tickets_own_stock( $ticket_post_id ) ) {
-				$types['tickets']['available'] += $global_stock;
-				$types['tickets']['stock'] += $global_stock;
+				// If there's at least one ticket with shared capacity, add the global stock to both available and stock totals.
+				// Only add global stock if tickets don't manage their own stock to prevent double-counting.
+				if ( ! self::tickets_own_stock( $ticket_post_id ) ) {
+					$types['tickets']['available'] += $global_stock;
+					$types['tickets']['stock']     += $global_stock;
+				}
 			}
-		}
+
 			/**
 			 * Allow filtering of ticket counts by event.
 			 *

--- a/tests/wpunit/Tribe/Tickets/GetTicketCountsTest.php
+++ b/tests/wpunit/Tribe/Tickets/GetTicketCountsTest.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace Tribe\Tickets;
+
+use Tribe\Events\Test\Factories\Event;
+use Tribe\Tickets\Test\Commerce\PayPal\Ticket_Maker as PayPal_Ticket_Maker;
+use Tribe__Tickets__Data_API as Data_API;
+use Tribe__Tickets__Global_Stock as Global_Stock;
+use Tribe__Tickets__Tickets as Tickets;
+
+/**
+ * Tests for Tribe__Tickets__Tickets::get_ticket_counts().
+ *
+ * Covers both the CAPPED_STOCK_MODE fix (stock must reflect remaining global pool,
+ * not the ticket cap ceiling) and the available double-count fix (global stock must
+ * not be added to 'available' when all tickets use OWN_STOCK_MODE).
+ */
+class GetTicketCountsTest extends \Codeception\TestCase\WPTestCase {
+
+	use PayPal_Ticket_Maker;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory()->event = new Event();
+		$this->event_id         = $this->factory()->event->create();
+
+		add_filter( 'tribe_tickets_commerce_paypal_is_active', '__return_true' );
+		add_filter( 'tribe_tickets_get_modules', function ( $modules ) {
+			$modules['Tribe__Tickets__Commerce__PayPal__Main'] = tribe( 'tickets.commerce.paypal' )->plugin_name;
+
+			return $modules;
+		} );
+
+		tribe_singleton( 'tickets.data_api', new Data_API );
+	}
+
+	public function tearDown() {
+		unset( $this->event_id );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_returns_empty_array_for_missing_post_id() {
+		$counts = Tickets::get_ticket_counts( 0 );
+
+		$this->assertEmpty( $counts );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_returns_empty_array_for_event_with_no_tickets() {
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEmpty( $counts );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_returns_correct_counts_for_own_stock_mode_ticket() {
+		// capacity=10, sales=3 → available=7
+		$this->create_paypal_ticket_basic( $this->event_id, 1, [
+			'meta_input' => [
+				'_capacity'   => 10,
+				'total_sales' => 3,
+			],
+		] );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEquals( 1, $counts['tickets']['count'],     'count mismatch' );
+		$this->assertEquals( 0, $counts['tickets']['global'],    'global flag must not be set for OWN_STOCK_MODE' );
+		$this->assertEquals( 7, $counts['tickets']['stock'],     'stock must equal ticket available' );
+		$this->assertEquals( 7, $counts['tickets']['available'], 'available must equal ticket available' );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_returns_correct_counts_for_global_stock_mode_ticket() {
+		// Shared pool: 50 total, 11 sold → 39 remaining.
+		$this->create_distinct_paypal_tickets_basic( $this->event_id, [
+			[
+				'meta_input' => [
+					'_capacity'                     => 50,
+					'total_sales'                   => 11,
+					Global_Stock::TICKET_STOCK_MODE => Global_Stock::GLOBAL_STOCK_MODE,
+				],
+			],
+		], 50 );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEquals( 1,  $counts['tickets']['count'],     'count mismatch' );
+		$this->assertEquals( 1,  $counts['tickets']['global'],    'global flag must be set for GLOBAL_STOCK_MODE' );
+		$this->assertEquals( 39, $counts['tickets']['stock'],     'stock must equal remaining global pool' );
+		$this->assertEquals( 39, $counts['tickets']['available'], 'available must equal remaining global pool' );
+	}
+
+	/**
+	 * @test
+	 *
+	 * Regression test for the CAPPED_STOCK_MODE fix.
+	 *
+	 * Before the fix, CAPPED tickets fell through to:
+	 *     $stock_level = $ticket->global_stock_cap()
+	 * which returns the ticket's sales ceiling (20 in this test), not what's
+	 * actually left in the shared pool (45).  Both 'stock' and 'available' must
+	 * now reflect the remaining pool, matching GLOBAL_STOCK_MODE behaviour.
+	 *
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_uses_remaining_global_pool_not_ticket_cap_for_capped_stock_mode() {
+		// Shared pool: 50 total, 5 sold → 45 remaining.
+		// CAPPED ticket cap: 20 (max this ticket type may sell from the pool).
+		$this->create_distinct_paypal_tickets_basic( $this->event_id, [
+			[
+				'meta_input' => [
+					'_capacity'                     => 20,
+					'total_sales'                   => 5,
+					Global_Stock::TICKET_STOCK_MODE => Global_Stock::CAPPED_STOCK_MODE,
+					Global_Stock::TICKET_STOCK_CAP  => 20,
+				],
+			],
+		], 50 );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEquals( 1,  $counts['tickets']['count'],     'count mismatch' );
+		$this->assertEquals( 1,  $counts['tickets']['global'],    'global flag must be set for CAPPED_STOCK_MODE' );
+		$this->assertEquals( 45, $counts['tickets']['stock'],     'stock must reflect remaining global pool, not the cap' );
+		$this->assertEquals( 45, $counts['tickets']['available'], 'available must reflect remaining global pool, not the cap' );
+
+		// Explicit guard: the cap value must never be used as the stock figure.
+		$this->assertNotEquals( 20, $counts['tickets']['stock'], 'stock must NOT equal the ticket type cap (20)' );
+	}
+
+	/**
+	 * @test
+	 *
+	 * Regression test for the available double-count fix.
+	 *
+	 * Before the fix, $types['tickets']['available'] += $global_stock was executed
+	 * unconditionally in the post-loop section, even when every ticket uses
+	 * OWN_STOCK_MODE.  The guard now prevents that addition so 'available' only
+	 * reflects what each OWN ticket reported via available().
+	 *
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_does_not_add_global_stock_to_available_when_all_tickets_are_own_stock_mode() {
+		// OWN ticket: capacity=10, sales=3 → available=7.
+		$this->create_paypal_ticket_basic( $this->event_id, 1, [
+			'meta_input' => [
+				'_capacity'   => 10,
+				'total_sales' => 3,
+			],
+		] );
+
+		// Manually enable global stock on the event (simulates a legacy or misconfigured
+		// state where the event has a global stock level even though every ticket is OWN).
+		$global_stock = new Global_Stock( $this->event_id );
+		$global_stock->enable( true );
+		update_post_meta( $this->event_id, Global_Stock::GLOBAL_STOCK_LEVEL, 50 );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		// 'available' must be 7 (own ticket only), not 57 (7 + 50 global pool).
+		$this->assertEquals( 7, $counts['tickets']['available'], 'global stock must NOT be added when all tickets use OWN_STOCK_MODE' );
+		$this->assertEquals( 7, $counts['tickets']['stock'],     'stock must only include OWN_STOCK_MODE ticket stock' );
+		$this->assertEquals( 0, $counts['tickets']['global'],    'global flag must not be set for OWN-only events' );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_returns_correct_counts_for_mixed_own_and_global_tickets() {
+		// OWN ticket: capacity=10, sales=2 → available=8.
+		// GLOBAL ticket: draws from a shared pool of 30 with 5 sold → pool remaining=25.
+		// Expected totals: stock = 8 + 25 = 33, available = 8 + 25 = 33.
+		$this->create_distinct_paypal_tickets_basic( $this->event_id, [
+			[
+				'meta_input' => [
+					'_capacity'   => 10,
+					'total_sales' => 2,
+					// OWN_STOCK_MODE is the default; no explicit key needed.
+				],
+			],
+			[
+				'meta_input' => [
+					'_capacity'                     => 30,
+					'total_sales'                   => 5,
+					Global_Stock::TICKET_STOCK_MODE => Global_Stock::GLOBAL_STOCK_MODE,
+				],
+			],
+		], 30 );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEquals( 2,  $counts['tickets']['count'],     'count mismatch' );
+		$this->assertEquals( 1,  $counts['tickets']['global'],    'global flag must be set when at least one ticket uses shared capacity' );
+		$this->assertEquals( 33, $counts['tickets']['stock'],     'stock must be OWN ticket stock + remaining global pool' );
+		$this->assertEquals( 33, $counts['tickets']['available'], 'available must be OWN ticket available + remaining global pool' );
+	}
+
+	/**
+	 * @test
+	 * @covers Tribe__Tickets__Tickets::get_ticket_counts
+	 */
+	public function it_counts_shared_pool_only_once_for_mixed_global_and_capped_tickets() {
+		// Two tickets sharing the same pool of 40:
+		//   GLOBAL ticket: 5 sold
+		//   CAPPED ticket: cap=15, 5 sold
+		// Total sold from pool: 10 → pool remaining: 30.
+		// Both tickets hit 'continue', so the pool is added exactly once below the loop.
+		$this->create_distinct_paypal_tickets_basic( $this->event_id, [
+			[
+				'meta_input' => [
+					'_capacity'                     => 40,
+					'total_sales'                   => 5,
+					Global_Stock::TICKET_STOCK_MODE => Global_Stock::GLOBAL_STOCK_MODE,
+				],
+			],
+			[
+				'meta_input' => [
+					'_capacity'                     => 15,
+					'total_sales'                   => 5,
+					Global_Stock::TICKET_STOCK_MODE => Global_Stock::CAPPED_STOCK_MODE,
+					Global_Stock::TICKET_STOCK_CAP  => 15,
+				],
+			],
+		], 40 );
+
+		$counts = Tickets::get_ticket_counts( $this->event_id );
+
+		$this->assertEquals( 2,  $counts['tickets']['count'],     'count mismatch' );
+		$this->assertEquals( 1,  $counts['tickets']['global'],    'global flag must be set' );
+		$this->assertEquals( 30, $counts['tickets']['stock'],     'global pool must be counted once, not once per shared ticket' );
+		$this->assertEquals( 30, $counts['tickets']['available'], 'available must equal global pool, not double-counted' );
+	}
+}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
@@ -15,7 +15,7 @@
 		
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">8.00</span>
+					<span class="tribe-amount">5.00</span>
 				</span>
 						</span>
 </div>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/Item/__snapshots__/ContentTest__test_should_render_if_has_ticket_object__1.php
@@ -5,7 +5,7 @@
 
 
 <div
-	id="tribe__details__content--12953"
+	id="tribe__details__content--12969"
 	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
 	Test ticket description for 8</div>
 <div  class="tribe-tickets__tickets-item-extra" >
@@ -15,7 +15,7 @@
 		
 				<span class="tribe-formatted-currency-wrap tribe-currency-prefix">
 					<span class="tribe-currency-symbol">$</span>
-					<span class="tribe-amount">5.00</span>
+					<span class="tribe-amount">8.00</span>
 				</span>
 						</span>
 </div>

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/ItemTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/ItemTest.php
@@ -143,7 +143,7 @@ class ItemTest extends V2TestCase {
 			]
 		);
 
-		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], [ '{{POST_ID}}', '{{TICKET_ID}}'], $html );
+		$html = str_replace( [ $args['ticket']->ID, $args['post_id'] ], [ '{{TICKET_ID}}', '{{POST_ID}}' ], $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -198,7 +198,7 @@ class ItemTest extends V2TestCase {
 			]
 		);
 
-		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], [ '{{POST_ID}}', '{{TICKET_ID}}'], $html );
+		$html = str_replace( [ $args['ticket']->ID, $args['post_id'] ], [ '{{TICKET_ID}}', '{{POST_ID}}' ], $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/ItemTest.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/ItemTest.php
@@ -2,8 +2,8 @@
 
 namespace Tribe\Tickets\Partials\V2\Tickets;
 
-use Tribe\Tickets\Test\Partials\V2TestCase;
 use Tribe\Tickets\Test\Commerce\PayPal\Ticket_Maker as PayPal_Ticket_Maker;
+use Tribe\Tickets\Test\Partials\V2TestCase;
 
 class ItemTest extends V2TestCase {
 
@@ -143,7 +143,7 @@ class ItemTest extends V2TestCase {
 			]
 		);
 
-		$html = str_replace( [ $args['ticket']->ID, $args['post_id'] ], [ '{{TICKET_ID}}', '{{POST_ID}}' ], $html );
+		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], [ '{{POST_ID}}', '{{TICKET_ID}}'], $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}
@@ -198,7 +198,7 @@ class ItemTest extends V2TestCase {
 			]
 		);
 
-		$html = str_replace( [ $args['ticket']->ID, $args['post_id'] ], [ '{{TICKET_ID}}', '{{POST_ID}}' ], $html );
+		$html = str_replace( [ $args['post_id'], $args['ticket']->ID ], [ '{{POST_ID}}', '{{TICKET_ID}}'], $html );
 
 		$this->assertMatchesSnapshot( $html, $driver );
 	}

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/__snapshots__/ItemTest__test_should_render_wit_whatever_data_attribute__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/__snapshots__/ItemTest__test_should_render_wit_whatever_data_attribute__1.php
@@ -1,6 +1,6 @@
 <?php return '<div
-	id="tribe-block-tickets-item-1303{{POST_ID}}"
-	 class="tribe-tickets__tickets-item post-1303{{POST_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="1303{{POST_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" data-whatever="value" >
+	id="tribe-block-tickets-item-{{TICKET_ID}}"
+	 class="tribe-tickets__tickets-item post-{{TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" data-whatever="value" >
 
 	<div  class="tribe-tickets__tickets-item-content-title-container" >
 		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
@@ -9,7 +9,7 @@
 
 
 <div
-	id="tribe__details__content--1303{{POST_ID}}"
+	id="tribe__details__content--{{TICKET_ID}}"
 	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
 	Test ticket description for {{POST_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/__snapshots__/ItemTest__test_should_render_wit_whatever_data_attribute__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/Tickets/__snapshots__/ItemTest__test_should_render_wit_whatever_data_attribute__1.php
@@ -1,6 +1,6 @@
 <?php return '<div
-	id="tribe-block-tickets-item-{{TICKET_ID}}"
-	 class="tribe-tickets__tickets-item post-{{TICKET_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="{{TICKET_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" data-whatever="value" >
+	id="tribe-block-tickets-item-1303{{POST_ID}}"
+	 class="tribe-tickets__tickets-item post-1303{{POST_ID}} tribe_tpp_tickets type-tribe_tpp_tickets status-publish hentry" 	 data-ticket-id="1303{{POST_ID}}" data-available="false" data-has-shared-cap="false" data-ticket-price="99" data-whatever="value" >
 
 	<div  class="tribe-tickets__tickets-item-content-title-container" >
 		<div  class="tribe-common-h7 tribe-common-h6--min-medium tribe-tickets__tickets-item-content-title" >
@@ -9,7 +9,7 @@
 
 
 <div
-	id="tribe__details__content--{{TICKET_ID}}"
+	id="tribe__details__content--1303{{POST_ID}}"
 	 class="tribe-common-b2 tribe-common-b3--min-medium tribe-tickets__tickets-item-details-content" >
 	Test ticket description for {{POST_ID}}</div>
 <div  class="tribe-tickets__tickets-item-extra" >


### PR DESCRIPTION
### 🎫 Ticket

[ET-2629](https://stellarwp.atlassian.net/browse/ET-2629)

### 🗒️ Description

After sell a ticket on an event the number of the available tickets on the list was showing the total of items without subtract the tickets that were sold.
Now it has been fixed and when using "Share capacity with other tickets" it will display just the number of tickets that the user can buy.

### 🎥 Artifacts <!-- if applicable-->
<img width="1288" height="444" alt="Screenshot 2026-03-02 at 22 18 54" src="https://github.com/user-attachments/assets/eaabb284-ba93-4bc7-8155-585938b5649f" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2629]: https://stellarwp.atlassian.net/browse/ET-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ