### PR TITLE
fix: send RSVP event ID as integer in classic-editor save (SOFT-3423)

### DIFF
--- a/changelog/fix-SOFT-3423-rsvp-classic-editor-event-integer
+++ b/changelog/fix-SOFT-3423-rsvp-classic-editor-event-integer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Fix saving an RSVP from the classic-editor metabox failing with a "must be a positive integer" REST error by sending the event ID as an integer instead of a string.

--- a/changelog/fix-SOFT-3423-rsvp-classic-editor-event-integer
+++ b/changelog/fix-SOFT-3423-rsvp-classic-editor-event-integer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix saving an RSVP from the classic-editor metabox failing with a "must be a positive integer" REST error by sending the event ID as an integer instead of a string.

--- a/src/resources/js/commerce/tickets.js
+++ b/src/resources/js/commerce/tickets.js
@@ -219,7 +219,7 @@ tribe.tickets.commerce.tickets = {};
 	 */
 	obj.mapFormValuesToApiParams = function( formValues ) {
 		const params = {
-			event: formValues.post_ID,
+			event: parseInt( formValues.post_ID, 10 ),
 			type: obj.tickets.ticketType || 'tc-rsvp',
 			title: formValues.ticket_name || '',
 			price: 0,


### PR DESCRIPTION
## Ticket
[SOFT-3423](https://linear.app/nexcess/issue/SOFT-3423/classic-editor-rsvp-save-fails-event-sent-as-string-rejected-by)

## Summary

Saving an RSVP from the new classic-editor RSVP metabox fails on every attempt. `POST /tec/v1/tickets` returns **400 `rest_invalid_param`**: `"event": "Argument `{event}` must be a positive integer."` The RSVP is never created.

[skip-changelog] because this bug was never public.

## Root cause (two parts)

**1. Latent bug in the RSVP code (since Jan 2026):** the classic-editor save builds its payload from form `<input>` values via jQuery `.val()` (always strings) and sends the post ID through as-is:

```js
event: formValues.post_ID,   // → the string "3580"
```

`src/resources/js/commerce/tickets.js` → `mapFormValuesToApiParams()`. Introduced 2026-01-20 (`ddf57cef2a`), on bucket mainline since 2026-01-23 (PR #4115).

**2. What made it surface now — a tribe-common fix pulled in via the main merge:** commit **`7617b5091` "fix: invoke validator"**. Previously every REST param's `validate_callback` was double-wrapped:

```php
'validate_callback' => function () { return function ( $value ) { ... }; },
```

WordPress core calls `validate_callback($value)` and expects `true`/`false`/`WP_Error`; the old outer closure returned the *inner* closure instead. A Closure is neither `false` nor a `WP_Error`, so **WP treated every value as valid — parameter validators never ran** across all TEC REST V1 endpoints. The fix unwrapped it so validation actually executes.

## Fix

Cast the post ID to an integer, matching how `capacity` is already handled:

```js
event: parseInt( formValues.post_ID, 10 ),
```

`src/resources/js/commerce/tickets.js` (~line 222).

