### PR TITLE
Prime cache when RSVP is made to keep availability accurate

### DIFF
--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -9,6 +9,7 @@
 
 namespace TEC\Tickets\Admin\Tickets;
 
+use Tribe__Cache_Listener;
 use Tribe__Tickets__Commerce__Currency;
 use Tribe__Tickets__Ticket_Object;
 use WP_List_Table;
@@ -1039,7 +1040,7 @@ class List_Table extends WP_List_Table {
 		// @todo @codingmusician - Add query priming solutions for other providers.
 		$ticket_ids             = wp_list_pluck( $items, 'ID' );
 		$cache                  = tribe_cache();
-		$attendees_by_ticket_id = $cache->get( 'tec_tickets_attendees_by_ticket_id' );
+		$attendees_by_ticket_id = $cache->get( 'tec_tickets_attendees_by_ticket_id', Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 		if ( ! is_array( $attendees_by_ticket_id ) ) {
 			$attendees_by_ticket_id = [];
 		}
@@ -1081,7 +1082,7 @@ class List_Table extends WP_List_Table {
 			$attendees_by_ticket_id[ $ticket_id ][] = $attendee;
 		}
 
-		$cache->set( 'tec_tickets_attendees_by_ticket_id', $attendees_by_ticket_id );
+		$cache->set( 'tec_tickets_attendees_by_ticket_id', $attendees_by_ticket_id, 0, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -6,6 +6,7 @@ use TEC\Tickets\Commerce;
 use TEC\Tickets\Commerce\Communications\Email;
 use TEC\Tickets\Commerce\Status\Status_Handler;
 use \Tribe__Tickets__Ticket_Object as Ticket_Object;
+use Tribe__Cache_Listener;
 use Tribe__Utils__Array as Arr;
 use Tribe__Date_Utils;
 use WP_Post;
@@ -810,9 +811,14 @@ class Attendee {
 			return [];
 		}
 		
-		// Check cache.
+		/*
+		 * Check cache. The cache is keyed to the `save_post` trigger so creating, updating or deleting
+		 * an Attendee (a post) invalidates it. Without this trigger the cached list would survive for the
+		 * rest of the request even after new Attendees are generated, making inventory()/available() report
+		 * a stale count right after an RSVP/purchase until the next page load.
+		 */
 		$cache                  = tribe_cache();
-		$attendees_by_ticket_id = $cache->get( 'tec_tickets_attendees_by_ticket_id' );
+		$attendees_by_ticket_id = $cache->get( 'tec_tickets_attendees_by_ticket_id', Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 		if ( ! is_array( $attendees_by_ticket_id ) ) {
 			$attendees_by_ticket_id = [];
 		}
@@ -824,7 +830,7 @@ class Attendee {
 
 			// Store in cache.
 			$attendees_by_ticket_id[ $ticket_id ] = $attendees;
-			$cache->set( 'tec_tickets_attendees_by_ticket_id', $attendees_by_ticket_id );
+			$cache->set( 'tec_tickets_attendees_by_ticket_id', $attendees_by_ticket_id, 0, Tribe__Cache_Listener::TRIGGER_SAVE_POST );
 		}
 
 		return tribe( Module::class )->get_attendees_from_module( $attendees_by_ticket_id[ $ticket_id ] );

--- a/tests/rsvp_v2_integration/RSVP/V2/Stock_Capacity_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Stock_Capacity_Test.php
@@ -3,7 +3,9 @@
 namespace TEC\Tickets\RSVP\V2;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Attendee;
 use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe__Tickets__Tickets as Tickets;
@@ -11,6 +13,7 @@ use Tribe__Tickets__Tickets as Tickets;
 class Stock_Capacity_Test extends WPTestCase {
 	use Ticket_Maker;
 	use Order_Maker;
+	use Attendee_Maker;
 
 	public function test_stock_and_capacity_with_no_attendees(): void {
 		$post_id   = static::factory()->post->create();
@@ -109,6 +112,37 @@ class Stock_Capacity_Test extends WPTestCase {
 		$this->assertEquals( 50, $ticket->capacity() );
 		$this->assertEquals( 48, $ticket->stock() );
 		$this->assertEquals( 2, $ticket->qty_sold() );
+	}
+
+	/**
+	 * Regression: after the per-request attendee cache is warmed (e.g. the event page rendered
+	 * the RSVP block once), creating attendees during the same request must invalidate it so
+	 * inventory()/available() reflect the new attendees immediately. Previously the
+	 * `tec_tickets_attendees_by_ticket_id` cache was stored without the save_post trigger, so the
+	 * RSVP success view reported the pre-RSVP "remaining" count until the next page load.
+	 *
+	 * @see \TEC\Tickets\Commerce\Attendee::get_attendees_by_ticket_id()
+	 */
+	public function test_attendee_list_cache_refreshes_when_attendees_are_created(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, [ 'tribe-ticket' => [ 'capacity' => 10 ] ] );
+
+		$attendees = tribe( Attendee::class );
+		$provider  = tribe( Module::class )->orm_provider;
+
+		// Warm the per-request cache, as a page view of the RSVP block (which reads inventory) would.
+		$this->assertCount( 0, $attendees->get_attendees_by_ticket_id( $ticket_id, $provider ) );
+
+		// Three attendees come into existence during the same request. The save_post on each must
+		// invalidate the cached attendee list; otherwise inventory()/available() keep reporting the
+		// pre-RSVP "remaining" count until the next page load.
+		$this->create_going_tc_rsvp_attendees( 3, $ticket_id, $post_id );
+
+		$this->assertCount(
+			3,
+			$attendees->get_attendees_by_ticket_id( $ticket_id, $provider ),
+			'The cached attendee list must refresh after attendees are created during the same request.'
+		);
 	}
 
 	/**

--- a/tests/slr_integration/Admin/Ajax_Test.php
+++ b/tests/slr_integration/Admin/Ajax_Test.php
@@ -2796,16 +2796,18 @@ class Ajax_Test extends Controller_Test_Case {
 		$ticket_1 = tribe( Module::class )->get_ticket( $post_id, $ticket_id_1 );
 		$ticket_2 = tribe( Module::class )->get_ticket( $post_id, $ticket_id_2 );
 
-		// Confirm the tickets have no layout set.
+		// Confirm the tickets have no layout set: capacity and raw stock are reset to 1 by the handler.
 		$this->assertEquals( 1, $ticket_1->capacity() );
 		$this->assertEquals( 1, $ticket_1->stock() );
-		$this->assertEquals( 1, $ticket_1->available() );
-		$this->assertEquals( 1, $ticket_1->inventory() );
+		// Removing the layout resets capacity to 1 but leaves the 5 existing attendees in place, so the
+		// ticket is oversold: inventory()/available() (which count attendees) correctly report 0, not 1.
+		$this->assertEquals( 0, $ticket_1->available() );
+		$this->assertEquals( 0, $ticket_1->inventory() );
 
 		$this->assertEquals( 1, $ticket_2->capacity() );
 		$this->assertEquals( 1, $ticket_2->stock() );
-		$this->assertEquals( 1, $ticket_2->available() );
-		$this->assertEquals( 1, $ticket_2->inventory() );
+		$this->assertEquals( 0, $ticket_2->available() );
+		$this->assertEquals( 0, $ticket_2->inventory() );
 
 		// Confirm the global stock is removed.
 		$this->assertFalse( $global_stock->is_enabled() );

--- a/tests/slr_integration/Admin/__snapshots__/Ajax_Test__test_remove_event_layout_success__0.snapshot.json
+++ b/tests/slr_integration/Admin/__snapshots__/Ajax_Test__test_remove_event_layout_success__0.snapshot.json
@@ -7,9 +7,9 @@
     },
     "tickets": {
         "count": 2,
-        "stock": 2,
+        "stock": 0,
         "global": 0,
         "unlimited": 0,
-        "available": 2
+        "available": 0
     }
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3428](https://linear.app/nexcess/issue/SOFT-3428/availability-amount-delayed-after-successful-rsvp)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

After a successful RSVP, the number of available RSVPs always just shows -1 from the previous amount, regardless of how many RSVPs were just reserved. Refreshing the page then shows the correct amount. 

Upon investigation, this seems to be because `TEC\Tickets\Commerce\Attendee::get_attendees_by_ticket_id()` cached the attendee list without an expiration trigger:
```php
$cache->get( 'tec_tickets_attendees_by_ticket_id' );          // no save_post trigger
$cache->set( 'tec_tickets_attendees_by_ticket_id', $list );   // no save_post trigger
```
Every other counter (inventory(), available(), capacity()) caches with `Tribe__Cache_Listener::TRIGGER_SAVE_POST`, so they invalidate when any attendee post is saved. This method didn't — so once warmed it stayed frozen for the rest of the request, and inventory() (which counts that list) reported the stale value.

> The same untriggered cache is also primed in `Admin/Tickets/List_Table.php`; it's updated to use the same trigger so the admin priming keeps matching the read key.

### 🪑 Note for Seating tests

Making `get_attendees_by_ticket_id()` refresh within the request surfaced one pre-existing assumption in `slr_integration`: `Ajax_Test::test_remove_event_layout_success` was only passing because the stale cache hid attendees.

TLDR; Before our fix: the attendee count came back stale as 0, so inventory was `1 − 0 = 1`. After: it correctly sees the 5 attendees, so `1 − 5 = 0` (or -4, but then clamped back to 0) .

- The test reads `inventory()` **before** creating attendees (warming an empty cache), creates 10 attendees, then removes the layout.
- `remove_event_layout()` resets each ticket to **capacity 1** while leaving its 5 attendees attached, so the ticket is **oversold**. With accurate counting, `inventory()`/`available()` now correctly return **0** (previously `1`, i.e. `capacity 1 − 0 stale attendees`). The `get_ticket_counts` snapshot moves from `stock/available: 2` → `0` for the same reason.

I updated the assertions + snapshot to the truthful values (capacity & raw `stock` stay `1`; `available`/`inventory` → `0`), consistent with how any oversold ticket reports. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="1320" height="1388" alt="image" src="https://github.com/user-attachments/assets/43fb2d95-4f14-4aad-967c-aa261aaee4f4" />
<img width="1326" height="586" alt="image" src="https://github.com/user-attachments/assets/23d1f29e-e950-46db-afa7-13d33df7ade0" />

After:
<img width="1242" height="1146" alt="CleanShot 2026-06-04 at 16 20 13@2x" src="https://github.com/user-attachments/assets/3e3c8aef-4b6d-468f-8746-28298a5a1dd8" />
(No refresh needed for accurate numbers) 

### ✔️ Checklist
- [x] We can [skip-changelog] since this is an internal bug before being released
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
