### PR TITLE
Fix event tickets plus notice in all pages

### DIFF
--- a/changelog/fix-plus-commerce-notice-scope
+++ b/changelog/fix-plus-commerce-notice-scope
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the Event Tickets Plus upsell notice for WooCommerce and Easy Digital Downloads was being shown on every wp-admin page; it is now limited to the Tickets admin screens and the Plugins page.

--- a/changelog/fix-plus-commerce-notice-scope
+++ b/changelog/fix-plus-commerce-notice-scope
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved an issue where the Event Tickets Plus upsell notice for WooCommerce and Easy Digital Downloads was being shown on every wp-admin page; it is now limited to the Tickets admin screens, The Events Calendar admin screens, and the Plugins page.
+Resolve an issue where the Event Tickets Plus upsell notice for WooCommerce and Easy Digital Downloads was shown on every wp-admin page; it is now limited to the Tickets admin screens, The Events Calendar admin screens, and the Plugins page.

--- a/changelog/fix-plus-commerce-notice-scope
+++ b/changelog/fix-plus-commerce-notice-scope
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved an issue where the Event Tickets Plus upsell notice for WooCommerce and Easy Digital Downloads was being shown on every wp-admin page; it is now limited to the Tickets admin screens and the Plugins page.
+Resolved an issue where the Event Tickets Plus upsell notice for WooCommerce and Easy Digital Downloads was being shown on every wp-admin page; it is now limited to the Tickets admin screens, The Events Calendar admin screens, and the Plugins page.

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -259,7 +259,7 @@ class Tribe__Tickets__Admin__Notices {
 		}
 
 		$is_tickets_screen     = 0 === strpos( (string) $screen->id, 'tickets_page_' );
-		$is_plugins_screen     = 'plugins' === $screen->base;
+		$is_plugins_screen     = in_array( $screen->id, [ 'plugins', 'plugins-network' ], true );
 		$is_tec_submenu_screen = 0 === strpos( (string) $screen->id, 'tribe_events_page_' );
 		$is_event_post_screen  = 'tribe_events' === ( $screen->post_type ?? '' );
 

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -258,10 +258,15 @@ class Tribe__Tickets__Admin__Notices {
 			return false;
 		}
 
-		$is_tickets_screen = 0 === strpos( (string) $screen->id, 'tickets_page_' );
-		$is_plugins_screen = 'plugins' === $screen->base;
+		$is_tickets_screen     = 0 === strpos( (string) $screen->id, 'tickets_page_' );
+		$is_plugins_screen     = 'plugins' === $screen->base;
+		$is_tec_submenu_screen = 0 === strpos( (string) $screen->id, 'tribe_events_page_' );
+		$is_event_post_screen  = 'tribe_events' === ( $screen->post_type ?? '' );
 
