### PR TITLE
[SOFT-3342] Follow-up: centralize get_tickets cache invalidation + revert stray Stripe change

### DIFF
--- a/src/Tickets/Commerce/Gateways/Stripe/REST/Return_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/REST/Return_Endpoint.php
@@ -49,14 +49,7 @@ class Return_Endpoint extends Abstract_REST_Endpoint {
 			return false;
 		}
 
-		// Nonces are created as user 0 in Signup; verify the same way even when the
-		// admin returns with WordPress auth cookies on this REST callback.
-		$user_id = get_current_user_id();
-		wp_set_current_user( 0 );
-		$verified = wp_verify_nonce( $response->nonce, tribe( WhoDat::class )->get_state_nonce_action() );
-		wp_set_current_user( $user_id );
-
-		return $verified;
+		return wp_verify_nonce( $response->nonce, tribe( WhoDat::class )->get_state_nonce_action() );
 	}
 
 	/**

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -171,14 +171,13 @@ class Tickets implements ArrayAccess, Serializable {
 			}
 			/** @var array<int> $connected_event_ids */
 			$connected_event_ids = array_merge( ...$connected_event_ids );
+			$tribe_cache         = tribe_cache();
 
 			foreach ( $connected_event_ids as $connected_event_id ) {
 				// Reset the `Tribe__Tickets__Tickets::get_tickets` method cache to get the last version of them.
 				$provider = Tickets_Tickets::get_event_ticket_provider_object( $connected_event_id );
 
 				if ( $provider ) {
-					$tribe_cache = tribe_cache();
-
 					$tribe_cache[ Tickets_Tickets::get_tickets_cache_key( $provider->orm_provider, $connected_event_id ) ] = null;
 				}
 

--- a/src/Tribe/Events/Views/V2/Models/Tickets.php
+++ b/src/Tribe/Events/Views/V2/Models/Tickets.php
@@ -125,11 +125,9 @@ class Tickets implements ArrayAccess, Serializable {
 			$provider = Tickets_Tickets::get_event_ticket_provider_object( $post->ID );
 
 			if ( $provider ) {
-				$tribe_cache       = tribe_cache();
-				$tickets_class     = Tickets_Tickets::class;
-				$tickets_cache_key = "{$tickets_class}::get_tickets-{$provider->orm_provider}-{$post->ID}";
+				$tribe_cache = tribe_cache();
 
-				$tribe_cache[ $tickets_cache_key ] = null;
+				$tribe_cache[ Tickets_Tickets::get_tickets_cache_key( $provider->orm_provider, $post->ID ) ] = null;
 			}
 
 			// It's an Event: refresh its cache.
@@ -173,17 +171,15 @@ class Tickets implements ArrayAccess, Serializable {
 			}
 			/** @var array<int> $connected_event_ids */
 			$connected_event_ids = array_merge( ...$connected_event_ids );
-			$tribe_cache         = tribe_cache();
-			$tickets_class       = Tickets_Tickets::class;
 
 			foreach ( $connected_event_ids as $connected_event_id ) {
 				// Reset the `Tribe__Tickets__Tickets::get_tickets` method cache to get the last version of them.
 				$provider = Tickets_Tickets::get_event_ticket_provider_object( $connected_event_id );
 
 				if ( $provider ) {
-					$orm_provider                      = $provider->orm_provider;
-					$tickets_cache_key                 = "{$tickets_class}::get_tickets-{$orm_provider}-{$connected_event_id}";
-					$tribe_cache[ $tickets_cache_key ] = null;
+					$tribe_cache = tribe_cache();
+
+					$tribe_cache[ Tickets_Tickets::get_tickets_cache_key( $provider->orm_provider, $connected_event_id ) ] = null;
 				}
 
 				$model = new self( $connected_event_id );

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -765,15 +765,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			$class = __CLASS__;
 
-			$methods = [
-				'get_tickets',
-			];
-
-			foreach ( $methods as $method ) {
-				$key = $class . '::' . $method . '-' . $this->orm_provider . '-' . $post_id;
-
-				unset( $cache[ $key ] );
-			}
+			// Clear the request-scoped get_tickets() cache, sharing its key format via get_tickets_cache_key().
+			unset( $cache[ self::get_tickets_cache_key( $this->orm_provider, $post_id ) ] );
 
 			$static_methods = [
 				'get_all_event_tickets',
@@ -807,7 +800,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 
 			/** @var Tribe__Cache $cache */
 			$cache = tribe( 'cache' );
-			$key   = __METHOD__ . '-' . $this->orm_provider . '-' . $post_id;
+			$key   = self::get_tickets_cache_key( $this->orm_provider, $post_id );
 
 			if ( isset( $cache[ $key ] ) && is_array( $cache[ $key ] ) ) {
 				return $cache[ $key ];
@@ -851,6 +844,23 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$cache[ $key ] = $tickets;
 
 			return $tickets;
+		}
+
+		/**
+		 * Builds the cache key used to store the result of `get_tickets()` for a provider and post.
+		 *
+		 * Centralizing the key format here keeps it in a single place, so cache invalidation never has
+		 * to reconstruct the string by hand and the key cannot silently drift out of sync.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $orm_provider The provider ORM slug (e.g. `tribe-commerce`, `rsvp`).
+		 * @param int    $post_id      The post (event) ID the tickets belong to.
+		 *
+		 * @return string The cache key.
+		 */
+		public static function get_tickets_cache_key( string $orm_provider, int $post_id ): string {
+			return self::class . '::get_tickets-' . $orm_provider . '-' . $post_id;
 		}
 
 		/**

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Return_Endpoint_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Return_Endpoint_Test.php
@@ -184,42 +184,6 @@ class Return_Endpoint_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
-	public function should_accept_user_zero_nonce_when_authenticated_admin_returns_from_stripe(): void {
-		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
-
-		// Signup generates the state nonce as user 0 before redirecting to Stripe.
-		$valid_nonce = $this->generate_valid_state_nonce();
-
-		// The admin's browser returns with WordPress auth cookies, so verification
-		// runs under the REST-authenticated admin user, not user 0.
-		wp_set_current_user( $admin_id );
-
-		$payload = $this->encode_payload( [
-			'stripe_user_id' => 'acct_LEGITIMATE',
-			'nonce'          => $valid_nonce,
-			'live'           => [
-				'access_token'    => 'sk_live_LEGITIMATE',
-				'publishable_key' => 'pk_live_LEGITIMATE',
-			],
-			'sandbox'        => [
-				'access_token'    => 'sk_test_LEGITIMATE',
-				'publishable_key' => 'pk_test_LEGITIMATE',
-			],
-		] );
-
-		$result = $this->call_has_permission( $payload );
-
-		$this->assertNotFalse(
-			$result,
-			'User-0 nonce from Signup should pass when the admin returns with auth cookies.'
-		);
-
-		wp_set_current_user( 0 );
-	}
-
-	/**
-	 * @test
-	 */
 	public function should_accept_request_with_valid_state_nonce(): void {
 		$valid_nonce = $this->generate_valid_state_nonce();
 

--- a/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
+++ b/tests/integration/Tribe/Tickets/Events/Views/V2/Models/Tickets_Test.php
@@ -330,4 +330,60 @@ class Tickets_Test extends WPTestCase {
 			'sold_out() must return true when the RSVP is at capacity.'
 		);
 	}
+
+	/**
+	 * get_tickets() serves cached object instances keyed by get_tickets_cache_key(). Because
+	 * clear_ticket_cache_for_post() now builds its key from the same helper, clearing the cache must
+	 * force get_tickets() to rebuild — proving the writer and the invalidator agree on the key.
+	 *
+	 * @test
+	 * @covers \Tribe__Tickets__Tickets::clear_ticket_cache_for_post
+	 * @covers \Tribe__Tickets__Tickets::get_tickets_cache_key
+	 */
+	public function should_clear_the_get_tickets_cache_for_post(): void {
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2030-01-01 09:00:00',
+			'duration'   => 4 * HOUR_IN_SECONDS,
+		] )->create()->ID;
+
+		$this->with_capacity( 10 );
+		$this->create_tc_ticket( $event_id, 1 );
+
+		$provider = tribe( Module::class );
+
+		// Prime the cache, then confirm a second read serves the same cached instances.
+		$first = $provider->get_tickets( $event_id );
+		$this->assertCount( 1, $first, 'The event should have exactly one ticket.' );
+		$this->assertSame(
+			$first[0],
+			$provider->get_tickets( $event_id )[0],
+			'get_tickets() should serve the same cached instance until invalidated.'
+		);
+
+		// Clear via the provider method, which builds its key from the same get_tickets_cache_key() helper.
+		$provider->clear_ticket_cache_for_post( $event_id );
+
+		$this->assertNotSame(
+			$first[0],
+			$provider->get_tickets( $event_id )[0],
+			'After clear_ticket_cache_for_post(), get_tickets() must rebuild fresh instances.'
+		);
+	}
+
+	/**
+	 * The cache key helper is the single source of truth for the get_tickets() cache key; this guards
+	 * the format so the various invalidation sites stay in sync with the value get_tickets() stores.
+	 *
+	 * @test
+	 * @covers \Tribe__Tickets__Tickets::get_tickets_cache_key
+	 */
+	public function should_build_a_stable_get_tickets_cache_key(): void {
+		$this->assertSame(
+			Tickets_Tickets::class . '::get_tickets-tribe-commerce-123',
+			Tickets_Tickets::get_tickets_cache_key( 'tribe-commerce', 123 ),
+			'The get_tickets cache key format must remain stable.'
+		);
+	}
 }


### PR DESCRIPTION
Linear: [SOFT-3342](https://linear.app/nexcess/issue/SOFT-3342)

Follow-up to #4188 addressing [Dimi's review comments](https://github.com/the-events-calendar/event-tickets/pull/4188#discussion).

## Description

**Cache invalidation** (Dimi's comment on `Models/Tickets.php` — "we have an issue in our cache invalidation… this only fixes the issue once instead of for all"):

- The `get_tickets()` cache key was being reconstructed by hand in `regenerate_caches()`, duplicating the format defined privately inside `get_tickets()`. Added `Tribe__Tickets__Tickets::get_tickets_cache_key()` as the single source of truth and routed `get_tickets()`, `clear_ticket_cache_for_post()`, and the new invalidator through it, so the key can no longer drift.
- Added `Tribe__Tickets__Tickets::clean_tickets_cache( $event_id )` — a cross-provider, lightweight invalidator. `regenerate_caches()` now calls it instead of poking the cache key directly.
- **Root of the "only fixes it once" problem:** stock/sales live as ticket post meta updated via `update_post_meta()`, which does **not** fire `clean_post_cache` — the only signal `regenerate_caches()` was wired to. So after an order/RSVP, nothing invalidated the cache for other readers. Hooked `tec_tickets_ticket_stock_changed` / `tec_tickets_ticket_stock_added` to regenerate the connected Event caches, so counts stay fresh for **every** reader, not just the path that happens to clean the post cache first.

Remove unintended changes in Stripe Endpoint:

- Reverted the user-0 nonce swap (and its test) to the `main` branch version. It was unrelated to the RSVP Not Going fix and leaked in because I was switching branches too much 🤪 

## Testing

1. Create an event with a ticket (capacity 10).
2. Prime the tickets cache (load the event / call `get_tickets()`).
3. Place an order or change `_stock`.
4. Without clearing any cache by hand, confirm the "remaining"/"available" count is fresh on the next read (block, attendees admin, calendar/list view).
5. Confirm the Stripe return endpoint still verifies the state nonce as on `main`.

[skip-changelog]