### PR TITLE
Fix fatal on admin attendees list

### DIFF
--- a/changelog/fix-SMTNC-1439-fatal-attendees-page
+++ b/changelog/fix-SMTNC-1439-fatal-attendees-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve an issue where the Attendees admin page caused a fatal error on sites using a translated admin locale. [SMTNC-1439]

--- a/src/Tickets/Admin/Attendees/Page.php
+++ b/src/Tickets/Admin/Attendees/Page.php
@@ -39,6 +39,10 @@ class Page {
 	/**
 	 * Event Tickets Attendees page hook suffix.
 	 *
+	 * This default reflects an English install. WordPress derives the real hook
+	 * suffix from the (translatable) parent menu title, so the actual value is
+	 * captured from the page registration in add_tec_tickets_attendees_page().
+	 *
 	 * @var string
 	 */
 	public static $hook_suffix = 'tickets_page_tec-tickets-attendees';
@@ -106,6 +110,20 @@ class Page {
 				],
 			]
 		);
+
+		// Bail if the page was not registered (e.g. the user lacks the capability).
+		if ( empty( $attendees_page ) ) {
+			return;
+		}
+
+		/*
+		 * Capture the hook suffix WordPress actually generated for this page and
+		 * use it to set up the attendees screen. The suffix is derived from the
+		 * translatable parent menu title, so it cannot be reliably hardcoded.
+		 */
+		static::$hook_suffix = $attendees_page;
+
+		add_action( "load-{$attendees_page}", [ tribe( 'tickets.attendees' ), 'screen_setup' ] );
 	}
 
 	/**

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -328,8 +328,6 @@ class Tribe__Tickets__Attendees {
 			[ $this, 'render' ]
 		);
 
-		$attendees_page_hook_suffix = \TEC\Tickets\Admin\Attendees\Page::$hook_suffix;
-
 		/**
 		 * @since 4.7.1
 		 *
@@ -340,7 +338,12 @@ class Tribe__Tickets__Attendees {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'load_pointers' ] );
 		add_action( "load-{$this->page_id}", [ $this, 'screen_setup' ] );
-		add_action( "load-{$attendees_page_hook_suffix}", [ $this, 'screen_setup' ] );
+
+		/*
+		 * The modern `tec-tickets-attendees` page hooks `screen_setup` onto its
+		 * own (locale-dependent) hook suffix from within its registration; see
+		 * TEC\Tickets\Admin\Attendees\Page::add_tec_tickets_attendees_page().
+		 */
 	}
 
 	/**

--- a/src/Tribe/Attendees.php
+++ b/src/Tribe/Attendees.php
@@ -338,12 +338,6 @@ class Tribe__Tickets__Attendees {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'load_pointers' ] );
 		add_action( "load-{$this->page_id}", [ $this, 'screen_setup' ] );
-
-		/*
-		 * The modern `tec-tickets-attendees` page hooks `screen_setup` onto its
-		 * own (locale-dependent) hook suffix from within its registration; see
-		 * TEC\Tickets\Admin\Attendees\Page::add_tec_tickets_attendees_page().
-		 */
 	}
 
 	/**

--- a/tests/integration/TEC/Tickets/Admin/Attendees/PageTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Attendees/PageTest.php
@@ -25,6 +25,16 @@ class PageTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected $page;
 
+	/**
+	 * The admin-menu globals as they were before this test mutated them, keyed by
+	 * global name. A key maps to [ bool $existed, mixed $value ] so tearDown can
+	 * restore the exact prior state (including "was unset") and avoid leaking an
+	 * empty array into sibling tests. See SMTNC-1439 regression notes.
+	 *
+	 * @var array<string,array{0:bool,1:mixed}>
+	 */
+	protected $original_admin_menu_globals = [];
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -38,7 +48,7 @@ class PageTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->page = new Page();
 
-		// Start each test from a clean admin-menu state.
+		// Start each test from a clean admin-menu state, remembering the prior one.
 		$this->reset_admin_menu_globals();
 
 		// Reset the static suffix to its English default so we observe the value the
