### PR TITLE
Fix/smtnc 295 list table php84 fatal

### DIFF
--- a/changelog/fix-SMTNC-295-list-table-days-left-php84-fatal
+++ b/changelog/fix-SMTNC-295-list-table-days-left-php84-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved a fatal error on the Tickets > All Tickets admin page when listing tickets with no end date on PHP 8.3.9 or later. [SMTNC-295]

--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -13,6 +13,7 @@ use Tribe__Tickets__Commerce__Currency;
 use Tribe__Tickets__Ticket_Object;
 use WP_List_Table;
 use DateTime;
+use DateTimeInterface;
 use TEC\Tickets\Commerce as TicketsCommerce;
 use Tribe\Tickets\Admin\Settings;
 use Tribe__Template;
@@ -681,6 +682,10 @@ class List_Table extends WP_List_Table {
 		}
 
 		$datetime = $item->end_date( false );
+		if ( ! $datetime instanceof DateTimeInterface ) {
+			return '-';
+		}
+
 		$now      = new DateTime();
 		$interval = $now->diff( $datetime );
 

--- a/tests/integration/TEC/Tickets/Admin/Tickets/List_TableTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Tickets/List_TableTest.php
@@ -342,6 +342,36 @@ class List_TableTest extends \Codeception\TestCase\WPTestCase {
 			yield "filter by discounted" => [ 'discounted' ];
 			yield "filter by all"        => [ 'all' ];
 	}
+
+	/**
+	 * Regression: tickets with no end date must not fatal in column_days_left().
+	 *
+	 * On PHP 8.3.9+ / 8.4, DateTime::diff() rejects null and throws TypeError. Before
+	 * the fix, end_date() returned null and triggered a fatal mid-row when the admin
+	 * list table rendered such a ticket.
+	 *
+	 * @see SMTNC-295
+	 */
+	public function test_column_days_left_returns_dash_when_ticket_has_no_end_date() {
+		$ticket = new \Tribe__Tickets__Ticket_Object();
+		// end_date intentionally left empty.
+
+		$this->assertSame( '-', $this->list_table->column_days_left( $ticket ) );
+	}
+
+	/**
+	 * Sanity check: tickets with a future end date still report numeric days remaining.
+	 */
+	public function test_column_days_left_returns_numeric_days_for_future_end_date() {
+		$ticket           = new \Tribe__Tickets__Ticket_Object();
+		$ticket->end_date = ( new \DateTime( '+15 days' ) )->format( 'Y-m-d' );
+
+		$output = $this->list_table->column_days_left( $ticket );
+
+		$this->assertNotSame( '-', $output );
+		$this->assertIsNumeric( $output );
+		$this->assertGreaterThan( 0, (int) $output );
+	}
 }
 
 


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-295](https://linear.app/nexcess/issue/SMTNC-295/php-83984-fatal-error-in-varwebsitepublic-htmlwp-contentpluginsevent)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"Fatal error occurs when using PHP 8.3.9/8.4 with Event Tickets. Customer reported it didn’t crash the site, but they are getting emails regarding this error."

I could not reproduce that issue even using the exact versions of php, wp and plugin so I asked Claude to review and fix it. Claude response:
"Reading the code, the bug is plain. Line 683 calls $item->end_date( false ) — and Ticket_Object::end_date() returns null when $this->end_date is empty (line 323). Line 685 then does $now->diff( null ) which throws TypeError under PHP 8.3.9+/8.4."
"Yes, reproduced — exact same TypeError at List_Table.php:685, on local ET 5.28.2 + PHP 8.4.18:"

```
CAUGHT TypeError at /var/www/html/wp-content/plugins/event-tickets/src/Tickets/Admin/Tickets/List_Table.php:685
 -> DateTime::diff(): Argument #1 ($targetObject) must be of type DateTimeInterface, null given
```

"You only hit it when:
1. A ticket exists with no end date (the "tickets are available until the event ends" path is common, but those tickets have end_date populated from the event — so a standalone ticket with no end is the actual trigger), AND
2. PHP ≥ 8.3.9 (8.3.8 still allowed DateTime::diff(null) with a deprecation), AND
3. You visit Tickets → All Tickets admin list table.
4. Pre-8.3.9 PHP silently coerced null and you'd get a wonky interval; the bug existed but didn't fatal."


<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
