### PR TITLE
[ET-2634] The use of _x() and esc_html_x() functions is invalid

### DIFF
--- a/changelog/et-2634-The-use-of-_x-and-esc_html_x-functions-is-invalid
+++ b/changelog/et-2634-The-use-of-_x-and-esc_html_x-functions-is-invalid
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Correct WordPress translation function usage [ET-2634]
+Correct WordPress translation function usage. [ET-2634]

--- a/changelog/et-2634-The-use-of-_x-and-esc_html_x-functions-is-invalid
+++ b/changelog/et-2634-The-use-of-_x-and-esc_html_x-functions-is-invalid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Correct WordPress translation function usage [ET-2634]

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -226,7 +226,7 @@ class Settings {
 			[
 				'id'       => static::$parent_slug,
 				'path'     => static::$parent_slug,
-				'title'    => 'Tickets',
+				'title'    => esc_html__( 'Tickets', 'event-tickets' ),
 				'icon'     => $this->get_menu_icon(),
 				'position' => 7,
 				'callback' => [

--- a/src/admin-views/editor/total-capacity.php
+++ b/src/admin-views/editor/total-capacity.php
@@ -15,7 +15,7 @@ $post_labels          = get_post_type_labels( get_post_type_object( get_post_typ
 $uppercase_post_label = $post_labels->singular_name ?? 'Event';
 $label                = sprintf(
 	/* translators: %s: uppercase post type label */
-	_x(
+	__(
 		'Total %s Capacity:',
 		'event-tickets'
 	),


### PR DESCRIPTION
### 🎫 Ticket

[ET-2634](https://stellarwp.atlassian.net/browse/ET-2634)

### 🗒️ Description
**Fix** (bug fix - i18n)
Fixed incorrect WordPress translation function usage that prevented proper localization.
**Changes:**
- **`src/admin-views/editor/total-capacity.php`:**
  - Replaced `_x()` with `__()` (was passing text domain as context parameter instead of proper domain)
  - Line 18-21: `'event-tickets'` was incorrectly used as context instead of domain parameter
- **`src/Tribe/Admin/Settings.php`:**
  - Added missing `esc_html__()` translation to Tickets admin menu title
  - Line 229: `'Tickets'` → `esc_html__( 'Tickets', 'event-tickets' )`
  - Menu title was hardcoded in English, preventing translation to other languages

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2634]: https://stellarwp.atlassian.net/browse/ET-2634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