### PR TITLE
Order RSVP metabox below Tickets in classic editor [SOFT-3430]

### DIFF
--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -69,10 +69,11 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Settings::class, 'change_tickets_commerce_settings' )
 		);
 
-		// Classic Editor. Priority 20 so the Tickets metabox (registered at the
-		// default priority of 10) renders above the RSVP metabox; both stay in the
-		// `normal`/`high` bucket.
-		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ), 20 );
+		// Classic Editor.
+		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		// Reposition the RSVP metabox to sit directly after the Tickets metabox.
+		// Runs late (priority 100) so every metabox is registered before reordering.
+		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'reorder_after_tickets_metabox' ), 100 );
 		add_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )
@@ -197,7 +198,8 @@ class Controller extends Controller_Contract {
 			'tec_tickets_commerce_settings_top_level',
 			$this->container->callback( Settings::class, 'change_tickets_commerce_settings' )
 		);
-		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ), 20 );
+		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'reorder_after_tickets_metabox' ), 100 );
 		remove_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -69,8 +69,10 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Settings::class, 'change_tickets_commerce_settings' )
 		);
 
-		// Classic Editor.
-		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		// Classic Editor. Priority 20 so the Tickets metabox (registered at the
+		// default priority of 10) renders above the RSVP metabox; both stay in the
+		// `normal`/`high` bucket.
+		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ), 20 );
 		add_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )
@@ -195,7 +197,7 @@ class Controller extends Controller_Contract {
 			'tec_tickets_commerce_settings_top_level',
 			$this->container->callback( Settings::class, 'change_tickets_commerce_settings' )
 		);
-		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ), 20 );
 		remove_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )

--- a/src/Tickets/RSVP/V2/Metabox.php
+++ b/src/Tickets/RSVP/V2/Metabox.php
@@ -56,6 +56,60 @@ class Metabox {
 	}
 
 	/**
+	 * Repositions the RSVP metabox to render immediately after the Tickets metabox.
+	 *
+	 * The Tickets, RSVP, and (when Event Tickets Plus is active) Waitlist metaboxes all
+	 * register into the `normal`/`high` group, where WordPress orders boxes by
+	 * registration order. That can leave another box (e.g. Waitlist) between the Tickets
+	 * and RSVP boxes. This moves the RSVP box to sit directly after the Tickets box.
+	 *
+	 * Users who have manually reordered their metaboxes are unaffected: WordPress applies
+	 * their saved per-user order separately, which takes precedence over this default.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|null $post_type The post type the metaboxes are being added for.
+	 *
+	 * @return void
+	 */
+	public function reorder_after_tickets_metabox( $post_type = null ): void {
+		if ( ! in_array( $post_type, Tribe__Tickets__Main::instance()->post_types(), true ) ) {
+			return;
+		}
+
+		global $wp_meta_boxes;
+
+		if ( empty( $wp_meta_boxes[ $post_type ]['normal']['high'] ) ) {
+			return;
+		}
+
+		$high           = &$wp_meta_boxes[ $post_type ]['normal']['high'];
+		$tickets_box_id = 'tribetickets';
+		$rsvp_box_id    = 'tec-tickets-commerce-rsvp';
+
+		// Both boxes must be present to reposition; the rebuild below is a no-op if the
+		// RSVP box already follows the Tickets box.
+		if ( ! isset( $high[ $tickets_box_id ], $high[ $rsvp_box_id ] ) ) {
+			return;
+		}
+
+		$rsvp_box = $high[ $rsvp_box_id ];
+		unset( $high[ $rsvp_box_id ] );
+
+		// Rebuild the group, inserting the RSVP box right after the Tickets box.
+		$reordered = [];
+		foreach ( $high as $id => $box ) {
+			$reordered[ $id ] = $box;
+
+			if ( $id === $tickets_box_id ) {
+				$reordered[ $rsvp_box_id ] = $rsvp_box;
+			}
+		}
+
+		$high = $reordered;
+	}
+
+	/**
 	 * Renders the RSVP metabox for the event editor in the admin area.
 	 *
 	 * @since TBD


### PR DESCRIPTION
Ticket: [SOFT-3430](https://linear.app/nexcess/issue/SOFT-3430/classic-editor-order-rsvp-metabox-below-tickets-metabox)

### Description

In the classic editor, the new RSVP V2 metabox rendered in the wrong place relative to the Tickets metabox. This was incidental, not intentional: RSVP V1 used a single combined metabox, and V2 splits RSVP into its own box (`tec-tickets-commerce-rsvp`).

The Tickets (`tribetickets`), RSVP, and — when Event Tickets Plus is active — Waitlist (`tec-tickets-plus-waitlist-metabox`) boxes all register into the **same `normal`/`high` group**, where WordPress orders boxes purely by registration order. Tickets and Waitlist both register at hook priority `10`, so no `add_meta_boxes` hook priority can place RSVP *between* them — anything `≤10` risks landing above Tickets, anything `>10` lands below Waitlist.

This adds an explicit reorder (`Metabox::reorder_after_tickets_metabox()`) hooked to `add_meta_boxes` at priority `100` — after all boxes are registered — that moves the RSVP box to sit **directly after the Tickets box**. The result is `Tickets → RSVP → Waitlist`. The approach is independent of the Waitlist box's own registration, so it won't break if ETP changes.

Users who have manually dragged their metaboxes are unaffected — WordPress applies their saved per-user order (`meta-box-order_*` user meta) separately, and it takes precedence over this default. This only changes the default for fresh users.

## Artifacts
Before:
<img width="1710" height="2329" alt="CleanShot 2026-06-05 at 11 39 27" src="https://github.com/user-attachments/assets/f4aa053e-b639-40d7-94b8-1577a0710a23" />

After:
<img width="1707" height="2345" alt="CleanShot 2026-06-05 at 12 00 47 2" src="https://github.com/user-attachments/assets/8aefe1d0-839d-45fb-817b-60685a025e62" />


### Testing steps

1. With Event Tickets Plus active (so the Waitlist metabox is present), ensure RSVP V2 is active (`tickets_rsvp_version` = `v2`) and Tickets Commerce is enabled.
2. Open an event (or other ticket-enabled post type) in the **classic editor**, using an account that has never reordered its editor metaboxes.
3. Confirm the order in the main column is **Tickets → RSVP → Waitlist**.
4. With ETP inactive (no Waitlist box), confirm the order is **Tickets → RSVP**.
5. Drag to reorder the boxes, reload — confirm your custom order persists (per-user order still takes precedence).

[skip-changelog]
