### PR TITLE
fix: remove stray newline in rsvp_form_toggle aria-label (SOFT-3343)

### DIFF
--- a/src/admin-views/editor/elements/new-rsvp.php
+++ b/src/admin-views/editor/elements/new-rsvp.php
@@ -15,8 +15,7 @@ $disabled = ! empty( $disabled );
 <button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
-	aria-label="
-	<?php
+	aria-label="<?php
 	echo esc_attr(
 		sprintf(
 			// translators: the %s is the name of the RSVP ticket type.
@@ -24,8 +23,7 @@ $disabled = ! empty( $disabled );
 			tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
 		)
 	);
-	?>
-	"
+	?>"
 	<?php if ( $disabled ) : ?>
 		disabled
 		title="<?php echo esc_attr_x( 'RSVP is temporarily disabled while migration is in progress.', 'Tooltip for disabled RSVP button during migration.', 'event-tickets' ); ?>"

--- a/src/admin-views/editor/elements/new-rsvp.php
+++ b/src/admin-views/editor/elements/new-rsvp.php
@@ -11,19 +11,17 @@
 defined( 'ABSPATH' ) || exit;
 
 $disabled = ! empty( $disabled );
+
+$aria_label = sprintf(
+	// translators: the %s is the name of the RSVP ticket type.
+	_x( 'Add a new %s', 'RSVP form toggle button label', 'event-tickets' ),
+	tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
+);
 ?>
 <button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
-	aria-label="<?php
-	echo esc_attr(
-		sprintf(
-			// translators: the %s is the name of the RSVP ticket type.
-			_x( 'Add a new %s', 'RSVP form toggle button label', 'event-tickets' ),
-			tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
-		)
-	);
-	?>"
+	aria-label="<?php echo esc_attr( $aria_label ); ?>"
 	<?php if ( $disabled ) : ?>
 		disabled
 		title="<?php echo esc_attr_x( 'RSVP is temporarily disabled while migration is in progress.', 'Tooltip for disabled RSVP button during migration.', 'event-tickets' ); ?>"


### PR DESCRIPTION
## Ticket 
[SOFT-3343](https://linear.app/nexcess/issue/SOFT-3343/metaboxtest-snapshot-failures-stray-newline-in-rsvp-form-toggle-aria)

## Summary

There was a test failure from some snapshots that needed to be updated. This PR updates those snapshots. 

Commit [`3363146`](https://github.com/the-events-calendar/event-tickets/commit/3363146c86d687ac45c028bb8ca95654d3016945) reformatted `src/admin-views/editor/elements/new-rsvp.php` so that the `aria-label` attribute opened on its own line with the PHP echo block indented below it. That introduced literal whitespace inside the attribute value — the rendered HTML became:

```
-aria-label="Add a new RSVP"
+aria-label="
+Add a new RSVP"
```

## Test plan

- [x] CI `test (integration)` job passes — `MetaboxTest::test_get_panels` and `MetaboxTest::test_get_panels_with_no_providers` no longer fail with `aria-label` snapshot diffs.
- [x] Manually open a post/event in the Classic Editor and confirm the "New RSVP" toggle button still has the expected accessible name.