### PR TITLE
Render RSVP responses count + View Attendees link in classic editor metabox [SOFT-3431]

### DIFF
--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -71,6 +71,12 @@ class Controller extends Controller_Contract {
 
 		// Classic Editor.
 		add_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		add_action(
+			'tec_event_tickets_rsvp_form__start',
+			$this->container->callback( Metabox::class, 'display_responses_info' ),
+			10,
+			3
+		);
 		add_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )
@@ -196,6 +202,11 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Settings::class, 'change_tickets_commerce_settings' )
 		);
 		remove_action( 'add_meta_boxes', $this->container->callback( Metabox::class, 'add' ) );
+		remove_action(
+			'tec_event_tickets_rsvp_form__start',
+			$this->container->callback( Metabox::class, 'display_responses_info' ),
+			10
+		);
 		remove_filter(
 			'tec_tickets_enabled_ticket_forms',
 			$this->container->callback( Classic_Editor::class, 'do_not_render_rsvp_form_toggle' )

--- a/src/Tickets/RSVP/V2/Metabox.php
+++ b/src/Tickets/RSVP/V2/Metabox.php
@@ -10,6 +10,7 @@
 namespace TEC\Tickets\RSVP\V2;
 
 use TEC\Tickets\Admin\Panels_Data\Ticket_Panel_Data;
+use TEC\Tickets\Commerce;
 use TEC\Tickets\Event;
 use Tribe__Tickets__Admin__Views as Admin_Views;
 use TEC\Tickets\RSVP\V2\Constants;
@@ -104,6 +105,61 @@ class Metabox {
 		return $admin_views->template(
 			[ 'editor', 'rsvp', 'metabox' ],
 			$context
+		);
+	}
+
+	/**
+	 * Renders the "Responses" count and "View Attendees" link at the top of the RSVP form.
+	 *
+	 * Hooked to `tec_event_tickets_rsvp_form__start`. The response total includes both
+	 * "going" and "not going" attendees, matching the count shown on the attendees report.
+	 *
+	 * @since TBD
+	 *
+	 * @param int|WP_Post $post_id     The event the RSVP is attached to.
+	 * @param string      $ticket_type The ticket type the form is being rendered for.
+	 * @param int|null    $rsvp_id     The RSVP ticket ID, or null when adding a new RSVP.
+	 *
+	 * @return void
+	 */
+	public function display_responses_info( $post_id, string $ticket_type, $rsvp_id = null ): void {
+		// Only render for saved TC RSVP tickets.
+		if ( Constants::TC_RSVP_TYPE !== $ticket_type || empty( $rsvp_id ) ) {
+			return;
+		}
+
+		// Count every response for this RSVP, including "going" and "not going".
+		$total_responses = tec_tc_attendees( Commerce::PROVIDER )
+			->by( 'ticket_id', $rsvp_id )
+			->found();
+
+		// Nothing to show until there is at least one response.
+		if ( $total_responses < 1 ) {
+			return;
+		}
+
+		$post = get_post( $post_id instanceof WP_Post ? $post_id->ID : (int) $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$cant_go_enabled = tribe_is_truthy(
+			get_post_meta( $rsvp_id, Constants::SHOW_NOT_GOING_META_KEY, true )
+		);
+
+		/** @var Admin_Views $admin_views */
+		$admin_views = tribe( 'tickets.admin.views' );
+
+		$admin_views->template(
+			[ 'editor', 'rsvp', 'panel', 'responses-info' ],
+			[
+				'post_id'         => $post->ID,
+				'rsvp_id'         => $rsvp_id,
+				'total_responses' => $total_responses,
+				'cant_go_enabled' => $cant_go_enabled,
+				'attendees_url'   => tribe( 'tickets.attendees' )->get_report_link( $post ),
+			]
 		);
 	}
 


### PR DESCRIPTION
**Ticket:** [SOFT-3431](https://linear.app/nexcess/issue/SOFT-3431/rsvp-v2-responses-count-view-attendees-link-missing-from-classic)

## Description

The classic-editor RSVP metabox was missing the **"Responses: NN — View Attendees"** line from the design spec (it should sit directly below "RSVP active").

It wasn't a styling glitch or a hidden conditional — the rendering code was never ported during the RSVP V2 merge. The template (`responses-info.php`) and the `tec_event_tickets_rsvp_form__start` hook both came across, but the handler that listens to that hook and renders the template did not, so nothing was drawn. A plugin-wide grep confirmed the only reference to the hook was the `do_action` that fires it.

This PR adds `Metabox::display_responses_info()` and registers it against `tec_event_tickets_rsvp_form__start` in the V2 RSVP controller. The handler:

- Bails unless the ticket type is `tc-rsvp` and the RSVP is saved.
- Counts every response for the ticket via the attendees ORM (`found()`) — this includes both **going and not going** attendees, matching the spec's "count includes not going" tooltip.
- Bails when there are 0 responses.
- Detects whether "Can't go" is enabled and builds the attendees-report URL via the canonical `tribe( 'tickets.attendees' )->get_report_link()` (post-type-agnostic, unlike the original feature-branch version which hardcoded `post_type=tribe_events`).

The CSS for `.tec-tickets-rsvp-responses-info__*` was already present on the branch, so no style changes are needed.

## Artifacts
Before:
<img width="2514" height="1434" alt="CleanShot 2026-06-05 at 12 45 26@2x" src="https://github.com/user-attachments/assets/52d6fe7c-c86e-4861-895b-cdca96a61e02" />

After:
<img width="2502" height="1518" alt="CleanShot 2026-06-05 at 12 44 31@2x" src="https://github.com/user-attachments/assets/b99d7c69-9a7f-4ddf-91a7-b42b59d55db6" />


## Testing steps

1. Open an event with an active RSVP that has at least one response in the classic editor.
2. Confirm the **"Responses: NN — View Attendees"** line renders below "RSVP active", with NN equal to total responses (going + not going).
3. With "Can't go" enabled, confirm the info tooltip ("Responses count includes 'not going'") appears.
4. Click **View Attendees** → it opens the attendees report for that event.
5. Confirm the line is hidden when the RSVP has 0 responses.

[skip-changelog]
