### PR TITLE
Fix `$wpdb->get_var` returns null when failing, and causes a fatal error when accessing events.

### DIFF
--- a/changelog/smtnc-1309-wpdb-get_var-returns-null-when-failing-and-causes-a-fatal
+++ b/changelog/smtnc-1309-wpdb-get_var-returns-null-when-failing-and-causes-a-fatal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved a fatal error on the Events backend list that causes a fatal error when accessing events.
+Prevent a fatal error on the Events admin list when the ticketed or unticketed post counts could not be calculated.

--- a/changelog/smtnc-1309-wpdb-get_var-returns-null-when-failing-and-causes-a-fatal
+++ b/changelog/smtnc-1309-wpdb-get_var-returns-null-when-failing-and-causes-a-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved a fatal error on the Events backend list that causes a fatal error when accessing events.

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -161,6 +161,8 @@ class Tribe__Tickets__Query {
 			// phpcs:enable
 		}
 
+		// Custom SQL can be provided by the related filter and is expected to be fully prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return (int) $wpdb->get_var( $query );
 	}
 
@@ -212,6 +214,8 @@ class Tribe__Tickets__Query {
 			// phpcs:enable
 		}
 
+		// Custom SQL can be provided by the related filter and is expected to be fully prepared.
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return (int) $wpdb->get_var( $query );
 	}
 

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -161,7 +161,7 @@ class Tribe__Tickets__Query {
 			// phpcs:enable
 		}
 
-		return $wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**
@@ -212,7 +212,7 @@ class Tribe__Tickets__Query {
 			// phpcs:enable
 		}
 
