### PR TITLE
Fix outdated code standards link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ worth knowing.
 
 ## Standards
 
-We have a set of [coding standards](http://the-events-calendar.github.io/products-engineering/)
+We have a set of [coding standards](https://docs.theeventscalendar.com/developer/code-standards/)
 that we follow and encourage others to follow as well. When you submit
 Pull Requests, you'll probably notice a friendly bot - `tr1b0t` - that
 comments on your PR and suggests changes. Be gentle with him, he's only

--- a/changelog/fix-broken-link-in-contributing-md
+++ b/changelog/fix-broken-link-in-contributing-md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updated broken link to coding standards in `CONTRIBUTING.md`


### PR DESCRIPTION
### 🎫 Ticket

https://linear.app/nexcess/issue/SMTNC-1451/fix-outdated-code-standards-links-in-contributingmd

### 🗒️ Description

This pull request updates the link to the coding standards in the `CONTRIBUTING.md` file to point to the correct documentation site.

- Updated the coding standards link in `CONTRIBUTING.md` from the old GitHub Pages URL to the new URL: `https://docs.theeventscalendar.com/developer/code-standards/`

### ✔️ Checklist
- [x] Automated code review comments are addressed.