### PR TITLE
Fix priceCurrency in Event Schema

### DIFF
--- a/changelog/fix-SMTNC-1239-event-schema-currency
+++ b/changelog/fix-SMTNC-1239-event-schema-currency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve an issue where the Event Schema always reported the price currency as USD, ignoring the currency configured in the Tickets Commerce settings. [SMTNC-1239]

--- a/src/Tribe/JSON_LD/Order.php
+++ b/src/Tribe/JSON_LD/Order.php
@@ -193,9 +193,10 @@ class Tribe__Tickets__JSON_LD__Order {
 	 */
 	public function get_price_currency( $ticket ) {
 
-		$currency = tribe_get_option( 'ticket-commerce-currency-code', 'USD' );
+		$currency = tribe_get_option( \TEC\Tickets\Commerce\Settings::$option_currency_code );
 
-		if ( class_exists( $ticket->provider_class ) ) {
+
+		if ( class_exists( $ticket->provider_class ) && empty( $currency ) ) {
 			$instance = call_user_func( array( $ticket->provider_class, 'get_instance' ) ) ;
 			$currency = $instance->get_currency();
 		}

--- a/src/Tribe/JSON_LD/Order.php
+++ b/src/Tribe/JSON_LD/Order.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+use TEC\Tickets\Commerce\Settings;
+
 /**
  * A JSON-LD class to hook and change how Orders work on Events
  * @todo rework this class to make it standalone from The Events Calendar
@@ -186,6 +188,7 @@ class Tribe__Tickets__JSON_LD__Order {
 	 * Return the price currency used on the Ticket
 	 *
 	 * @since 4.7.1
+	 * @since TBD Use the Tickets Commerce currency setting as the source of truth.
 	 *
 	 * @param object  $ticket
 	 *
@@ -193,7 +196,7 @@ class Tribe__Tickets__JSON_LD__Order {
 	 */
 	public function get_price_currency( $ticket ) {
 
-		$currency = tribe_get_option( \TEC\Tickets\Commerce\Settings::$option_currency_code );
+		$currency = tribe_get_option( Settings::$option_currency_code );
 
 
 		if ( class_exists( $ticket->provider_class ) && empty( $currency ) ) {

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -29,11 +29,12 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 		$this->ticket    = tribe( Module::class )->get_ticket( $this->post_id, $ticket_id );
 	}
 
-	/**
-	 * @after
-	 */
-	public function reset_currency() {
+	public function tearDown() {
+		// Reset the currency inside the transaction so Tribe's in-memory option
+		// cache is refreshed before the DB rollback; otherwise the value leaks.
 		tribe_update_option( Settings::$option_currency_code, 'USD' );
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tribe\Tickets\JSON_LD;
+
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Settings;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker as TC_Ticket_Maker;
+use Tribe__Tickets__JSON_LD__Order as JSON_LD_Order;
+
+class OrderTest extends \Codeception\TestCase\WPTestCase {
+
+	use TC_Ticket_Maker;
+
+	/**
+	 * @var int
+	 */
+	protected $post_id;
+
+	/**
+	 * @var \Tribe__Tickets__Ticket_Object
+	 */
+	protected $ticket;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->post_id   = $this->factory()->post->create();
+		$ticket_id       = $this->create_tc_ticket( $this->post_id, 10 );
+		$this->ticket    = tribe( Module::class )->get_ticket( $this->post_id, $ticket_id );
+	}
+
+	public function tearDown() {
+		tribe_update_option( Settings::$option_currency_code, 'USD' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @return JSON_LD_Order
+	 */
+	private function make_instance() {
+		return JSON_LD_Order::instance();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_be_instantiatable() {
+		$this->assertInstanceOf( JSON_LD_Order::class, $this->make_instance() );
+	}
+
+	/**
+	 * @test
+	 * it should use the currency configured in Tickets Commerce settings
+	 */
+	public function it_should_use_the_configured_tickets_commerce_currency() {
+		tribe_update_option( Settings::$option_currency_code, 'EUR' );
+
+		$currency = $this->make_instance()->get_price_currency( $this->ticket );
+
+		$this->assertEquals( 'EUR', $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
+	}
+
+	/**
+	 * @test
+	 * it should reflect changes to the Tickets Commerce currency setting
+	 */
+	public function it_should_reflect_a_non_default_currency() {
+		tribe_update_option( Settings::$option_currency_code, 'GBP' );
+
+		$currency = $this->make_instance()->get_price_currency( $this->ticket );
+
+		$this->assertEquals( 'GBP', $currency );
+		$this->assertNotEquals( 'USD', $currency, 'The currency should no longer be hardcoded to USD.' );
+	}
+
+	/**
+	 * @test
+	 * it should fall back to the provider currency when the option is empty
+	 */
+	public function it_should_fall_back_to_the_provider_currency_when_option_is_empty() {
+		tribe_update_option( Settings::$option_currency_code, '' );
+
+		$currency = $this->make_instance()->get_price_currency( $this->ticket );
+
+		$this->assertEquals( $this->ticket->get_provider()->get_currency(), $currency );
+	}
+}

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -21,18 +21,20 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected $ticket;
 
-	public function setUp() {
-		parent::setUp();
-
+	/**
+	 * @before
+	 */
+	public function set_up_ticket() {
 		$this->post_id   = $this->factory()->post->create();
 		$ticket_id       = $this->create_tc_ticket( $this->post_id, 10 );
 		$this->ticket    = tribe( Module::class )->get_ticket( $this->post_id, $ticket_id );
 	}
 
-	public function tearDown() {
+	/**
+	 * @after
+	 */
+	public function reset_currency() {
 		tribe_update_option( Settings::$option_currency_code, 'USD' );
-
-		parent::tearDown();
 	}
 
 	/**
@@ -52,13 +54,30 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 * it should use the currency configured in Tickets Commerce settings
+	 *
+	 * @dataProvider currency_code_provider
 	 */
-	public function it_should_use_the_configured_tickets_commerce_currency() {
-		tribe_update_option( Settings::$option_currency_code, 'EUR' );
+	public function it_should_use_the_configured_tickets_commerce_currency( $currency_code ) {
+		tribe_update_option( Settings::$option_currency_code, $currency_code );
 
 		$currency = $this->make_instance()->get_price_currency( $this->ticket );
 
-		$this->assertEquals( 'EUR', $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
+		$this->assertEquals( $currency_code, $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
+	}
+
+	/**
+	 * Provides a set of currency codes to verify the schema follows the configured setting.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function currency_code_provider() {
+		return [
+			'Euro'            => [ 'EUR' ],
+			'British Pound'   => [ 'GBP' ],
+			'Japanese Yen'    => [ 'JPY' ],
+			'Canadian Dollar' => [ 'CAD' ],
+			'Brazilian Real'  => [ 'BRL' ],
+		];
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -21,20 +21,18 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	 */
 	protected $ticket;
 
-	/**
-	 * @before
-	 */
-	public function set_up_ticket() {
+	public function setUp() {
+		parent::setUp();
+
 		$this->post_id   = $this->factory()->post->create();
 		$ticket_id       = $this->create_tc_ticket( $this->post_id, 10 );
 		$this->ticket    = tribe( Module::class )->get_ticket( $this->post_id, $ticket_id );
 	}
 
-	/**
-	 * @after
-	 */
-	public function reset_currency() {
+	public function tearDown() {
 		tribe_update_option( Settings::$option_currency_code, 'USD' );
+
+		parent::tearDown();
 	}
 
 	/**
@@ -54,30 +52,13 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 * it should use the currency configured in Tickets Commerce settings
-	 *
-	 * @dataProvider currency_code_provider
 	 */
-	public function it_should_use_the_configured_tickets_commerce_currency( $currency_code ) {
-		tribe_update_option( Settings::$option_currency_code, $currency_code );
+	public function it_should_use_the_configured_tickets_commerce_currency() {
+		tribe_update_option( Settings::$option_currency_code, 'EUR' );
 
 		$currency = $this->make_instance()->get_price_currency( $this->ticket );
 
-		$this->assertEquals( $currency_code, $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
-	}
-
-	/**
-	 * Provides a set of currency codes to verify the schema follows the configured setting.
-	 *
-	 * @return array<string,array{0:string}>
-	 */
-	public function currency_code_provider() {
-		return [
-			'Euro'            => [ 'EUR' ],
-			'British Pound'   => [ 'GBP' ],
-			'Japanese Yen'    => [ 'JPY' ],
-			'Canadian Dollar' => [ 'CAD' ],
-			'Brazilian Real'  => [ 'BRL' ],
-		];
+		$this->assertEquals( 'EUR', $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -30,8 +30,6 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	public function tearDown() {
-		// Reset the currency inside the transaction so Tribe's in-memory option
-		// cache is refreshed before the DB rollback; otherwise the value leaks.
 		tribe_update_option( Settings::$option_currency_code, 'USD' );
 
 		parent::tearDown();
@@ -54,43 +52,13 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 * it should use the currency configured in Tickets Commerce settings
-	 *
-	 * @dataProvider currency_code_provider
 	 */
-	public function it_should_use_the_configured_tickets_commerce_currency( $currency_code ) {
-		tribe_update_option( Settings::$option_currency_code, $currency_code );
+	public function it_should_use_the_configured_tickets_commerce_currency() {
+		tribe_update_option( Settings::$option_currency_code, 'EUR' );
 
 		$currency = $this->make_instance()->get_price_currency( $this->ticket );
 
-		$this->assertEquals( $currency_code, $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
-	}
-
-	/**
-	 * Provides currency codes to verify the schema follows the configured setting.
-	 *
-	 * @return array<string,array{0:string}>
-	 */
-	public function currency_code_provider() {
-		return [
-			'Euro'            => [ 'EUR' ],
-			'British Pound'   => [ 'GBP' ],
-			'Japanese Yen'    => [ 'JPY' ],
-			'Canadian Dollar' => [ 'CAD' ],
-			'Brazilian Real'  => [ 'BRL' ],
-		];
-	}
-
-	/**
-	 * @test
-	 * it should reflect changes to the Tickets Commerce currency setting
-	 */
-	public function it_should_reflect_a_non_default_currency() {
-		tribe_update_option( Settings::$option_currency_code, 'GBP' );
-
-		$currency = $this->make_instance()->get_price_currency( $this->ticket );
-
-		$this->assertEquals( 'GBP', $currency );
-		$this->assertNotEquals( 'USD', $currency, 'The currency should no longer be hardcoded to USD.' );
+		$this->assertEquals( 'EUR', $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
+++ b/tests/wpunit/Tribe/Tickets/JSON_LD/OrderTest.php
@@ -29,10 +29,11 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 		$this->ticket    = tribe( Module::class )->get_ticket( $this->post_id, $ticket_id );
 	}
 
-	public function tearDown() {
+	/**
+	 * @after
+	 */
+	public function reset_currency() {
 		tribe_update_option( Settings::$option_currency_code, 'USD' );
-
-		parent::tearDown();
 	}
 
 	/**
@@ -52,13 +53,30 @@ class OrderTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 * it should use the currency configured in Tickets Commerce settings
+	 *
+	 * @dataProvider currency_code_provider
 	 */
-	public function it_should_use_the_configured_tickets_commerce_currency() {
-		tribe_update_option( Settings::$option_currency_code, 'EUR' );
+	public function it_should_use_the_configured_tickets_commerce_currency( $currency_code ) {
+		tribe_update_option( Settings::$option_currency_code, $currency_code );
 
 		$currency = $this->make_instance()->get_price_currency( $this->ticket );
 
-		$this->assertEquals( 'EUR', $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
+		$this->assertEquals( $currency_code, $currency, 'The schema currency should follow the Tickets Commerce currency setting.' );
+	}
+
+	/**
+	 * Provides currency codes to verify the schema follows the configured setting.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function currency_code_provider() {
+		return [
+			'Euro'            => [ 'EUR' ],
+			'British Pound'   => [ 'GBP' ],
+			'Japanese Yen'    => [ 'JPY' ],
+			'Canadian Dollar' => [ 'CAD' ],
+			'Brazilian Real'  => [ 'BRL' ],
+		];
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1239](https://linear.app/nexcess/issue/SMTNC-1239/the-pricecurrency-is-always-usd-in-the-event-schema-even-if-et)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"The priceCurrency is always USD in the Event Schema even if ET settings are set to another Currency"

Fix the the Event Schema that was wrongly calling USD for all currencies
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="1713" height="1292" alt="Screenshot 2026-06-05 at 18 28 48" src="https://github.com/user-attachments/assets/8b59d274-fdcb-4e02-8a0c-d1f92baf25f6" />

### ✔️ Checklist
- [X] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [X] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [X] Are all the **required** tests passing?
- [X] Automated code review comments are addressed.
- [X] Have you added Artifacts?
- [X] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
