### PR TITLE
Fix ET scripts in checkout

### DIFF
--- a/changelog/fix-SMTNC-1284-prevent-frontend-ticket-assets-on-non-ticket-pages
+++ b/changelog/fix-SMTNC-1284-prevent-frontend-ticket-assets-on-non-ticket-pages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent the front-end ticket styles and scripts from loading on pages without tickets — such as the WooCommerce cart and checkout. [SMTNC-1284]

--- a/changelog/tweak-SMTNC-1284-should-enqueue-frontend-filter
+++ b/changelog/tweak-SMTNC-1284-should-enqueue-frontend-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Add the `tribe_tickets_assets_should_enqueue_frontend` filter to allow controlling whether the front-end ticket styles and scripts are enqueued for the current request. [SMTNC-1284]

--- a/changelog/tweak-SMTNC-1284-should-enqueue-frontend-filter
+++ b/changelog/tweak-SMTNC-1284-should-enqueue-frontend-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add the `tribe_tickets_assets_should_enqueue_frontend` filter to allow controlling whether the front-end ticket styles and scripts are enqueued for the current request. [SMTNC-1284]

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -503,8 +503,6 @@ class Tribe__Tickets__Assets {
 	 * @return bool
 	 */
 	public function should_enqueue_frontend() {
-		$is_on_valid_post_type = tribe_tickets_is_enabled_post_context();
-
 		/**
 		 * This Try/Catch is present to deal with a problem on Autoloading from version 5.1.0 ET+ with ET 5.0.3.
 		 *
@@ -519,7 +517,49 @@ class Tribe__Tickets__Assets {
 			$is_on_ar_page = false;
 		}
 
-		return $is_on_valid_post_type || $is_on_ar_page;
+		$should_enqueue = $is_on_ar_page || $this->is_frontend_ticket_context();
+
+		/**
+		 * Allow filtering whether the Event Tickets front-end ticket assets should be enqueued.
+		 *
+		 * Useful to force-load (or prevent loading of) the front-end ticket styles and scripts
+		 * in custom contexts that are not covered by the default checks.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_enqueue Whether the front-end ticket assets should be enqueued.
+		 */
+		return (bool) apply_filters( 'tribe_tickets_assets_should_enqueue_frontend', $should_enqueue );
+	}
+
+	/**
+	 * Whether the current front-end request actually renders ticket UI and therefore needs
+	 * the front-end ticket assets.
+	 *
+	 * Being on a tickets-enabled post type is not, on its own, enough: by default the `page`
+	 * post type is tickets-enabled, which would otherwise load these assets on every WordPress
+	 * Page — including the WooCommerce cart and checkout pages, which render no ticket UI. We
+	 * therefore additionally require that the post actually has tickets or that we are on a
+	 * tickets-enabled archive. The purchase flow's attendee fields live on the dedicated
+	 * Attendee Registration page, which is handled separately in should_enqueue_frontend().
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the front-end ticket assets are needed for the current request.
+	 */
+	protected function is_frontend_ticket_context(): bool {
+		// Not a tickets-enabled context at all (e.g. an unrelated post type).
+		if ( ! tribe_tickets_is_enabled_post_context() ) {
+			return false;
+		}
+
+		// Archives of tickets-enabled post types: we cannot check per-post, so load.
+		if ( is_post_type_archive( tribe( 'tickets.main' )->post_types() ) ) {
+			return true;
+		}
+
+		// On a singular tickets-enabled post, only load when the post actually has tickets.
+		return tribe_events_has_tickets( get_queried_object_id() );
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -708,6 +708,13 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 			return;
 		}
 
+		// Only load the RSVP assets when the post actually has tickets to render. Otherwise these
+		// would load on every singular tickets-enabled post (the `page` post type is enabled by
+		// default), including pages with no RSVP/ticket UI such as the WooCommerce cart and checkout.
+		if ( ! tribe_events_has_tickets( get_queried_object_id() ) ) {
+			return;
+		}
+
 		wp_enqueue_style( 'event-tickets-rsvp' );
 		wp_enqueue_script( 'event-tickets-rsvp' );
 

--- a/tests/wpunit/Tribe/Tickets/AssetsTest.php
+++ b/tests/wpunit/Tribe/Tickets/AssetsTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tribe\Tickets;
+
+use Tribe\Tickets\Test\Testcases\Ticket_Object_TestCase;
+use Tribe__Tickets__Assets as Assets;
+use Tribe__Tickets__RSVP as RSVP;
+
+/**
+ * Tests for the front-end asset enqueue gating.
+ *
+ * Covers SMTNC-1284: the front-end ticket styles/scripts must only load where ticket UI is
+ * actually rendered, not on every tickets-enabled post type (the `page` post type is enabled by
+ * default, which made these assets load on plain pages such as the WooCommerce cart and checkout).
+ *
+ * @see \Tribe__Tickets__Assets::should_enqueue_frontend()
+ * @see \Tribe__Tickets__RSVP::enqueue_resources()
+ */
+class AssetsTest extends Ticket_Object_TestCase {
+
+	/**
+	 * @return Assets
+	 */
+	private function assets(): Assets {
+		return tribe( 'tickets.assets' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_enqueue_frontend_on_ticketed_post_type_without_tickets() {
+		// `post` is a tickets-enabled post type in this context, but this post has no tickets.
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse(
+			$this->assets()->should_enqueue_frontend(),
+			'A tickets-enabled post with no tickets should not enqueue the front-end assets.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_enqueue_frontend_on_post_that_has_tickets() {
+		$post_id = $this->factory()->post->create();
+		$this->create_rsvp_ticket( $post_id );
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertTrue(
+			$this->assets()->should_enqueue_frontend(),
+			'A post that actually has tickets should enqueue the front-end assets.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_enqueue_frontend_on_non_ticketed_post_type() {
+		// `page` is not a tickets-enabled post type in this context (only post + tribe_events are).
+		$page_id = $this->factory()->post->create( [ 'post_type' => 'page' ] );
+		$this->go_to( get_permalink( $page_id ) );
+
+		$this->assertFalse(
+			$this->assets()->should_enqueue_frontend(),
+			'A post type that is not tickets-enabled should never enqueue the front-end assets.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function filter_can_force_enqueue_frontend() {
+		// Default decision is false: tickets-enabled post type, but no tickets.
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse( $this->assets()->should_enqueue_frontend() );
+
+		add_filter( 'tribe_tickets_assets_should_enqueue_frontend', '__return_true' );
+
+		$this->assertTrue(
+			$this->assets()->should_enqueue_frontend(),
+			'The tribe_tickets_assets_should_enqueue_frontend filter should be able to force-enqueue.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function filter_can_prevent_enqueue_frontend() {
+		// Default decision is true: the post has tickets.
+		$post_id = $this->factory()->post->create();
+		$this->create_rsvp_ticket( $post_id );
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertTrue( $this->assets()->should_enqueue_frontend() );
+
+		add_filter( 'tribe_tickets_assets_should_enqueue_frontend', '__return_false' );
+
+		$this->assertFalse(
+			$this->assets()->should_enqueue_frontend(),
+			'The tribe_tickets_assets_should_enqueue_frontend filter should be able to prevent enqueuing.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function rsvp_resources_are_not_enqueued_on_post_without_tickets() {
+		$post_id = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+
+		/** @var RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+		$rsvp->register_resources();
+
+		// Start from a clean slate so the assertion does not depend on test order.
+		wp_dequeue_style( 'event-tickets-rsvp' );
+		wp_dequeue_script( 'event-tickets-rsvp' );
+
+		$rsvp->enqueue_resources();
+
+		$this->assertFalse( wp_style_is( 'event-tickets-rsvp', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'event-tickets-rsvp', 'enqueued' ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function rsvp_resources_are_enqueued_on_post_with_tickets() {
+		$post_id = $this->factory()->post->create();
+		$this->create_rsvp_ticket( $post_id );
+		$this->go_to( get_permalink( $post_id ) );
+
+		/** @var RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+		$rsvp->register_resources();
+		$rsvp->enqueue_resources();
+
+		$this->assertTrue( wp_style_is( 'event-tickets-rsvp', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'event-tickets-rsvp', 'enqueued' ) );
+	}
+}

--- a/tests/wpunit/Tribe/Tickets/AssetsTest.php
+++ b/tests/wpunit/Tribe/Tickets/AssetsTest.php
@@ -19,6 +19,32 @@ use Tribe__Tickets__RSVP as RSVP;
 class AssetsTest extends Ticket_Object_TestCase {
 
 	/**
+	 * The REQUEST_URI value before each test, restored on tear down.
+	 *
+	 * @var string|null
+	 */
+	protected $original_request_uri;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->original_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null;
+	}
+
+	public function tearDown() {
+		// go_to() sets $_SERVER['REQUEST_URI'] and $_GET without restoring them; clean up so the
+		// leaked request context does not bleed into later tests (e.g. WP_List_Table referer URLs).
+		if ( null === $this->original_request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		}
+		$_GET = [];
+
+		parent::tearDown();
+	}
+
+	/**
 	 * @return Assets
 	 */
 	private function assets(): Assets {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1284](https://linear.app/nexcess/issue/SMTNC-1284/woocommerce-pages-are-loading-et-scripts-without-event-tickets-or)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
"A user has reported that the WooCommerce pages are loading TEC resources even though they don't have Event Tickets or any need for those assets on the product pages."

Fixed the enqueue scripts method so it don't load in not necessary pages.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before (13 matches):
<img width="1709" height="1278" alt="Screenshot 2026-06-11 at 11 16 27" src="https://github.com/user-attachments/assets/5c2961fd-dafc-40c0-96e3-3793b44c2f49" />

After (1 match):
<img width="1714" height="1311" alt="Screenshot 2026-06-11 at 11 17 51" src="https://github.com/user-attachments/assets/0ec2ef08-91fc-47bb-a317-f419ba278c05" />

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
