### PR TITLE
[SMTNC-288] Hide From Event Listings is hiding Events from Events Tickets App

### DIFF
--- a/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
+++ b/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: "tweak: added filters"
+
+tec_tickets_rest_events_archive_include_hidden_from_listings

--- a/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
+++ b/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
@@ -1,4 +1,4 @@
 Significance: patch
-Type: "tweak: added filters"
+Type: tweak
 
 tec_tickets_rest_events_archive_include_hidden_from_listings

--- a/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
+++ b/changelog/smtnc-288-add-rest-events-archive-include-hidden-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-tec_tickets_rest_events_archive_include_hidden_from_listings
+Added filters: `tec_tickets_rest_events_archive_include_hidden_from_listings`.

--- a/changelog/smtnc-288-tecetpapp-hide-from-event-listings-is-hiding-events-from
+++ b/changelog/smtnc-288-tecetpapp-hide-from-event-listings-is-hiding-events-from
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Show events marked "Hide From Event Listings" in the Event Tickets App so on-site managers can still see and check them in. [SMTNC-288]

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -194,6 +194,8 @@ class Tribe__Tickets__REST__V1__Main extends Tribe__REST__Main {
 		 * @param bool            $include_hidden Whether to include hidden-from-listings events.
 		 * @param array           $args           The current query args.
 		 * @param WP_REST_Request $request        The request object.
+		 
+		 * @return bool true to include hidden events, false to exclude.
 		 */
 		$include_hidden = apply_filters(
 			'tec_tickets_rest_events_archive_include_hidden_from_listings',

--- a/src/Tribe/REST/V1/Main.php
+++ b/src/Tribe/REST/V1/Main.php
@@ -182,6 +182,33 @@ class Tribe__Tickets__REST__V1__Main extends Tribe__REST__Main {
 			$args['has_rsvp_or_tickets'] = tribe_is_truthy( $request['ticketed'] );
 		}
 
+		/**
+		 * Whether the REST events archive query should include events marked
+		 * "Hide From Event Listings". Defaults to true for privileged requests
+		 * (e.g. the Event Tickets App) so on-site managers can still see and
+		 * check in hidden events, while the public website and unauthenticated
+		 * REST consumers keep them hidden.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool            $include_hidden Whether to include hidden-from-listings events.
+		 * @param array           $args           The current query args.
+		 * @param WP_REST_Request $request        The request object.
+		 */
+		$include_hidden = apply_filters(
+			'tec_tickets_rest_events_archive_include_hidden_from_listings',
+			$this->request_has_manage_access(),
+			$args,
+			$request
+		);
+
+		if ( $include_hidden ) {
+			// In Tribe__Events__Query::getEvents(), hide_upcoming=false sets the internal
+			// $hidden flag to null, which skips the hidden-from-upcoming exclusion and
+			// returns hidden + visible events alike.
+			$args['hide_upcoming'] = false;
+		}
+
 		return $args;
 	}
 

--- a/tests/wpunit/Tribe/REST/V1/MainTest.php
+++ b/tests/wpunit/Tribe/REST/V1/MainTest.php
@@ -108,6 +108,63 @@ class MainTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * @test
+	 * it should include hidden-from-listings events for privileged requests
+	 */
+	public function it_should_include_hidden_events_for_privileged_requests() {
+		// The `tribe_manage_attendees` cap grants manage access (works on single and multisite).
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		( new \WP_User( $admin_id ) )->add_cap( 'tribe_manage_attendees' );
+		wp_set_current_user( $admin_id );
+
+		$sut     = $this->make_instance();
+		$request = new \WP_REST_Request( 'GET', '/tribe/events/v1/events' );
+
+		$args = $sut->parse_events_rest_args( [], [], $request );
+
+		$this->assertArrayHasKey( 'hide_upcoming', $args );
+		$this->assertFalse( $args['hide_upcoming'] );
+	}
+
+	/**
+	 * @test
+	 * it should not include hidden-from-listings events for unprivileged requests
+	 */
+	public function it_should_not_include_hidden_events_for_unprivileged_requests() {
+		// Logged-out request with no API key configured: no manage access.
+		wp_set_current_user( 0 );
+		tribe_update_option( 'tickets-plus-qr-options-api-key', '' );
+
+		$sut     = $this->make_instance();
+		$request = new \WP_REST_Request( 'GET', '/tribe/events/v1/events' );
+
+		$args = $sut->parse_events_rest_args( [], [], $request );
+
+		$this->assertArrayNotHasKey( 'hide_upcoming', $args );
+	}
+
+	/**
+	 * @test
+	 * it should let the filter override the include-hidden decision
+	 */
+	public function it_should_let_the_filter_override_the_include_hidden_decision() {
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		( new \WP_User( $admin_id ) )->add_cap( 'tribe_manage_attendees' );
+		wp_set_current_user( $admin_id );
+
+		add_filter( 'tec_tickets_rest_events_archive_include_hidden_from_listings', '__return_false' );
+
+		$sut     = $this->make_instance();
+		$request = new \WP_REST_Request( 'GET', '/tribe/events/v1/events' );
+
+		$args = $sut->parse_events_rest_args( [], [], $request );
+
+		remove_filter( 'tec_tickets_rest_events_archive_include_hidden_from_listings', '__return_false' );
+
+		$this->assertArrayNotHasKey( 'hide_upcoming', $args );
+	}
+
+	/**
 	 * @return Main
 	 */
 	protected function make_instance() {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-288](https://linear.app/nexcess/issue/SMTNC-288/tecetpapp-hide-from-event-listings-is-hiding-events-from-events)

### 🗒️ Description

Events flagged **"Hide From Event Listings"** were disappearing from the **Event Tickets App**, so on-site managers could no longer see or check in attendees for those events. They now remain visible to the App while staying hidden from the public website and unauthenticated REST consumers.

### 🎥 Artifacts
[https://www.loom.com/share/53192ccbc3d7499d8ddc7cf1180942a3](https://www.loom.com/share/53192ccbc3d7499d8ddc7cf1180942a3)

### 🧪 Testing Instructions for QA

**Setup**
1. Activate **The Events Calendar**, **Event Tickets**, and **Event Tickets Plus**.
2. Go to **Tickets → Settings** and enable the **QR / App** connection; copy the App API key (the value embedded in the connection QR code).

**Reproduce the bug (without the fix)**
1. Create an **Event** and add a **ticket or RSVP** to it. Check **"Hide From Event Listings"**.
2. Open the App-equivalent request in a browser (replace host + key):
   `<site_url>/wp-json/tribe/events/v1/events?ticketed=1&api_key=<APP_API_KEY>`
3. The hidden event **appears** and is selectable for check-in. ✅

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