-		return $is_tickets_screen || $is_plugins_screen;
+		return $is_tickets_screen
+			|| $is_plugins_screen
+			|| $is_tec_submenu_screen
+			|| $is_event_post_screen;
 	}
 
 	/**

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -229,8 +229,39 @@ class Tribe__Tickets__Admin__Notices {
 			// Wrap in <p> tag.
 			$message = sprintf( '<p>%s</p>', $message );
 
-			tribe_notice( "event-tickets-plus-missing-{$provider}-support", $message, 'dismiss=1&type=warning' );
+			tribe_notice(
+				"event-tickets-plus-missing-{$provider}-support",
+				$message,
+				'dismiss=1&type=warning',
+				[ $this, 'is_plus_commerce_notice_context' ]
+			);
 		}
+	}
+
+	/**
+	 * Whether the current admin screen is one where the ET+ commerce upsell notice should appear.
+	 *
+	 * Runs at notice-display time (admin_notices), when `get_current_screen()` is guaranteed to be
+	 * resolved — unlike `admin_init`, where the screen may still be null.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_plus_commerce_notice_context(): bool {
+		if ( ! function_exists( '\get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = \get_current_screen();
+		if ( ! $screen ) {
+			return false;
+		}
+
+		$is_tickets_screen = 0 === strpos( (string) $screen->id, 'tickets_page_' );
+		$is_plugins_screen = 'plugins' === $screen->base;
+
+		return $is_tickets_screen || $is_plugins_screen;
 	}
 
 	/**

--- a/tests/integration/Tribe/Admin/NoticesTest.php
+++ b/tests/integration/Tribe/Admin/NoticesTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tribe\Admin;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__Admin__Notices;
+use Tribe__Tickets__Admin__Notices;
+
+class NoticesTest extends WPTestCase {
+
+	use With_Uopz;
+
+	private const WOO_NOTICE_SLUG = 'event-tickets-plus-missing-woocommerce-support';
+	private const EDD_NOTICE_SLUG = 'event-tickets-plus-missing-easydigitaldownloads-support';
+
+	/**
+	 * @before
+	 */
+	public function clear_registered_notices(): void {
+		$notices = Tribe__Admin__Notices::instance();
+		$notices->remove( self::WOO_NOTICE_SLUG );
+		$notices->remove( self::EDD_NOTICE_SLUG );
+	}
+
+	/**
+	 * @after
+	 */
+	public function reset_current_screen(): void {
+		unset( $GLOBALS['current_screen'] );
+	}
+
+	private function fake_plugin_active( array $active_paths ): void {
+		$this->set_fn_return(
+			'is_plugin_active',
+			static function ( $path ) use ( $active_paths ): bool {
+				return in_array( $path, $active_paths, true );
+			},
+			true
+		);
+	}
+
+	private function get_notices_class(): Tribe__Tickets__Admin__Notices {
+		return new Tribe__Tickets__Admin__Notices();
+	}
+
+	/**
+	 * The screen gate must allow Tickets admin screens.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_tickets_admin_screen(): void {
+		set_current_screen( 'tickets_page_tec-tickets-settings' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The screen gate must allow the Plugins page so the notice surfaces right after activation.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_plugins_screen(): void {
+		set_current_screen( 'plugins' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * Network admin Plugins page shares the same screen base.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_network_plugins_screen(): void {
+		set_current_screen( 'plugins-network' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The screen gate must reject screens outside the Tickets and Plugins contexts.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_reject_unrelated_screen(): void {
+		set_current_screen( 'dashboard' );
+
+		$this->assertFalse( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * If no screen is set, the gate must reject (the active_callback runs on admin_notices,
+	 * so this case is mostly defensive).
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_reject_when_no_screen_set(): void {
+		unset( $GLOBALS['current_screen'] );
+
+		$this->assertFalse( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The notice should be registered (and gated by the active_callback) when WooCommerce is active.
+	 *
+	 * @test
+	 */
+	public function it_should_register_woocommerce_notice_with_screen_gate_active_callback(): void {
+		$this->fake_plugin_active( [ 'woocommerce/woocommerce.php' ] );
+
+		$this->get_notices_class()->maybe_display_plus_commerce_notice();
+
+		$notice = Tribe__Admin__Notices::instance()->get( self::WOO_NOTICE_SLUG );
+
+		$this->assertNotNull( $notice, 'WooCommerce notice should be registered when WooCommerce is active.' );
+		$this->assertTrue(
+			is_callable( $notice->active_callback ?? null ),
+			'The notice must be registered with an active_callback so the screen check runs at display time.'
+		);
+	}
+
+	/**
+	 * Same for Easy Digital Downloads.
+	 *
+	 * @test
+	 */
+	public function it_should_register_edd_notice_with_screen_gate_active_callback(): void {
+		$this->fake_plugin_active( [ 'easy-digital-downloads/easy-digital-downloads.php' ] );
+
+		$this->get_notices_class()->maybe_display_plus_commerce_notice();
+
+		$notice = Tribe__Admin__Notices::instance()->get( self::EDD_NOTICE_SLUG );
+
+		$this->assertNotNull( $notice, 'EDD notice should be registered when EDD is active.' );
+		$this->assertTrue(
+			is_callable( $notice->active_callback ?? null ),
+			'The notice must be registered with an active_callback so the screen check runs at display time.'
+		);
+	}
+
+	/**
+	 * Notices should not be registered when none of the supported providers are active.
+	 *
+	 * @test
+	 */
+	public function it_should_not_register_notice_when_no_supported_provider_is_active(): void {
+		$this->fake_plugin_active( [] );
+
+		$this->get_notices_class()->maybe_display_plus_commerce_notice();
+
+		$this->assertFalse(
+			Tribe__Admin__Notices::instance()->exists( self::WOO_NOTICE_SLUG ),
+			'WooCommerce notice should not be registered when WooCommerce is inactive.'
+		);
+		$this->assertFalse(
+			Tribe__Admin__Notices::instance()->exists( self::EDD_NOTICE_SLUG ),
+			'EDD notice should not be registered when EDD is inactive.'
+		);
+	}
+
+	/**
+	 * The registered active_callback should drive display: true on Tickets/Plugins screens, false elsewhere.
+	 *
+	 * @test
+	 */
+	public function active_callback_should_gate_by_current_screen(): void {
+		$this->fake_plugin_active( [ 'woocommerce/woocommerce.php' ] );
+
+		$this->get_notices_class()->maybe_display_plus_commerce_notice();
+
+		$notice = Tribe__Admin__Notices::instance()->get( self::WOO_NOTICE_SLUG );
+		$this->assertNotNull( $notice );
+
+		set_current_screen( 'tickets_page_tec-tickets-settings' );
+		$this->assertTrue( call_user_func( $notice->active_callback ) );
+
+		set_current_screen( 'plugins' );
+		$this->assertTrue( call_user_func( $notice->active_callback ) );
+
+		set_current_screen( 'dashboard' );
+		$this->assertFalse( call_user_func( $notice->active_callback ) );
+	}
+}

