### PR TITLE
[SMTNC-1469] Fix Tickets admin pages breaking on non-English installs

### DIFF
--- a/changelog/fix-SMTNC-1469-non-english-break-settings-page
+++ b/changelog/fix-SMTNC-1469-non-english-break-settings-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Ensure proper functionality of Tickets admin pages (Settings, Help Hub, and Notifications) on non-English installs. [SMTNC-1469]

--- a/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
+++ b/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
@@ -77,24 +77,15 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 * @since 5.24.0
 	 */
 	public function __construct() {
-		add_action( 'current_screen', [ $this, 'maybe_initialize' ] );
+		add_action(
+			'admin_init',
+			function () {
+				$page_hook = $this->get_help_hub_id();
+
+				add_action( 'load-' . $page_hook, [ $this, 'initialize' ] );
+			}
+		);
 		add_action( 'tec_help_hub_before_iframe_render', [ $this, 'register_with_hub' ] );
-	}
-
-	/**
-	 * Initializes the Help Hub data when on the Help Hub page, using a locale-independent slug check
-	 * instead of a `load-{hook_suffix}` action that breaks when the menu title is translated.
-	 *
-	 * @since TBD
-	 *
-	 * @return void
-	 */
-	public function maybe_initialize(): void {
-		if ( ! $this->is_help_hub_page() ) {
-			return;
-		}
-
-		$this->initialize();
 	}
 
 	/**
@@ -107,8 +98,8 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 * @return void
 	 */
 	public function register_with_hub( Hub $help_hub ): void {
-		// Slug-based check; the HELP_HUB_PAGE_ID hook suffix never matches when the menu title is translated.
-		if ( ! $this->is_help_hub_page() ) {
+		$page = tec_get_request_var( 'page' );
+		if ( self::HELP_HUB_PAGE_ID !== $page ) {
 			return;
 		}
 		$this->initialize();
@@ -458,17 +449,7 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 * @return array<string> Modified array of help pages.
 	 */
 	public function add_help_hub_pages( $help_pages ): array {
-		$help_pages[] = self::HELP_HUB_PAGE_ID;
-
-		// This list is matched against the current screen id, so add the translated screen id too.
-		$screen = null;
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-		}
-		if ( $screen instanceof \WP_Screen && $this->is_help_hub_page() ) {
-			$help_pages[] = $screen->id;
-		}
-
+		$help_pages[] = $this->get_help_hub_id();
 		return $help_pages;
 	}
 
@@ -491,10 +472,22 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	/**
 	 * Get the Help Hub page ID.
 	 *
+	 * @since TBD Updated to account for translations.
+	 *
 	 * @return string
 	 */
 	public function get_help_hub_id(): string {
-		return self::HELP_HUB_PAGE_ID;
+		if ( ! did_action( 'admin_init' ) ) {
+			return self::HELP_HUB_PAGE_ID;
+		}
+
+		$page_hook = get_plugin_page_hook( self::HELP_HUB_SLUG, 'admin.php' );
+
+		if ( ! $page_hook || ! is_string( $page_hook ) ) {
+			return self::HELP_HUB_PAGE_ID;
+		}
+
+		return $page_hook;
 	}
 
 	/**

--- a/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
+++ b/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
@@ -77,8 +77,24 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 * @since 5.24.0
 	 */
 	public function __construct() {
-		add_action( 'load-' . self::HELP_HUB_PAGE_ID, [ $this, 'initialize' ] );
+		add_action( 'current_screen', [ $this, 'maybe_initialize' ] );
 		add_action( 'tec_help_hub_before_iframe_render', [ $this, 'register_with_hub' ] );
+	}
+
+	/**
+	 * Initializes the Help Hub data when on the Help Hub page, using a locale-independent slug check
+	 * instead of a `load-{hook_suffix}` action that breaks when the menu title is translated.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function maybe_initialize(): void {
+		if ( ! $this->is_help_hub_page() ) {
+			return;
+		}
+
+		$this->initialize();
 	}
 
 	/**
@@ -91,8 +107,8 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 * @return void
 	 */
 	public function register_with_hub( Hub $help_hub ): void {
-		$page = tec_get_request_var( 'page' );
-		if ( self::HELP_HUB_PAGE_ID !== $page ) {
+		// Slug-based check; the HELP_HUB_PAGE_ID hook suffix never matches when the menu title is translated.
+		if ( ! $this->is_help_hub_page() ) {
 			return;
 		}
 		$this->initialize();
@@ -443,6 +459,13 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 	 */
 	public function add_help_hub_pages( $help_pages ): array {
 		$help_pages[] = self::HELP_HUB_PAGE_ID;
+
+		// This list is matched against the current screen id, so add the translated screen id too.
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( $screen instanceof \WP_Screen && $this->is_help_hub_page() ) {
+			$help_pages[] = $screen->id;
+		}
+
 		return $help_pages;
 	}
 

--- a/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
+++ b/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
@@ -461,7 +461,10 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 		$help_pages[] = self::HELP_HUB_PAGE_ID;
 
 		// This list is matched against the current screen id, so add the translated screen id too.
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$screen = null;
+		if( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+		}
 		if ( $screen instanceof \WP_Screen && $this->is_help_hub_page() ) {
 			$help_pages[] = $screen->id;
 		}

--- a/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
+++ b/src/Tickets/Admin/Help_Hub/ET_Hub_Resource_Data.php
@@ -462,7 +462,7 @@ class ET_Hub_Resource_Data implements Help_Hub_Data_Interface {
 
 		// This list is matched against the current screen id, so add the translated screen id too.
 		$screen = null;
-		if( function_exists( 'get_current_screen' ) ) {
+		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 		}
 		if ( $screen instanceof \WP_Screen && $this->is_help_hub_page() ) {

--- a/src/Tickets/Admin/Tickets/Page.php
+++ b/src/Tickets/Admin/Tickets/Page.php
@@ -88,6 +88,18 @@ class Page extends Abstract_Admin_Page {
 	const STATUS_KEY = 'status-filter';
 
 	/**
+	 * Registers the All Tickets admin page and captures the real (locale-dependent) hook suffix,
+	 * which the hardcoded default cannot represent when the menu title is translated.
+	 *
+	 * @since TBD
+	 */
+	public function admin_page() {
+		parent::admin_page();
+
+		static::$hook_suffix = get_plugin_page_hookname( static::get_page_slug(), static::$parent_slug );
+	}
+
+	/**
 	 * Get Provider information.
 	 *
 	 * @since 5.14.0

--- a/src/Tickets/Notifications/Notifications.php
+++ b/src/Tickets/Notifications/Notifications.php
@@ -61,7 +61,7 @@ class Notifications extends Integration_Abstract {
 		$allowed[] = 'tickets_page_tec-tickets-settings';
 		$allowed[] = 'tickets_page_tickets-setup';
 
-		// Also allow current screen by page slug to support translated menu titles.
+		// Also allow the translated screen id when on those pages.
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		if ( $screen instanceof \WP_Screen && preg_match( '/_page_(tec-tickets-settings|tickets-setup)$/', $screen->id ) ) {
 			$allowed[] = $screen->id;

--- a/src/Tickets/Notifications/Notifications.php
+++ b/src/Tickets/Notifications/Notifications.php
@@ -52,6 +52,7 @@ class Notifications extends Integration_Abstract {
 	 * Adds the Tickets settings page to the list of allowed pages for Notifications.
 	 *
 	 * @since 5.19.3
+	 * @since TBD Resolve page hooks so the icon keeps showing in non-English locales.
 	 *
 	 * @param array $allowed An array of pages where notifications will be displayed.
 	 *
@@ -61,13 +62,13 @@ class Notifications extends Integration_Abstract {
 		$allowed[] = 'tickets_page_tec-tickets-settings';
 		$allowed[] = 'tickets_page_tickets-setup';
 
-		// Also allow the translated screen id when on those pages.
-		$screen = null;
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-		}
-		if ( $screen instanceof \WP_Screen && preg_match( '/_page_(tec-tickets-settings|tickets-setup)$/', $screen->id ) ) {
-			$allowed[] = $screen->id;
+		// Check page hook of each slug to keep matching in non-English locales.
+		foreach ( [ 'tec-tickets-settings', 'tickets-setup' ] as $slug ) {
+			$page_hook = get_plugin_page_hook( $slug, 'admin.php' );
+
+			if ( is_string( $page_hook ) && '' !== $page_hook ) {
+				$allowed[] = $page_hook;
+			}
 		}
 
 		return $allowed;

--- a/src/Tickets/Notifications/Notifications.php
+++ b/src/Tickets/Notifications/Notifications.php
@@ -60,6 +60,13 @@ class Notifications extends Integration_Abstract {
 	public function add_allowed_pages( $allowed ) {
 		$allowed[] = 'tickets_page_tec-tickets-settings';
 		$allowed[] = 'tickets_page_tickets-setup';
+
+		// Also allow current screen by page slug to support translated menu titles.
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( $screen instanceof \WP_Screen && preg_match( '/_page_(tec-tickets-settings|tickets-setup)$/', $screen->id ) ) {
+			$allowed[] = $screen->id;
+		}
+
 		return $allowed;
 	}
 

--- a/src/Tickets/Notifications/Notifications.php
+++ b/src/Tickets/Notifications/Notifications.php
@@ -64,7 +64,7 @@ class Notifications extends Integration_Abstract {
 		// Also allow the translated screen id when on those pages.
 		$screen = null;
 		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = function_exists( 'get_current_screen' );
+			$screen = get_current_screen();
 		}
 		if ( $screen instanceof \WP_Screen && preg_match( '/_page_(tec-tickets-settings|tickets-setup)$/', $screen->id ) ) {
 			$allowed[] = $screen->id;

--- a/src/Tickets/Notifications/Notifications.php
+++ b/src/Tickets/Notifications/Notifications.php
@@ -62,7 +62,10 @@ class Notifications extends Integration_Abstract {
 		$allowed[] = 'tickets_page_tickets-setup';
 
 		// Also allow the translated screen id when on those pages.
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$screen = null;
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = function_exists( 'get_current_screen' );
+		}
 		if ( $screen instanceof \WP_Screen && preg_match( '/_page_(tec-tickets-settings|tickets-setup)$/', $screen->id ) ) {
 			$allowed[] = $screen->id;
 		}

--- a/src/Tribe/Admin/Provider.php
+++ b/src/Tribe/Admin/Provider.php
@@ -21,6 +21,7 @@ class Provider extends \TEC\Common\Contracts\Service_Provider {
 	public function add_hooks() {
 		add_action( 'tribe_settings_do_tabs', tribe_callback( Settings::class, 'settings_ui' ) );
 		add_action( 'admin_menu', tribe_callback( Settings::class, 'add_admin_pages' ) );
+		add_filter( 'admin_body_class', tribe_callback( Settings::class, 'filter_admin_body_class' ) );
 		add_action( 'network_admin_menu', tribe_callback( Settings::class, 'maybe_add_network_settings_page' ) );
 		add_action( 'tribe_settings_do_tabs', tribe_callback( Settings::class, 'do_network_settings_tab' ), 400 );
 		// Set priority to 50 to overwrite any other sidebars that are currently registered.

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -158,6 +158,43 @@ class Settings {
 	}
 
 	/**
+	 * Adds a locale-independent body class to the Tickets admin pages.
+	 *
+	 * WordPress builds the admin body class from the (translatable) parent menu title, so the
+	 * Tickets pages get `tickets_page_*` in English but `biglietti_page_*`, `karten_page_*`, etc.
+	 * in other languages. The admin CSS targets the English value (e.g. `.tickets_page_tec-tickets-settings`),
+	 * which means non-English installs render unstyled. Re-add the canonical English-prefixed class so
+	 * the existing selectors keep matching in any language.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $classes Space-separated list of admin body classes.
+	 *
+	 * @return string The filtered list of admin body classes.
+	 */
+	public function filter_admin_body_class( $classes ): string {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( ! $screen instanceof \WP_Screen ) {
+			return $classes;
+		}
+
+		// Match the "{menu}_page_{slug}" hook suffix for the Tickets admin pages.
+		if ( ! preg_match( '/_page_(tec-tickets[\w-]*)$/', $screen->id, $matches ) ) {
+			return $classes;
+		}
+
+		$canonical = 'tickets_page_' . $matches[1];
+
+		// Bail if the class is already present (e.g. on English installs).
+		if ( in_array( $canonical, preg_split( '/\s+/', trim( $classes ) ), true ) ) {
+			return $classes;
+		}
+
+		return trim( $classes . ' ' . $canonical );
+	}
+
+	/**
 	 * Check if the current page is on a specific tab for the Tickets settings.
 	 *
 	 * @since 5.5.9

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -158,13 +158,8 @@ class Settings {
 	}
 
 	/**
-	 * Adds a locale-independent body class to the Tickets admin pages.
-	 *
-	 * WordPress builds the admin body class from the (translatable) parent menu title, so the
-	 * Tickets pages get `tickets_page_*` in English but `biglietti_page_*`, `karten_page_*`, etc.
-	 * in other languages. The admin CSS targets the English value (e.g. `.tickets_page_tec-tickets-settings`),
-	 * which means non-English installs render unstyled. Re-add the canonical English-prefixed class so
-	 * the existing selectors keep matching in any language.
+	 * Adds the canonical English-prefixed body class to the Tickets admin pages so locale-independent
+	 * CSS selectors keep matching when the menu title is translated.
 	 *
 	 * @since TBD
 	 *
@@ -179,14 +174,12 @@ class Settings {
 			return $classes;
 		}
 
-		// Match the "{menu}_page_{slug}" hook suffix for the Tickets admin pages.
 		if ( ! preg_match( '/_page_(tec-tickets[\w-]*)$/', $screen->id, $matches ) ) {
 			return $classes;
 		}
 
 		$canonical = 'tickets_page_' . $matches[1];
 
-		// Bail if the class is already present (e.g. on English installs).
 		if ( in_array( $canonical, preg_split( '/\s+/', trim( $classes ) ), true ) ) {
 			return $classes;
 		}

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -161,6 +161,8 @@ class Settings {
 	 * Adds the canonical English-prefixed body class to the Tickets admin pages so locale-independent
 	 * CSS selectors keep matching when the menu title is translated.
 	 *
+	 * The page is detected via its URL slug, which is locale-independent, rather than the translated screen id.
+	 *
 	 * @since TBD
 	 *
 	 * @param string $classes Space-separated list of admin body classes.
@@ -168,20 +170,14 @@ class Settings {
 	 * @return string The filtered list of admin body classes.
 	 */
 	public function filter_admin_body_class( $classes ): string {
-		$screen = null;
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-		}
 
-		if ( ! $screen instanceof \WP_Screen ) {
+		$admin_page = tribe_get_request_var( 'page' );
+
+		if ( empty( $admin_page ) || 0 !== strpos( $admin_page, static::$parent_slug ) ) {
 			return $classes;
 		}
 
-		if ( ! preg_match( '/_page_(tec-tickets[\w-]*)$/', $screen->id, $matches ) ) {
-			return $classes;
-		}
-
-		$canonical = 'tickets_page_' . $matches[1];
+		$canonical = 'tickets_page_' . $admin_page;
 
 		if ( in_array( $canonical, preg_split( '/\s+/', trim( $classes ) ), true ) ) {
 			return $classes;

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -168,7 +168,10 @@ class Settings {
 	 * @return string The filtered list of admin body classes.
 	 */
 	public function filter_admin_body_class( $classes ): string {
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		$screen = null;
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+		}
 
 		if ( ! $screen instanceof \WP_Screen ) {
 			return $classes;

--- a/tests/integration/Settings/Admin_Body_Class_Test.php
+++ b/tests/integration/Settings/Admin_Body_Class_Test.php
@@ -9,6 +9,9 @@ use Tribe\Tickets\Admin\Settings;
  * Ensures the Tickets admin pages keep a locale-independent body class so the admin CSS (which is
  * scoped to `.tickets_page_tec-tickets-*`) keeps matching when the menu title is translated.
  *
+ * The page is detected via its URL `page` slug, which is locale-independent, so the canonical class
+ * is added regardless of the (possibly translated) screen id.
+ *
  * @see Settings::filter_admin_body_class()
  */
 class Admin_Body_Class_Test extends WPTestCase {
@@ -16,8 +19,8 @@ class Admin_Body_Class_Test extends WPTestCase {
 	/**
 	 * @after
 	 */
-	public function reset_screen(): void {
-		unset( $GLOBALS['current_screen'] );
+	public function reset_request(): void {
+		unset( $_GET['page'], $_REQUEST['page'] );
 	}
 
 	/**
@@ -28,11 +31,20 @@ class Admin_Body_Class_Test extends WPTestCase {
 	}
 
 	/**
+	 * @param string $page The URL `page` slug.
+	 */
+	private function set_current_page( string $page ): void {
+		$_GET['page']     = $page;
+		$_REQUEST['page'] = $page;
+	}
+
+	/**
 	 * @test
 	 */
 	public function it_should_add_the_canonical_class_when_the_menu_title_is_translated(): void {
-		// Italian: "Tickets" -> "Biglietti", so the screen id is prefixed with `biglietti_page_`.
-		set_current_screen( 'biglietti_page_tec-tickets-settings' );
+		// Italian: "Tickets" -> "Biglietti", so the screen id is prefixed with `biglietti_page_`,
+		// but the URL slug stays `tec-tickets-settings`.
+		$this->set_current_page( 'tec-tickets-settings' );
 
 		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin biglietti_page_tec-tickets-settings' );
 
@@ -43,7 +55,7 @@ class Admin_Body_Class_Test extends WPTestCase {
 	 * @test
 	 */
 	public function it_should_not_duplicate_the_class_on_an_english_install(): void {
-		set_current_screen( 'tickets_page_tec-tickets-settings' );
+		$this->set_current_page( 'tec-tickets-settings' );
 
 		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin tickets_page_tec-tickets-settings' );
 
@@ -59,7 +71,7 @@ class Admin_Body_Class_Test extends WPTestCase {
 	 * @test
 	 */
 	public function it_should_leave_non_tickets_screens_untouched(): void {
-		set_current_screen( 'edit-post' );
+		$this->set_current_page( 'edit-post' );
 
 		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin edit-post' );
 

--- a/tests/integration/Settings/Admin_Body_Class_Test.php
+++ b/tests/integration/Settings/Admin_Body_Class_Test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace TEC\Tickets\Test\Integration\Settings;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tickets\Admin\Settings;
+
+/**
+ * Ensures the Tickets admin pages keep a locale-independent body class so the admin CSS (which is
+ * scoped to `.tickets_page_tec-tickets-*`) keeps matching when the menu title is translated.
+ *
+ * @see Settings::filter_admin_body_class()
+ */
+class Admin_Body_Class_Test extends WPTestCase {
+
+	/**
+	 * @after
+	 */
+	public function reset_screen(): void {
+		unset( $GLOBALS['current_screen'] );
+	}
+
+	/**
+	 * @return Settings
+	 */
+	private function make_instance(): Settings {
+		return new Settings();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_the_canonical_class_when_the_menu_title_is_translated(): void {
+		// Italian: "Tickets" -> "Biglietti", so the screen id is prefixed with `biglietti_page_`.
+		set_current_screen( 'biglietti_page_tec-tickets-settings' );
+
+		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin biglietti_page_tec-tickets-settings' );
+
+		$this->assertContains( 'tickets_page_tec-tickets-settings', explode( ' ', $classes ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_duplicate_the_class_on_an_english_install(): void {
+		set_current_screen( 'tickets_page_tec-tickets-settings' );
+
+		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin tickets_page_tec-tickets-settings' );
+
+		$occurrences = array_filter(
+			explode( ' ', $classes ),
+			static fn( $class ) => 'tickets_page_tec-tickets-settings' === $class
+		);
+
+		$this->assertCount( 1, $occurrences );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_leave_non_tickets_screens_untouched(): void {
+		set_current_screen( 'edit-post' );
+
+		$classes = $this->make_instance()->filter_admin_body_class( 'wp-admin edit-post' );
+
+		$this->assertSame( 'wp-admin edit-post', $classes );
+	}
+}

--- a/tests/integration/TEC/Tickets/Admin/Help_Hub/Resource_Data_Test.php
+++ b/tests/integration/TEC/Tickets/Admin/Help_Hub/Resource_Data_Test.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace TEC\Tickets\Admin\Help_Hub;
+
+use Codeception\TestCase\WPTestCase;
+
+/**
+ * Ensures the Help Hub page detection and asset gating stay locale-independent so the page keeps
+ * loading its assets when the menu title is translated (and the screen id is no longer `tickets_page_*`).
+ *
+ * @see ET_Hub_Resource_Data::is_help_hub_page()
+ * @see ET_Hub_Resource_Data::add_help_hub_pages()
+ */
+class Resource_Data_Test extends WPTestCase {
+
+	/**
+	 * @after
+	 */
+	public function reset_request(): void {
+		$_GET = [];
+		unset( $GLOBALS['current_screen'] );
+	}
+
+	/**
+	 * @return ET_Hub_Resource_Data
+	 */
+	private function make_instance(): ET_Hub_Resource_Data {
+		return new ET_Hub_Resource_Data();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_detect_the_help_hub_page_by_slug_in_any_language(): void {
+		$instance = $this->make_instance();
+
+		$_GET['page'] = 'tec-tickets-help-hub';
+		$this->assertTrue( $instance->is_help_hub_page() );
+
+		$_GET['page'] = 'some-other-page';
+		$this->assertFalse( $instance->is_help_hub_page() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_allow_the_translated_screen_id_on_the_help_hub_page(): void {
+		$_GET['page'] = 'tec-tickets-help-hub';
+		// German: "Tickets" -> "Karten", so the screen id is prefixed with `karten_page_`.
+		set_current_screen( 'karten_page_tec-tickets-help-hub' );
+
+		$pages = $this->make_instance()->add_help_hub_pages( [] );
+
+		// The canonical English id and the live (translated) screen id must both be present.
+		$this->assertContains( 'tickets_page_tec-tickets-help-hub', $pages );
+		$this->assertContains( 'karten_page_tec-tickets-help-hub', $pages );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_add_the_current_screen_when_off_the_help_hub_page(): void {
+		$_GET['page'] = 'some-other-page';
+		set_current_screen( 'karten_page_tec-tickets-help-hub' );
+
+		$pages = $this->make_instance()->add_help_hub_pages( [] );
+
+		$this->assertNotContains( 'karten_page_tec-tickets-help-hub', $pages );
+	}
+}

--- a/tests/integration/TEC/Tickets/Admin/Help_Hub/Resource_Data_Test.php
+++ b/tests/integration/TEC/Tickets/Admin/Help_Hub/Resource_Data_Test.php
@@ -5,11 +5,15 @@ namespace TEC\Tickets\Admin\Help_Hub;
 use Codeception\TestCase\WPTestCase;
 
 /**
- * Ensures the Help Hub page detection and asset gating stay locale-independent so the page keeps
- * loading its assets when the menu title is translated (and the screen id is no longer `tickets_page_*`).
+ * Ensures the Help Hub page detection stays locale-independent so the page keeps loading its assets
+ * when the menu title is translated (and the screen id is no longer `tickets_page_*`).
+ *
+ * The page is detected by its URL `page` slug, which is locale-independent, and the page hook is
+ * resolved from WordPress core via get_plugin_page_hook(), falling back to the canonical English id.
  *
  * @see ET_Hub_Resource_Data::is_help_hub_page()
  * @see ET_Hub_Resource_Data::add_help_hub_pages()
+ * @see ET_Hub_Resource_Data::get_help_hub_id()
  */
 class Resource_Data_Test extends WPTestCase {
 
@@ -34,7 +38,7 @@ class Resource_Data_Test extends WPTestCase {
 	public function it_should_detect_the_help_hub_page_by_slug_in_any_language(): void {
 		$instance = $this->make_instance();
 
-		$_GET['page'] = 'tec-tickets-help-hub';
+		$_GET['page'] = ET_Hub_Resource_Data::HELP_HUB_SLUG;
 		$this->assertTrue( $instance->is_help_hub_page() );
 
 		$_GET['page'] = 'some-other-page';
@@ -44,27 +48,16 @@ class Resource_Data_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
-	public function it_should_allow_the_translated_screen_id_on_the_help_hub_page(): void {
-		$_GET['page'] = 'tec-tickets-help-hub';
-		// German: "Tickets" -> "Karten", so the screen id is prefixed with `karten_page_`.
-		set_current_screen( 'karten_page_tec-tickets-help-hub' );
-
-		$pages = $this->make_instance()->add_help_hub_pages( [] );
-
-		// The canonical English id and the live (translated) screen id must both be present.
-		$this->assertContains( 'tickets_page_tec-tickets-help-hub', $pages );
-		$this->assertContains( 'karten_page_tec-tickets-help-hub', $pages );
+	public function it_should_not_detect_the_help_hub_page_without_a_page_request(): void {
+		$this->assertFalse( $this->make_instance()->is_help_hub_page() );
 	}
 
 	/**
 	 * @test
 	 */
-	public function it_should_not_add_the_current_screen_when_off_the_help_hub_page(): void {
-		$_GET['page'] = 'some-other-page';
-		set_current_screen( 'karten_page_tec-tickets-help-hub' );
-
+	public function it_should_fall_back_to_the_canonical_id_when_the_page_hook_is_unresolved(): void {
 		$pages = $this->make_instance()->add_help_hub_pages( [] );
 
-		$this->assertNotContains( 'karten_page_tec-tickets-help-hub', $pages );
+		$this->assertContains( ET_Hub_Resource_Data::HELP_HUB_PAGE_ID, $pages );
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[[SMTNC-1469]](https://linear.app/nexcess/issue/SMTNC-1469/admin-styles-break-in-event-tickets-non-english-locales)

### 🗒️ Description

WordPress builds the admin page **hook suffix** and **body class** from the parent menu title (`{sanitize_title( menu_title )}_page_{slug}`). The "Tickets" menu title is translatable, so on a non-English install it becomes `biglietti_page_…` (Italian), `karten_page_…` (German), etc., instead of `tickets_page_…`.

Several places hardcoded the English value, so they silently stopped working in other languages:

- **Settings page** rendered unstyled — the whole admin stylesheet is scoped under `.tickets_page_tec-tickets-settings`, which never matched the translated body class.
- **Help Hub** rendered unstyled and the support iframe threw a `RuntimeException` — its `initialize()` was hooked to `load-{HELP_HUB_PAGE_ID}`.
- **In-app notifications** icon / `ian-client.css` was not loaded.

This PR makes those surfaces locale-independent:

- `Tribe\Tickets\Admin\Settings::filter_admin_body_class()` re-adds the canonical `tickets_page_tec-tickets-*` body class on any `tec-tickets*` admin screen, so the existing CSS keeps matching in any language (also fixes Settings, All Tickets, Order Modifiers and Help Hub styling, plus the `ian-client.js` context check).
- `TEC\Tickets\Admin\Tickets\Page::admin_page()` captures the real hook suffix into `static::$hook_suffix` for the screen options.
- `TEC\Tickets\Admin\Help_Hub\ET_Hub_Resource_Data` triggers `initialize()` on `current_screen` via a slug-based check, sets the Hub data for the iframe regardless of language, and registers the live screen id for the asset gate.
- `TEC\Tickets\Notifications\Notifications::add_allowed_pages()` also allows the translated screen id.

Detection that relies on the URL `page` slug (e.g. `is_tec_tickets_settings()`, `is_help_hub_page()`) is already locale-independent and is used as the basis for the fixes.

### 🎥 Artifacts

Video: Added in Linear ticket.

Before fix:
<img width="1152" height="889" alt="Screenshot 2026-06-09 at 5 57 19 PM" src="https://github.com/user-attachments/assets/2471d940-e0b9-4936-a35f-a47014c1a629" />


After fix:
<img width="1314" height="849" alt="Screenshot 2026-06-09 at 5 57 30 PM" src="https://github.com/user-attachments/assets/cb421cf6-68cf-49a9-b7b6-0f961b981ba5" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

---