### PR TITLE
fix: seed _tribe_ticket_version on RSVP V2 → TC migration (SOFT-3344)

### DIFF
--- a/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
+++ b/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
@@ -19,6 +19,7 @@ use TEC\Tickets\Commerce\Ticket as TC_Ticket;
 use TEC\Tickets\Commerce\Utils\Currency;
 use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 use Tribe__Cache_Listener as Cache_Listener;
+use Tribe__Tickets__Main;
 use Tribe__Tickets__RSVP as RSVP;
 use TEC\Common\StellarWP\Migrations\Utilities\Logger;
 use WP_Post;
@@ -105,6 +106,7 @@ class RSVP_To_Tickets_Commerce extends Migration_Abstract {
 			TC_Ticket::$allow_backorders_meta_key    => 'no',
 			'_price'                                 => 0,
 			'_tribe_ticket_show_description'         => 'yes',
+			'_tribe_ticket_version'                  => Tribe__Tickets__Main::VERSION,
 			'format'                                 => 'standard',
 			'sticky'                                 => '',
 		];
@@ -132,6 +134,7 @@ class RSVP_To_Tickets_Commerce extends Migration_Abstract {
 			TC_Ticket::$stock_mode_meta_key,
 			TC_Ticket::$stock_status_meta_key,
 			TC_Ticket::$allow_backorders_meta_key,
+			'_tribe_ticket_version',
 			'format',
 			'sticky',
 			'show_not_going',


### PR DESCRIPTION
## Ticket
[SOFT-3344](https://linear.app/nexcess/issue/SOFT-3344/rsvp-v2-tc-migration-drops-tribe-ticket-version-meta-key)

## Summary

Native TC tickets get `_tribe_ticket_version` written by `Tribe__Tickets__Version::update()`, which is hooked to the `tribe_tickets_ticket_add` action when a ticket is created. The RSVP → TC migration in `src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php` doesn't go through that creation flow — it changes the post type with `wp_update_post` — so the action never fires and the migrated post is missing the version meta.

The integration test compares the migrated ticket's meta against a freshly-created native TC ticket and fails on the missing key:

```
Migrated RSVP V2 ticket is missing meta keys that a native TC ticket has: _tribe_ticket_version
```

This PR adds `'_tribe_ticket_version' => Tribe__Tickets__Main::VERSION` to the static meta map written during migration (`get_ticket_meta_to_add()`) in `src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php`:

## Test plan

- [x] CI `test (rsvp_to_tc_migration)` job passes — `should_migrate_stock_and_capacity_meta_to_match_tc_ticket` no longer reports the missing key.