--- a/tests/integration/Tribe/Admin/NoticesTest.php
+++ b/tests/integration/Tribe/Admin/NoticesTest.php
@@ -78,12 +78,56 @@ class NoticesTest extends WPTestCase {
 	}
 
 	/**
-	 * The screen gate must reject screens outside the Tickets and Plugins contexts.
+	 * The screen gate must allow The Events Calendar submenu screens.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_tec_submenu_screen(): void {
+		set_current_screen( 'tribe_events_page_tec-events-settings' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The screen gate must allow the All Events list table.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_events_list_screen(): void {
+		set_current_screen( 'edit-tribe_events' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The screen gate must allow the single event editor.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_allow_single_event_screen(): void {
+		set_current_screen( 'tribe_events' );
+
+		$this->assertTrue( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * The screen gate must reject screens outside the Tickets, TEC, and Plugins contexts.
 	 *
 	 * @test
 	 */
 	public function is_plus_commerce_notice_context_should_reject_unrelated_screen(): void {
 		set_current_screen( 'dashboard' );
+
+		$this->assertFalse( $this->get_notices_class()->is_plus_commerce_notice_context() );
+	}
+
+	/**
+	 * Editing a non-event post should not surface the notice.
+	 *
+	 * @test
+	 */
+	public function is_plus_commerce_notice_context_should_reject_non_event_post_editor(): void {
+		set_current_screen( 'post' );
 
 		$this->assertFalse( $this->get_notices_class()->is_plus_commerce_notice_context() );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1303](https://linear.app/nexcess/issue/SMTNC-1303/woocommerce-compatibility-notice-displays-on-all-wp-admin-pages)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"Brief summary of the issue: If I have Event Tickets active, When I activate WooCommerce, Then I see a compatibility notice in all the wp-admin pages. Not just in the admin pages in the context of Tickets or Events"
Fixed the logic where the notice is triggered. Now it's triggered only in Plugins and Ticket/Events related pages.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1712" height="1321" alt="Screenshot 2026-05-27 at 17 39 26" src="https://github.com/user-attachments/assets/3af46d0d-314e-4beb-8b68-d9371bc3f0d8" />
<img width="1712" height="1322" alt="Screenshot 2026-05-27 at 17 39 51" src="https://github.com/user-attachments/assets/e1acd2b5-5e2d-4bf7-a603-4fdc256e1dd6" />
<img width="1718" height="1323" alt="Screenshot 2026-05-27 at 17 40 10" src="https://github.com/user-attachments/assets/a70692a5-b837-4683-8b02-cf54d2742088" />

### ✔️ Checklist
- [X] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [X] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
