### PR TITLE
Show Going/Not Going status + hide check-in for declined RSVPs on attendee report [SOFT-3432]

### DIFF
--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -153,7 +153,11 @@ class Attendees {
 		}
 
 		$is_going    = 'no' !== $status;
-		$status_text = $is_going ? __( 'Going', 'event-tickets' ) : __( 'Not Going', 'event-tickets' );
+		$status_text = __( 'Not Going', 'event-tickets' );
+
+		if ( $is_going ) {
+			$status_text = __( 'Going', 'event-tickets' );
+		}
 
 		// Reuse the existing status-pill styling: blue-grey for going, amber for not going.
 		$classes = [

--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -131,4 +131,116 @@ class Attendees {
 
 		return $args;
 	}
+
+	/**
+	 * Replaces the order-status label with a "Going" / "Not Going" indicator for TC RSVP attendees.
+	 *
+	 * Hooked to `tribe_tickets_attendees_table_order_status`. All RSVP attendees have a
+	 * "Completed" order status, so the going/not-going answer is read from attendee meta.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                     $label The order-status HTML built by the attendees table.
+	 * @param array<string,mixed>|object $item  The attendees-table row item.
+	 *
+	 * @return string The (possibly) modified status label.
+	 */
+	public function modify_status_display( $label, $item ): string {
+		$status = $this->get_item_rsvp_status( $item );
+
+		if ( null === $status ) {
+			return $label;
+		}
+
+		$is_going    = 'no' !== $status;
+		$status_text = $is_going ? __( 'Going', 'event-tickets' ) : __( 'Not Going', 'event-tickets' );
+
+		// Reuse the existing status-pill styling: blue-grey for going, amber for not going.
+		$classes = [
+			'tec-tickets__admin-table-attendees-order-status',
+			'tec-tickets__admin-table-attendees-order-status--tc-rsvp',
+			'tec-tickets__admin-table-attendees-order-status--' . ( $is_going ? 'going' : 'not-going' ),
+			'tec-tickets__admin-table-attendees-order-status--' . ( $is_going ? 'completed' : 'cancelled' ),
+		];
+
+		return sprintf(
+			'<div class="tec-tickets__admin-table-attendees-order-status-wrapper"><span class="%1$s">%2$s</span></div>',
+			esc_attr( implode( ' ', $classes ) ),
+			esc_html( $status_text )
+		);
+	}
+
+	/**
+	 * Hides the check-in column control for TC RSVP attendees who are not going.
+	 *
+	 * Hooked to `tec_tickets_attendees_table_column_check_in`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string                     $content The check-in column HTML.
+	 * @param array<string,mixed>|object $item    The attendees-table row item.
+	 *
+	 * @return string The (possibly) emptied check-in content.
+	 */
+	public function modify_checkin_display( $content, $item ): string {
+		if ( 'no' === $this->get_item_rsvp_status( $item ) ) {
+			return '';
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Removes the check-in row action for TC RSVP attendees who are not going.
+	 *
+	 * Hooked to `event_tickets_attendees_table_row_actions`.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<int|string,string>   $actions The row actions.
+	 * @param array<string,mixed>|object $item    The attendees-table row item.
+	 *
+	 * @return array<int|string,string> The (possibly) filtered row actions.
+	 */
+	public function modify_row_actions( $actions, $item ): array {
+		if ( 'no' !== $this->get_item_rsvp_status( $item ) ) {
+			return (array) $actions;
+		}
+
+		// Drop the check-in / undo check-in action; not-going attendees cannot be checked in.
+		foreach ( (array) $actions as $key => $action ) {
+			if ( false !== strpos( (string) $action, 'tickets_checkin' ) ) {
+				unset( $actions[ $key ] );
+			}
+		}
+
+		return (array) $actions;
+	}
+
+	/**
+	 * Resolves the RSVP "going" status for an attendees-table row.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed>|object $item The attendees-table row item.
+	 *
+	 * @return string|null 'no' when the attendee is not going, 'yes' when going, or null when the
+	 *                     row is not a TC RSVP attendee and should be left untouched.
+	 */
+	private function get_item_rsvp_status( $item ): ?string {
+		$item = (array) $item;
+
+		if ( empty( $item['ticket_type'] ) || Constants::TC_RSVP_TYPE !== $item['ticket_type'] ) {
+			return null;
+		}
+
+		$attendee_id = (int) ( $item['attendee_id'] ?? $item['ID'] ?? 0 );
+
+		if ( ! $attendee_id ) {
+			return null;
+		}
+
+		// Only an explicit "no" counts as not going; anything else is treated as going.
+		return 'no' === get_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, true ) ? 'no' : 'yes';
+	}
 }

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -177,6 +177,26 @@ class Controller extends Controller_Contract {
 			4
 		);
 
+		// Attendees report: show Going/Not Going status and hide check-in for "not going" RSVPs.
+		add_filter(
+			'tribe_tickets_attendees_table_order_status',
+			$this->container->callback( Attendees::class, 'modify_status_display' ),
+			10,
+			2
+		);
+		add_filter(
+			'tec_tickets_attendees_table_column_check_in',
+			$this->container->callback( Attendees::class, 'modify_checkin_display' ),
+			10,
+			2
+		);
+		add_filter(
+			'event_tickets_attendees_table_row_actions',
+			$this->container->callback( Attendees::class, 'modify_row_actions' ),
+			10,
+			2
+		);
+
 		add_action(
 			'tec_tickets_commerce_single_order_details_metabox_after',
 			$this->container->callback( Metabox::class, 'add_rsvp_status_to_single_order_details_metabox' )
@@ -266,6 +286,18 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_view_count_ticket_attendees_args',
 			$this->container->callback( Attendees::class, 'exclude_rsvp_tickets_from_tickets_view_data_link_count' )
+		);
+		remove_filter(
+			'tribe_tickets_attendees_table_order_status',
+			$this->container->callback( Attendees::class, 'modify_status_display' )
+		);
+		remove_filter(
+			'tec_tickets_attendees_table_column_check_in',
+			$this->container->callback( Attendees::class, 'modify_checkin_display' )
+		);
+		remove_filter(
+			'event_tickets_attendees_table_row_actions',
+			$this->container->callback( Attendees::class, 'modify_row_actions' )
 		);
 		remove_action(
 			'tec_tickets_commerce_single_order_details_metabox_after',


### PR DESCRIPTION
**Ticket:** [SOFT-3432](https://linear.app/nexcess/issue/SOFT-3432/rsvp-v2-attendee-report-doesnt-show-goingnot-going-status-or-hide)

## Description

On the **Attendees report** for an event with a TC RSVP, attendees who selected "Not going" were indistinguishable from those going, and they were still offered a **Check In**:

- The **Status** column showed **"Completed"** for everyone (all RSVP attendees share a "Completed" order status; the going/not-going answer lives in the `_tec_tickets_commerce_rsvp_status` attendee meta, which the table never read).
- The **Check In** control appeared for all attendees, including those who declined.

The top **Attendance Overview** panel already shows the correct RSVPs Total/Going/Not Going breakdown — this PR only fixes the per-attendee table rows.

## Artifacts
Before:
<img width="3064" height="1700" alt="CleanShot 2026-06-05 at 13 45 27@2x" src="https://github.com/user-attachments/assets/08d8a8f0-a2a8-4e73-a231-0e4e858d764c" />


After:
<img width="3414" height="1856" alt="CleanShot 2026-06-05 at 13 30 44@2x" src="https://github.com/user-attachments/assets/f9699b90-a2e2-4bd6-939c-7841175be5cd" />


## Testing steps

1. Open the Attendees report for an event with a TC RSVP that has both "going" and "not going" responses.
2. **Status** column shows **"Going"** / **"Not Going"** per attendee (not "Completed").
3. **Check In** control is hidden for "not going" attendees and present for "going".
4. Hover row actions for "not going" attendees no longer include Check In / Undo Check In.
5. Non-RSVP (paid ticket) attendees are unchanged.

[skip-changelog]