@@ -47,22 +57,43 @@ class PageTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function tearDown(): void {
-		$this->reset_admin_menu_globals();
+		$this->restore_admin_menu_globals();
 		Page::$hook_suffix = 'tickets_page_tec-tickets-attendees';
 
 		parent::tearDown();
 	}
 
 	/**
-	 * Clears the WordPress admin-menu registries so each test registers the parent
-	 * "Tickets" menu (and its hook suffix) from scratch.
+	 * Snapshots and then clears the WordPress admin-menu registries so each test
+	 * registers the parent "Tickets" menu (and its hook suffix) from scratch.
 	 */
 	protected function reset_admin_menu_globals(): void {
-		$GLOBALS['menu']              = [];
-		$GLOBALS['submenu']           = [];
-		$GLOBALS['admin_page_hooks']  = [];
-		$GLOBALS['_registered_pages'] = [];
-		$GLOBALS['_parent_pages']     = [];
+		$globals = [ 'menu', 'submenu', 'admin_page_hooks', '_registered_pages', '_parent_pages' ];
+
+		foreach ( $globals as $key ) {
+			$this->original_admin_menu_globals[ $key ] = [
+				array_key_exists( $key, $GLOBALS ),
+				$GLOBALS[ $key ] ?? null,
+			];
+
+			$GLOBALS[ $key ] = [];
+		}
+	}
+
+	/**
+	 * Restores the admin-menu registries to their pre-test state so we do not leak
+	 * an empty array (or a freshly-created key) into other test cases.
+	 */
+	protected function restore_admin_menu_globals(): void {
+		foreach ( $this->original_admin_menu_globals as $key => [ $existed, $value ] ) {
+			if ( $existed ) {
+				$GLOBALS[ $key ] = $value;
+			} else {
+				unset( $GLOBALS[ $key ] );
+			}
+		}
+
+		$this->original_admin_menu_globals = [];
 	}
 
 	/**

--- a/tests/integration/TEC/Tickets/Admin/Attendees/PageTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Attendees/PageTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace TEC\Tickets\Admin\Attendees;
+
+use Tribe\Admin\Pages;
+use Tribe__Tickets__Attendees as Attendees;
+use Tribe__Tickets__Attendees_Table as Attendees_Table;
+
+/**
+ * @covers \TEC\Tickets\Admin\Attendees\Page
+ *
+ * Regression coverage for SMTNC-1439: opening the Attendees admin page fataled
+ * with "Call to a member function prepare_items() on null" on sites running a
+ * translated admin locale. The page wired Tribe__Tickets__Attendees::screen_setup()
+ * - the only thing that builds $attendees->attendees_table - to a *hardcoded*
+ * English hook suffix ("tickets_page_tec-tickets-attendees"). WordPress derives
+ * the real hook suffix from the translatable parent "Tickets" menu title, so under
+ * any other locale the load hook never fired, the table stayed null, and
+ * admin-views/attendees/attendees-table.php:12 fataled.
+ */
+class PageTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @var Page
+	 */
+	protected $page;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// register_page() runs add_submenu_page(), which lives in the admin plugin API.
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		// The page capability defaults to manage_options; act as an admin so it registers.
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		tribe_singleton( 'admin.pages', new Pages() );
+
+		$this->page = new Page();
+
+		// Start each test from a clean admin-menu state.
+		$this->reset_admin_menu_globals();
+
+		// Reset the static suffix to its English default so we observe the value the
+		// page actually captures during registration rather than a previous test's.
+		Page::$hook_suffix = 'tickets_page_tec-tickets-attendees';
+	}
+
+	public function tearDown(): void {
+		$this->reset_admin_menu_globals();
+		Page::$hook_suffix = 'tickets_page_tec-tickets-attendees';
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Clears the WordPress admin-menu registries so each test registers the parent
+	 * "Tickets" menu (and its hook suffix) from scratch.
+	 */
+	protected function reset_admin_menu_globals(): void {
+		$GLOBALS['menu']              = [];
+		$GLOBALS['submenu']           = [];
+		$GLOBALS['admin_page_hooks']  = [];
+		$GLOBALS['_registered_pages'] = [];
+		$GLOBALS['_parent_pages']     = [];
+	}
+
+	/**
+	 * Registers the top-level "Tickets" parent menu under the given (already
+	 * translated) title, mirroring Tribe\Admin\Settings::add_admin_pages(). This is
+	 * what seeds $admin_page_hooks['tec-tickets'] = sanitize_title( $title ), from
+	 * which WordPress derives every child page's hook suffix.
+	 *
+	 * @param string $translated_title The translated "Tickets" menu label.
+	 */
+	protected function register_parent_menu_with_title( string $translated_title ): void {
+		add_menu_page(
+			$translated_title,
+			$translated_title,
+			'manage_options',
+			Page::$parent_slug,
+			'__return_null'
+		);
+	}
+
+	/**
+	 * @return \Generator<string,array{0:string,1:string}>
+	 */
+	public function locale_menu_title_provider(): \Generator {
+		yield 'English (Tickets)' => [ 'Tickets', 'tickets_page_tec-tickets-attendees' ];
+		yield 'Portuguese (Ingressos)' => [ 'Ingressos', 'ingressos_page_tec-tickets-attendees' ];
+		yield 'French (Billets)' => [ 'Billets', 'billets_page_tec-tickets-attendees' ];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider locale_menu_title_provider
+	 */
+	public function it_should_hook_screen_setup_to_the_real_locale_aware_hook_suffix( string $menu_title, string $expected_hook_suffix ): void {
+		$this->register_parent_menu_with_title( $menu_title );
+
+		$this->page->add_tec_tickets_attendees_page();
+
+		$this->assertSame(
+			$expected_hook_suffix,
+			Page::$hook_suffix,
+			'The page should capture the hook suffix WordPress actually generated for the (translated) parent menu, not a hardcoded one.'
+		);
+
+		$this->assertNotFalse(
+			has_action( "load-{$expected_hook_suffix}", [ tribe( 'tickets.attendees' ), 'screen_setup' ] ),
+			'screen_setup() must be hooked to the page\'s real load hook so the attendees table gets initialized before render.'
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * Pins the actual regression: under a translated locale the page must NOT be
+	 * relying solely on the hardcoded English hook, which never fires.
+	 */
+	public function it_should_not_leave_screen_setup_on_only_the_hardcoded_english_hook_under_a_translated_locale(): void {
+		$this->register_parent_menu_with_title( 'Ingressos' );
+
+		$this->page->add_tec_tickets_attendees_page();
+
+		$this->assertFalse(
+			has_action( 'load-tickets_page_tec-tickets-attendees', [ tribe( 'tickets.attendees' ), 'screen_setup' ] ),
+			'Under a translated locale the English hook is never fired by WordPress, so screen_setup wired only to it would never run.'
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * Once screen_setup() runs (it is now correctly hooked), the attendees table is
+	 * an object, so attendees-table.php:12 can no longer call prepare_items() on null.
+	 */
+	public function it_should_populate_the_attendees_table_when_the_load_hook_fires(): void {
+		$this->register_parent_menu_with_title( 'Ingressos' );
+		$this->page->add_tec_tickets_attendees_page();
+
+		/** @var Attendees $attendees */
+		$attendees = tribe( 'tickets.attendees' );
+		$attendees->attendees_table = null;
+
+		// Mimic an actual request to the attendees page so screen_setup()'s guard passes.
+		$_GET['page'] = Page::$slug;
+
+		do_action( 'load-' . Page::$hook_suffix );
+
+		unset( $_GET['page'] );
+
+		$this->assertInstanceOf(
+			Attendees_Table::class,
+			$attendees->attendees_table,
+			'Firing the page load hook must build the attendees table so the template never dereferences null.'
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * Defensive: when the page is not registered (e.g. the user lacks the capability)
+	 * the method must bail without hooking anything or mutating the suffix.
+	 */
+	public function it_should_bail_when_the_page_is_not_registered(): void {
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->register_parent_menu_with_title( 'Ingressos' );
+
+		$this->page->add_tec_tickets_attendees_page();
+
+		$this->assertSame(
+			'tickets_page_tec-tickets-attendees',
+			Page::$hook_suffix,
+			'A failed registration should leave the default suffix untouched.'
+		);
+		$this->assertFalse(
+			has_action( 'load-ingressos_page_tec-tickets-attendees', [ tribe( 'tickets.attendees' ), 'screen_setup' ] ),
+			'No screen_setup hook should be added when the page is not registered.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1439](https://linear.app/nexcess/issue/SMTNC-1439/attendees-list-crashes-in-event-tickets-admin)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"Opening the participants/attendees list triggers a fatal error in the Event Tickets admin view."

It happened when the website was any language besides English. 
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1812" height="1105" alt="Screenshot 2026-06-03 at 13 02 23" src="https://github.com/user-attachments/assets/7535c64c-6618-4b64-a677-900e6868f587" />

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
