### PR TITLE
Fix bucket/rsvp-merge test failures

### DIFF
--- a/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
+++ b/src/Tickets/Migrations/RSVP_To_Tickets_Commerce.php
@@ -19,6 +19,7 @@ use TEC\Tickets\Commerce\Ticket as TC_Ticket;
 use TEC\Tickets\Commerce\Utils\Currency;
 use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 use Tribe__Cache_Listener as Cache_Listener;
+use Tribe__Tickets__Main;
 use Tribe__Tickets__RSVP as RSVP;
 use TEC\Common\StellarWP\Migrations\Utilities\Logger;
 use WP_Post;
@@ -105,6 +106,7 @@ class RSVP_To_Tickets_Commerce extends Migration_Abstract {
 			TC_Ticket::$allow_backorders_meta_key    => 'no',
 			'_price'                                 => 0,
 			'_tribe_ticket_show_description'         => 'yes',
+			'_tribe_ticket_version'                  => Tribe__Tickets__Main::VERSION,
 			'format'                                 => 'standard',
 			'sticky'                                 => '',
 		];
@@ -132,6 +134,7 @@ class RSVP_To_Tickets_Commerce extends Migration_Abstract {
 			TC_Ticket::$stock_mode_meta_key,
 			TC_Ticket::$stock_status_meta_key,
 			TC_Ticket::$allow_backorders_meta_key,
+			'_tribe_ticket_version',
 			'format',
 			'sticky',
 			'show_not_going',

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -2170,19 +2170,6 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					$types['tickets']['global'] = 1;
 					continue;
 				}
-
-				$stock_level = Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE === $global_stock_mode ? $ticket->global_stock_cap() : $ticket->available();
-
-				// Whether the stock level is negative because it represents unlimited stock (`-1`)
-				// or because it's oversold we normalize to `0` for the sake of displaying.
-				$stock_level = max( 0, (int) $stock_level );
-
-				$types['tickets']['stock'] += $stock_level;
-
-				// If current availability is unlimited (available = -1) and the ticket has stock, set it to 0.
-				if ( $types['tickets']['available'] < 0 && 0 !== $types['tickets']['stock'] ) {
-					$types['tickets']['available'] = 0;
-				}
 			}
 
 			/*
@@ -2204,9 +2191,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			);
 
 			foreach ( $ticket_post_ids as $ticket_post_id ) {
-				$global_stock                   = new Tribe__Tickets__Global_Stock( $ticket_post_id );
-				$global_stock                   = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
-				$types['tickets']['available'] += $global_stock;
+				$global_stock = new Tribe__Tickets__Global_Stock( $ticket_post_id );
+				$global_stock = $global_stock->is_enabled() ? $global_stock->get_stock_level() : 0;
 
 				// If there's at least one ticket with shared capacity, add the global stock to both available and stock totals.
 				// Only add global stock if tickets don't manage their own stock to prevent double-counting.

--- a/src/admin-views/editor/elements/new-rsvp.php
+++ b/src/admin-views/editor/elements/new-rsvp.php
@@ -11,21 +11,17 @@
 defined( 'ABSPATH' ) || exit;
 
 $disabled = ! empty( $disabled );
+
+// translators: the %s is the name of the RSVP ticket type.
+$add_new_rsvp_label = sprintf(
+	_x( 'Add a new %s', 'RSVP form toggle button label', 'event-tickets' ),
+	tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
+);
 ?>
 <button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
-	aria-label="
-	<?php
-	echo esc_attr(
-		sprintf(
-			// translators: the %s is the name of the RSVP ticket type.
-			_x( 'Add a new %s', 'RSVP form toggle button label', 'event-tickets' ),
-			tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
-		)
-	);
-	?>
-	"
+	aria-label="<?php echo esc_attr( $add_new_rsvp_label ); ?>"
 	<?php if ( $disabled ) : ?>
 		disabled
 		title="<?php echo esc_attr_x( 'RSVP is temporarily disabled while migration is in progress.', 'Tooltip for disabled RSVP button during migration.', 'event-tickets' ); ?>"

--- a/src/admin-views/editor/elements/new-rsvp.php
+++ b/src/admin-views/editor/elements/new-rsvp.php
@@ -12,8 +12,8 @@ defined( 'ABSPATH' ) || exit;
 
 $disabled = ! empty( $disabled );
 
-// translators: the %s is the name of the RSVP ticket type.
 $add_new_rsvp_label = sprintf(
+	// translators: the %s is the name of the RSVP ticket type.
 	_x( 'Add a new %s', 'RSVP form toggle button label', 'event-tickets' ),
 	tribe_get_rsvp_label_singular( 'rsvp_form_toggle_button_label' )
 );


### PR DESCRIPTION
[skip-changelog]

Fixes the test failures on `bucket/rsvp-merge` (the failures seen on the #4200 sanity PR). All changes are bug fixes + the related test corrections; caught pre-release on the bucket branch, so no changelog. Mirrors the salvageable fixes from the closed #4187, minus the forward-merge muddle.

## Changes

### 1. RSVP toggle aria-label (markup)
`new-rsvp.php` was rendering the label on its own indented line, injecting stray whitespace into the `aria-label` value. Precompute the label and echo it inline (same pattern as `new-ticket.php`). Fixes the `integration` MetaboxTest snapshot assertions.

### 2. `get_ticket_counts()` double-counting (core)
The method was in a half-merged state — it added the event's global stock to `available` **unconditionally** and **again** inside the shared-capacity branch, double-counting the shared pool and also adding it when every ticket uses `OWN_STOCK_MODE`. Drop the unconditional add (global stock is now added once, only when tickets don't manage their own stock) and remove the now-unreachable capped-stock block.
Fixes `wpunit/GetTicketCountsTest`, `commerce_integration/EventStockTest` + `SharedCapacityTest`, and the `integration/TicketsTest` count assertions.

### 3. Migrated-ticket version meta (migration)
RSVP V2 → Tickets Commerce migration wasn't setting `_tribe_ticket_version`, so migrated tickets lacked meta a native TC ticket has. Add it in `get_ticket_meta_to_add()` (and clean it up in `get_ticket_meta_to_delete()`). Fixes `rsvp_to_tc_migration/RSVP_To_Tickets_Commerce_Test`.