-		return $wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/QueryTest.php
+++ b/tests/wpunit/Tribe/Tickets/QueryTest.php
@@ -203,6 +203,32 @@ class QueryTest extends WPTestCase {
 	}
 
 	/**
+	 * It should return zero and not fatal when ticketed count query fails.
+	 *
+	 * @test
+	 */
+	public function should_return_zero_and_not_fatal_when_ticketed_count_query_fails(): void {
+		add_filter( 'tec_tickets_query_ticketed_count_query', static fn() => 'SELECT NULL' );
+
+		$result = tribe( 'tickets.query' )->get_ticketed_count( 'post' );
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * It should return zero and not fatal when unticketed count query fails.
+	 *
+	 * @test
+	 */
+	public function should_return_zero_and_not_fatal_when_unticketed_count_query_fails(): void {
+		add_filter( 'tec_tickets_query_unticketed_count_query', static fn() => 'SELECT NULL' );
+
+		$result = tribe( 'tickets.query' )->get_unticketed_count( 'post' );
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
 	 * It should correctly restrict by ticketed status
 	 *
 	 * @test

--- a/tests/wpunit/Tribe/Tickets/QueryTest.php
+++ b/tests/wpunit/Tribe/Tickets/QueryTest.php
@@ -79,6 +79,130 @@ class QueryTest extends WPTestCase {
 	}
 
 	/**
+	 * Data provider for should_return_correct_ticketed_count.
+	 *
+	 * @return Generator
+	 */
+	public function get_ticketed_count_provider(): Generator {
+		yield 'no posts at all' => [
+			function (): array {
+				return [ 'post', 0 ];
+			}
+		];
+
+		yield '3 unticketed posts, none ticketed' => [
+			function (): array {
+				static::factory()->post->create_many( 3 );
+
+				return [ 'post', 0 ];
+			}
+		];
+
+		yield '3 ticketed posts' => [
+			function (): array {
+				$ticketed = static::factory()->post->create_many( 3 );
+				foreach ( $ticketed as $id ) {
+					$this->create_tc_ticket( $id );
+				}
+
+				return [ 'post', 3 ];
+			}
+		];
+
+		yield '2 ticketed, 4 unticketed posts' => [
+			function (): array {
+				static::factory()->post->create_many( 4 );
+				$ticketed = static::factory()->post->create_many( 2 );
+				foreach ( $ticketed as $id ) {
+					$this->create_tc_ticket( $id );
+				}
+
+				return [ 'post', 2 ];
+			}
+		];
+	}
+
+	/**
+	 * It should return correct int count of ticketed posts, including 0 when none exist.
+	 *
+	 * @test
+	 * @dataProvider get_ticketed_count_provider
+	 *
+	 * @param Closure $fixture Fixture providing post_type and expected count.
+	 */
+	public function should_return_correct_ticketed_count( Closure $fixture ): void {
+		[ $post_type, $expected ] = $fixture();
+
+		$query  = tribe( 'tickets.query' );
+		$result = $query->get_ticketed_count( $post_type );
+
+		$this->assertIsInt( $result );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Data provider for should_return_correct_unticketed_count.
+	 *
+	 * @return Generator
+	 */
+	public function get_unticketed_count_provider(): Generator {
+		yield 'no posts at all' => [
+			function (): array {
+				return [ 'post', 0 ];
+			}
+		];
+
+		yield '3 unticketed posts' => [
+			function (): array {
+				static::factory()->post->create_many( 3 );
+
+				return [ 'post', 3 ];
+			}
+		];
+
+		yield '3 ticketed posts, none unticketed' => [
+			function (): array {
+				$ticketed = static::factory()->post->create_many( 3 );
+				foreach ( $ticketed as $id ) {
+					$this->create_tc_ticket( $id );
+				}
+
+				return [ 'post', 0 ];
+			}
+		];
+
+		yield '2 ticketed, 4 unticketed posts' => [
+			function (): array {
+				static::factory()->post->create_many( 4 );
+				$ticketed = static::factory()->post->create_many( 2 );
+				foreach ( $ticketed as $id ) {
+					$this->create_tc_ticket( $id );
+				}
+
+				return [ 'post', 4 ];
+			}
+		];
+	}
+
+	/**
+	 * It should return correct int count of unticketed posts, including 0 when none exist.
+	 *
+	 * @test
+	 * @dataProvider get_unticketed_count_provider
+	 *
+	 * @param Closure $fixture Fixture providing post_type and expected count.
+	 */
+	public function should_return_correct_unticketed_count( Closure $fixture ): void {
+		[ $post_type, $expected ] = $fixture();
+
+		$query  = tribe( 'tickets.query' );
+		$result = $query->get_unticketed_count( $post_type );
+
+		$this->assertIsInt( $result );
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
 	 * It should correctly restrict by ticketed status
 	 *
 	 * @test


### PR DESCRIPTION
### 🎫 Ticket

[SMTN-1309](https://linear.app/nexcess/issue/SMTNC-1309/dollarwpdb-get-var-returns-null-when-failing-and-causes-a-fatal-error)

### 🗒️ Description

This pull request addresses a fatal error on the Events backend list related to ticketed and unticketed post counts. The main changes ensure that the methods for retrieving these counts always return an integer, even when there are no matching posts, preventing potential type errors. Additionally, comprehensive unit tests have been added to verify correct behavior in various scenarios.

**Bug Fixes:**

* Updated `get_ticketed_count` and `get_unticketed_count` methods in `src/Tribe/Query.php` to cast the result of `$wpdb->get_var` to an integer, ensuring an integer is always returned and preventing fatal errors when no results are found. [[1]](diffhunk://#diff-830d7239ef7d3dec86fe131583f9ccfed450d29748ab5880f6803b5a66dd4054L164-R164) [[2]](diffhunk://#diff-830d7239ef7d3dec86fe131583f9ccfed450d29748ab5880f6803b5a66dd4054L215-R215)

**Testing Improvements:**

* Added new data providers and test cases in `tests/wpunit/Tribe/Tickets/QueryTest.php` to verify that ticketed and unticketed count methods return the correct integer values, including when there are no posts.

### 🎥 Artifacts

https://www.loom.com/share/ced4e1b04132470eb39f2a003a8597e2

### 🧪 Plugin to simulate it

[smtnc-1309-repro.php](https://github.com/user-attachments/files/28819164/smtnc-1309-repro.php)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
