### PR TITLE
[ET-2617] Fix checkout page title heading level

### DIFF
--- a/changelog/fix-ET-2617-checkout-title-heading
+++ b/changelog/fix-ET-2617-checkout-title-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Corrected checkout page heading from `h3` to `h2` for proper heading hierarchy and screen reader accessibility.

--- a/src/views/v2/commerce/checkout/header/title.php
+++ b/src/views/v2/commerce/checkout/header/title.php
@@ -31,6 +31,6 @@ $the_title = sprintf(
 	tribe_get_ticket_label_plural( 'tickets_commerce_checkout_title' ) // phpcs:ignore
 );
 ?>
-<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
 	<?php echo esc_html( $the_title ); ?>
-</h3>
+</h2>

--- a/src/views/v2/commerce/checkout/header/title.php
+++ b/src/views/v2/commerce/checkout/header/title.php
@@ -11,7 +11,7 @@
  *
  * @since 5.1.10
  *
- * @version 5.1.10
+ * @version TBD
  *
  * @var \Tribe__Template $this                  [Global] Template object.
  * @var Module           $provider              [Global] The tickets provider instance.

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_not_on_sale_should_match_html__1.php
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="jhd73jd873" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Shortcodes/__snapshots__/Checkout_ShortcodeTest__ticket_on_sale_should_match_html__1.php
@@ -12,8 +12,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="jhd73jd873" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket from an event__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="123123" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__multiple ticket with multiple series pass from an event__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="123123" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__single ticket from an event__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="123123" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
+++ b/tests/ft_integration/TEC/Tickets/Commerce/Checkout/__snapshots__/CheckoutTest__test_ticketscommerce_checkout_template__ticket with series pass from an event__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="123123" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Coupons_Test__it_should_calculate_coupons_simple_math__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="TEC\Tickets\Tests\Order_Modifiers_Integration\Checkout\Coupons_Test::it_should_calculate_coupons_simple_math" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_complex_math__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_calculate_fees_and_store_them_correctly_simple_math__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $10, Fee $5, Application All__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $15, Fee $2, Application Per__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $20, Fee $3, Application All__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_display_fee_section__Ticket $50, Fee $10, Application Per__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a

--- a/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
+++ b/tests/order_modifiers_integration/Checkout/__snapshots__/Fees_Test__it_should_not_calculate_fees_for_free_tickets__0.snapshot.html
@@ -3,8 +3,8 @@
 		class="tribe-tickets__commerce-checkout"
 		 data-js="tec-tickets-commerce-notice" data-notice-default-title="Checkout Unavailable!" data-notice-default-content="Checkout is not available at this time because a payment method has not been set up for this event. Please notify the site administrator." 	>
 		<input type="hidden" id="tec-tc-checkout-nonce" name="tec-tc-checkout-nonce" value="1029384756" /><input type="hidden" name="_wp_http_referer" value="" />		<header class="tribe-tickets__commerce-checkout-header">
-	<h3 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
-	Purchase Tickets</h3>
+	<h2 class="tribe-common-h2 tribe-tickets__commerce-checkout-header-title">
+	Purchase Tickets</h2>
 	<div class="tribe-common-b2 tribe-tickets__commerce-checkout-header-links">
 	
 <a


### PR DESCRIPTION
### 🎫 Ticket

[ET-2617](https://stellarwp.atlassian.net/browse/ET-2617)
[SMTNC-971](https://linear.app/nexcess/issue/SMTNC-971/et-incorrect-heading-order-checkout)

### 🗒️ Description

The Tickets Commerce checkout page has an accessibility violation: the "Purchase Tickets" heading uses `<h3>` which causes headings to jump from `h1` → `h3`, skipping `h2`. This breaks screen reader navigation and violates WCAG heading hierarchy rules.

This Pull Request changes heading level from `h3` -> `h2` to keep correct accessibility.

### 📽️Artifacts

<img width="813" height="576" alt="image" src="https://github.com/user-attachments/assets/a1345543-6e37-4101-b5b4-cdd3ff080bf2" />

QA: Visually should be the same, but more importantly, test it with screen reader since the fix is for screen readers.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[ET-2617]: https://stellarwp.atlassian.net/browse/ET-2617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