### PR TITLE
[SOFT-3451]: abstract ticket and ticket-able bost actions

### DIFF
--- a/changelog/feat-abstract-ticket-and-event-actions
+++ b/changelog/feat-abstract-ticket-and-event-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Absrtact ticket-able post type changed action, ticket-able post type deleted and ticket deleted actions. [SOFT-3451]

--- a/changelog/feat-abstract-ticket-and-event-actions
+++ b/changelog/feat-abstract-ticket-and-event-actions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Absrtact ticket-able post type changed action, ticket-able post type deleted and ticket deleted actions. [SOFT-3451]
+Abstract ticket-able post type changed action, ticket-able post type deleted, and ticket deleted actions. [SOFT-3451]

--- a/src/Tickets/Commerce/Attendee.php
+++ b/src/Tickets/Commerce/Attendee.php
@@ -755,6 +755,11 @@ class Attendee {
 	public function decreases_inventory( $attendee ) {
 		$attendee = tec_tc_get_attendee( $attendee['ID'] );
 		$order    = tec_tc_get_order( $attendee->post_parent );
+
+		if ( ! $order ) {
+			return false;
+		}
+
 		$statuses = array_unique(
 			[
 				tribe( Status_Handler::class )->get_inventory_decrease_status()->get_wp_slug(),
@@ -809,7 +814,7 @@ class Attendee {
 		if ( ! tec_tickets_commerce_is_enabled() ) {
 			return [];
 		}
-		
+
 		// Check cache.
 		$cache                  = tribe_cache();
 		$attendees_by_ticket_id = $cache->get( 'tec_tickets_attendees_by_ticket_id' );

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Controller.php
@@ -210,7 +210,7 @@ class Controller extends Controller_Contract {
 	 * @return array The syncable tickets.
 	 */
 	public static function get_sync_able_tickets_of_event( int $event_id ): array {
-		_deprecated_function( __METHOD__, 'TBD', Ticket_Data::class . '::get_sync_able_tickets_of_event' );
+		_deprecated_function( __METHOD__, 'TBD', esc_html( Ticket_Data::class . '::get_sync_able_tickets_of_event' ) );
 		$ticket_data = tribe( Ticket_Data::class );
 		return $ticket_data->get_sync_able_tickets_of_event( $event_id );
 	}

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Controller.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Controller.php
@@ -203,49 +203,16 @@ class Controller extends Controller_Contract {
 	 * Get the sync-able tickets of an event.
 	 *
 	 * @since 5.24.0
+	 * @deprecated TBD
 	 *
 	 * @param int $event_id The event ID.
 	 *
 	 * @return array The syncable tickets.
 	 */
 	public static function get_sync_able_tickets_of_event( int $event_id ): array {
-		$cache_key = 'tec_tickets_commerce_square_sync_able_tickets_' . $event_id;
-		$cache     = tribe_cache();
-
-		if ( ! empty( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
-			return $cache[ $cache_key ];
-		}
-
+		_deprecated_function( __METHOD__, 'TBD', Ticket_Data::class . '::get_sync_able_tickets_of_event' );
 		$ticket_data = tribe( Ticket_Data::class );
-
-		$tickets_stats = $ticket_data->get_posts_tickets_data( $event_id );
-
-		if (
-			empty( $tickets_stats['tickets_on_sale'] ) &&
-			empty( $tickets_stats['tickets_about_to_go_to_sale'] ) &&
-			empty( $tickets_stats['tickets_have_ended_sales'] )
-		) {
-			return [];
-		}
-
-		$ticket_ids = array_unique(
-			array_merge(
-				$tickets_stats['tickets_on_sale'],
-				$tickets_stats['tickets_about_to_go_to_sale'],
-				$tickets_stats['tickets_have_ended_sales']
-			)
-		);
-
-		$tickets = array_filter(
-			array_map(
-				static fn ( $ticket_id ) => $ticket_data->load_ticket_object( $ticket_id ),
-				$ticket_ids
-			)
-		);
-
-		$cache[ $cache_key ] = $tickets;
-
-		return $tickets;
+		return $ticket_data->get_sync_able_tickets_of_event( $event_id );
 	}
 
 	/**

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Inventory_Sync.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Inventory_Sync.php
@@ -15,7 +15,7 @@ use TEC\Tickets\Commerce\Gateways\Square\Syncs\Objects\Item;
 use TEC\Tickets\Commerce\Gateways\Square\Syncs\Controller as Sync_Controller;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
 use TEC\Tickets\Commerce\Meta as Commerce_Meta;
-use TEC\Tickets\Commerce\Ticket as Tickets_Data;
+use TEC\Tickets\Commerce\Ticket as Ticket_Data;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use TEC\Tickets\Commerce\Gateways\Square\Syncs\Objects\NotSyncableItemException;
 
@@ -180,7 +180,7 @@ class Inventory_Sync {
 	 */
 	public function sync_event( int $event_id, bool $execute = true, array $tickets = [] ): array {
 		if ( empty( $tickets ) ) {
-			$tickets = Sync_Controller::get_sync_able_tickets_of_event( $event_id );
+			$tickets = tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $event_id );
 		}
 
 		if ( ! $execute ) {
@@ -204,7 +204,7 @@ class Inventory_Sync {
 	 * @return void
 	 */
 	public function sync_ticket( int $ticket_id, int $square_quantity, string $square_state ): void {
-		$ticket = tribe( Tickets_Data::class )->load_ticket_object( $ticket_id );
+		$ticket = tribe( Ticket_Data::class )->load_ticket_object( $ticket_id );
 
 		if ( ! $ticket instanceof Ticket_Object ) {
 			return;

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Items_Sync.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Items_Sync.php
@@ -14,6 +14,7 @@ use TEC\Tickets\Commerce\Gateways\Square\Requests;
 use TEC\Tickets\Commerce\Gateways\Square\Syncs\Objects\Item;
 use TEC\Tickets\Commerce\Gateways\Square\Syncs\Controller as Sync_Controller;
 use TEC\Tickets\Commerce\Settings as Commerce_Settings;
+use TEC\Tickets\Commerce\Ticket as Commerce_Ticket_Data;
 use TEC\Tickets\Commerce\Meta as Commerce_Meta;
 
 /**
@@ -191,7 +192,7 @@ class Items_Sync {
 	 * @return array The tickets.
 	 */
 	public function sync_event( int $event_id, bool $execute = true ): array {
-		$tickets = Sync_Controller::get_sync_able_tickets_of_event( $event_id );
+		$tickets = tribe( Commerce_Ticket_Data::class )->get_sync_able_tickets_of_event( $event_id );
 
 		if ( ! $execute ) {
 			return $tickets;

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
@@ -76,6 +76,7 @@ class Listeners extends Controller_Contract {
 	 * Register the controller.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Updated hooks we listen for changes.
 	 *
 	 * @return void
 	 */
@@ -86,12 +87,12 @@ class Listeners extends Controller_Contract {
 			return;
 		}
 
-		add_action( 'tec_tickets_ticket_able_post_upserted', [ $this, 'schedule_sync_on_save' ], 10, 2 );
+		add_action( 'tec_tickets_ticket_able_post_upserted', [ $this, 'schedule_sync_on_save' ], 10, 4 );
 		add_action( 'tec_tickets_ticket_upserted', [ $this, 'schedule_sync' ], 10, 2 );
 		add_action( 'tec_tickets_ticket_start_date_trigger', [ $this, 'schedule_sync_on_date_start' ], 10, 4 );
 		add_action( 'tec_tickets_ticket_end_date_trigger', [ $this, 'schedule_sync_on_date_end' ], 10, 4 );
-		add_action( 'wp_trash_post', [ $this, 'schedule_sync_on_delete' ] );
-		add_action( 'before_delete_post', [ $this, 'schedule_sync_on_delete' ] );
+		add_action( 'tec_tickets_ticket_able_post_deleted', [ $this, 'schedule_deletion_on_ticket_able_deleted' ] );
+		add_action( 'tec_tickets_ticket_deleted', [ $this, 'schedule_deletion_on_ticket_deleted' ] );
 		add_action( 'tec_tickets_commerce_square_ticket_out_of_sync', [ $this, 'schedule_ticket_sync_on_out_of_sync' ], 10, 3 );
 		add_action( 'tec_tickets_ticket_stock_changed', [ $this, 'schedule_ticket_sync_on_stock_changed' ] );
 		add_action( 'tec_tickets_commerce_square_merchant_disconnected', [ $this, 'unsync' ] );
@@ -101,6 +102,7 @@ class Listeners extends Controller_Contract {
 	 * Unregister the controller.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Updated hooks we listen for changes.
 	 *
 	 * @return void
 	 */
@@ -115,8 +117,8 @@ class Listeners extends Controller_Contract {
 		remove_action( 'tec_tickets_ticket_upserted', [ $this, 'schedule_sync' ] );
 		remove_action( 'tec_tickets_ticket_start_date_trigger', [ $this, 'schedule_sync_on_date_start' ] );
 		remove_action( 'tec_tickets_ticket_end_date_trigger', [ $this, 'schedule_sync_on_date_end' ] );
-		remove_action( 'wp_trash_post', [ $this, 'schedule_sync_on_delete' ] );
-		remove_action( 'before_delete_post', [ $this, 'schedule_sync_on_delete' ] );
+		remove_action( 'tec_tickets_ticket_able_post_deleted', [ $this, 'schedule_deletion_on_ticket_able_deleted' ] );
+		remove_action( 'tec_tickets_ticket_deleted', [ $this, 'schedule_deletion_on_ticket_deleted' ] );
 		remove_action( 'tec_tickets_commerce_square_ticket_out_of_sync', [ $this, 'schedule_ticket_sync_on_out_of_sync' ] );
 		remove_action( 'tec_tickets_ticket_stock_changed', [ $this, 'schedule_ticket_sync_on_stock_changed' ] );
 		remove_action( 'tec_tickets_commerce_square_merchant_disconnected', [ $this, 'unsync' ] );
@@ -294,22 +296,17 @@ class Listeners extends Controller_Contract {
 	 * Schedule the sync on save.
 	 *
 	 * @since 5.24.0
+	 * @since TBD Updated hook we are listening for and its arguments.
 	 *
 	 * @param int     $post_id The post ID.
 	 * @param WP_Post $post    The post object.
+	 * @param bool    $is_update Whether the post is being updated.
+	 * @param bool    $has_syncable_tickets Whether the post has sync-able tickets.
 	 *
 	 * @return void
 	 */
-	public function schedule_sync_on_save( int $post_id, WP_Post $post ): void {
-		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
-			return;
-		}
-
-		if ( ! in_array( $post->post_type, (array) tribe_get_option( 'ticket-enabled-post-types', [] ), true ) ) {
-			return;
-		}
-
-		if ( empty( tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $post_id ) ) ) {
+	public function schedule_sync_on_save( int $post_id, WP_Post $post, bool $is_update, bool $has_syncable_tickets ): void {
+		if ( ! $has_syncable_tickets ) {
 			return;
 		}
 
@@ -320,68 +317,56 @@ class Listeners extends Controller_Contract {
 	 * Schedule the sync on delete.
 	 *
 	 * @since 5.24.0
+	 * @deprecated TBD
 	 *
 	 * @param int $post_id The post ID.
 	 *
 	 * @return void
 	 */
 	public function schedule_sync_on_delete( int $post_id ): void {
-		$post = get_post( $post_id );
+		_deprecated_function( __METHOD__, 'TBD' );
+	}
 
-		if ( ! $post instanceof WP_Post ) {
-			return;
-		}
-
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		$ticket_types = tribe_tickets()->ticket_types();
-
-		$ticket_or_event_types = array_merge(
-			(array) tribe_get_option( 'ticket-enabled-post-types', [] ),
-			$ticket_types
-		);
-
-		if ( ! in_array( $post->post_type, $ticket_or_event_types, true ) ) {
-			return;
-		}
-
+	/**
+	 * Schedule the deletion on ticket-able post deleted.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public function schedule_deletion_on_ticket_able_deleted( int $post_id ): void {
 		if ( ! $this->is_object_syncable( $post_id, true ) ) {
 			return;
 		}
 
-		if ( ! in_array( $post->post_type, $ticket_types, true ) ) {
-			$this->schedule_deletion( $post_id );
+		$this->schedule_deletion( $post_id );
+	}
+
+	/**
+	 * Schedule the deletion on ticket deleted.
+	 *
+	 * @since TBD
+	 *
+	 * @param int   $ticket_id The ticket ID.
+	 * @param bool  $is_full_deletion Whether the post is being fully deleted.
+	 * @param ?int  $parent_id The parent ID.
+	 * @param ?bool $has_more_syncable_tickets Whether the post has more sync-able tickets.
+	 */
+	public function schedule_deletion_on_ticket_deleted( int $ticket_id, bool $is_full_deletion, ?int $parent_id, ?bool $has_more_syncable_tickets ): void {
+		if ( ! $this->is_object_syncable( $ticket_id, true ) ) {
 			return;
 		}
-
-		// This is a ticket - if this is the last "sync-able" ticket we need to schedule deletion for the parent event instead.
-		$ticket = Tickets::load_ticket_object( $post_id );
-
-		if ( ! $ticket instanceof Ticket_Object ) {
-			// It seems like we cant delete its parent...
-			$this->schedule_deletion( $post_id );
-			return;
-		}
-
-		$parent_id = $ticket->get_event_id();
 
 		if ( ! $parent_id ) {
-			// The parent is already deleted...
-			$this->schedule_deletion( $post_id );
+			$this->schedule_deletion( $ticket_id );
 			return;
 		}
 
-		$syncable_tickets = tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $parent_id );
-
-		if ( count( $syncable_tickets ) > 1 ) {
-			// There are more sync-able tickets for this event, we only need to delete the ticket from Square.
-			$this->schedule_deletion( $post_id );
+		if ( $has_more_syncable_tickets ) {
+			$this->schedule_deletion( $ticket_id );
 			return;
 		}
 
-		// This is the last sync-able ticket for this event, we need to schedule deletion for the parent event instead.
 		$this->schedule_deletion( $parent_id );
 	}
 

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
@@ -86,7 +86,7 @@ class Listeners extends Controller_Contract {
 			return;
 		}
 
-		add_action( 'save_post', [ $this, 'schedule_sync_on_save' ], 10, 2 );
+		add_action( 'tec_tickets_ticket_able_post_upserted', [ $this, 'schedule_sync_on_save' ], 10, 2 );
 		add_action( 'tec_tickets_ticket_upserted', [ $this, 'schedule_sync' ], 10, 2 );
 		add_action( 'tec_tickets_ticket_start_date_trigger', [ $this, 'schedule_sync_on_date_start' ], 10, 4 );
 		add_action( 'tec_tickets_ticket_end_date_trigger', [ $this, 'schedule_sync_on_date_end' ], 10, 4 );
@@ -111,7 +111,7 @@ class Listeners extends Controller_Contract {
 			return;
 		}
 
-		remove_action( 'save_post', [ $this, 'schedule_sync_on_save' ] );
+		remove_action( 'tec_tickets_ticket_able_post_upserted', [ $this, 'schedule_sync_on_save' ] );
 		remove_action( 'tec_tickets_ticket_upserted', [ $this, 'schedule_sync' ] );
 		remove_action( 'tec_tickets_ticket_start_date_trigger', [ $this, 'schedule_sync_on_date_start' ] );
 		remove_action( 'tec_tickets_ticket_end_date_trigger', [ $this, 'schedule_sync_on_date_end' ] );

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
@@ -92,7 +92,7 @@ class Listeners extends Controller_Contract {
 		add_action( 'tec_tickets_ticket_start_date_trigger', [ $this, 'schedule_sync_on_date_start' ], 10, 4 );
 		add_action( 'tec_tickets_ticket_end_date_trigger', [ $this, 'schedule_sync_on_date_end' ], 10, 4 );
 		add_action( 'tec_tickets_ticket_able_post_deleted', [ $this, 'schedule_deletion_on_ticket_able_deleted' ] );
-		add_action( 'tec_tickets_ticket_deleted', [ $this, 'schedule_deletion_on_ticket_deleted' ] );
+		add_action( 'tec_tickets_ticket_deleted', [ $this, 'schedule_deletion_on_ticket_deleted' ], 10, 4 );
 		add_action( 'tec_tickets_commerce_square_ticket_out_of_sync', [ $this, 'schedule_ticket_sync_on_out_of_sync' ], 10, 3 );
 		add_action( 'tec_tickets_ticket_stock_changed', [ $this, 'schedule_ticket_sync_on_stock_changed' ] );
 		add_action( 'tec_tickets_commerce_square_merchant_disconnected', [ $this, 'unsync' ] );

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Listeners.php
@@ -309,7 +309,7 @@ class Listeners extends Controller_Contract {
 			return;
 		}
 
-		if ( empty( Sync_Controller::get_sync_able_tickets_of_event( $post_id ) ) ) {
+		if ( empty( tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $post_id ) ) ) {
 			return;
 		}
 
@@ -373,7 +373,7 @@ class Listeners extends Controller_Contract {
 			return;
 		}
 
-		$syncable_tickets = Sync_Controller::get_sync_able_tickets_of_event( $parent_id );
+		$syncable_tickets = tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $parent_id );
 
 		if ( count( $syncable_tickets ) > 1 ) {
 			// There are more sync-able tickets for this event, we only need to delete the ticket from Square.

--- a/src/Tickets/Commerce/Gateways/Square/Syncs/Objects/Event_Item.php
+++ b/src/Tickets/Commerce/Gateways/Square/Syncs/Objects/Event_Item.php
@@ -14,7 +14,7 @@ namespace TEC\Tickets\Commerce\Gateways\Square\Syncs\Objects;
 
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use WP_Post;
-use TEC\Tickets\Commerce\Gateways\Square\Syncs\Controller as Sync_Controller;
+use TEC\Tickets\Commerce\Ticket as Commerce_Ticket_Data;
 use TEC\Tickets\Commerce\Meta as Commerce_Meta;
 
 /**
@@ -98,7 +98,7 @@ class Event_Item extends Item {
 		$this->event            = get_post( $post_id );
 
 		if ( empty( $tickets ) ) {
-			$tickets = Sync_Controller::get_sync_able_tickets_of_event( $post_id );
+			$tickets = tribe( Commerce_Ticket_Data::class )->get_sync_able_tickets_of_event( $post_id );
 		}
 
 		$this->set_tickets( $tickets );

--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -7,7 +7,6 @@ use WP_Error;
 use TEC\Tickets\Commerce;
 use Tribe__Utils__Array as Arr;
 use TEC\Tickets\Commerce\Communication\Email as Email_Communication;
-use TEC\Tickets\Commerce\Reports\Attendees as Attendees_Reports;
 
 /**
  * Class Tickets Provider class for Tickets Commerce

--- a/src/Tickets/Provider.php
+++ b/src/Tickets/Provider.php
@@ -107,6 +107,9 @@ class Provider extends Service_Provider {
 		// Seating.
 		$this->container->register( Seating\Controller::class );
 
+		// Ticket-Able Post Actions.
+		$this->container->register( Ticket_Able_Post_Actions::class );
+
 		// Ticket Action hooks.
 		$this->container->register( Ticket_Actions::class );
 

--- a/src/Tickets/Ticket_Able_Post_Actions.php
+++ b/src/Tickets/Ticket_Able_Post_Actions.php
@@ -9,14 +9,11 @@
 namespace TEC\Tickets;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
-use TEC\Common\lucatume\DI52\Container;
 use Tribe__Tickets__Tickets as Tickets;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
 use TEC\Tickets\Commerce\Ticket as Commerce_Ticket_Data;
 use WP_Post;
-use Exception;
 use TEC\Tickets\Commerce\Module as Commerce_Ticket_Provider;
-use TEC\Common\StellarWP\DB\DB;
 
 /**
  * Class Ticket_Able_Post_Actions.

--- a/src/Tickets/Ticket_Able_Post_Actions.php
+++ b/src/Tickets/Ticket_Able_Post_Actions.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * The Ticket-Able Post Actions controller.
+ *
+ * @since TBD
+ * @package TEC\Tickets
+ */
+
+namespace TEC\Tickets;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\lucatume\DI52\Container;
+use Tribe__Tickets__Tickets as Tickets;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
+use TEC\Tickets\Commerce\Ticket as Commerce_Ticket_Data;
+use WP_Post;
+use Exception;
+use TEC\Tickets\Commerce\Module as Commerce_Ticket_Provider;
+use TEC\Common\StellarWP\DB\DB;
+
+/**
+ * Class Ticket_Able_Post_Actions.
+ *
+ * @since TBD
+ * @package TEC\Tickets
+ */
+class Ticket_Able_Post_Actions extends Controller_Contract {
+	/**
+	 * Registers the controller by subscribing to front-end hooks and binding implementations.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		add_action( 'save_post', [ $this, 'fire_ticket_able_post_change_action' ], 10, 3 );
+		add_action( 'wp_trash_post', [ $this, 'fire_ticket_or_ticket_able_post_deleted' ] );
+		add_action( 'before_delete_post', [ $this, 'fire_ticket_or_ticket_able_post_deleted' ] );
+	}
+
+	/**
+	 * Un-registers the Controller by unsubscribing from WordPress hooks.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_action( 'save_post', [ $this, 'fire_ticket_able_post_change_action' ] );
+		remove_action( 'wp_trash_post', [ $this, 'fire_ticket_or_ticket_able_post_deleted' ] );
+		remove_action( 'before_delete_post', [ $this, 'fire_ticket_or_ticket_able_post_deleted' ] );
+	}
+
+	/**
+	 * Fire the ticket-able post deleted action.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return void
+	 */
+	public function fire_ticket_or_ticket_able_post_deleted( int $post_id ): void {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		$ticket_types = tribe_tickets()->ticket_types();
+
+		$ticket_or_event_types = array_merge(
+			(array) tribe_get_option( 'ticket-enabled-post-types', [] ),
+			$ticket_types
+		);
+
+		if ( ! in_array( $post->post_type, $ticket_or_event_types, true ) ) {
+			return;
+		}
+
+		$is_full_deletion = doing_action( 'before_delete_post' );
+
+		if ( ! in_array( $post->post_type, $ticket_types, true ) ) {
+			/**
+			 * Fires when a ticket-able post is deleted.
+			 *
+			 * @since TBD
+			 *
+			 * @param int  $post_id         The post ID.
+			 * @param bool $is_full_deletion Whether the post is being fully deleted.
+			 */
+			do_action( 'tec_tickets_ticket_able_post_deleted', $post_id, $is_full_deletion );
+			return;
+		}
+
+		$ticket = Tickets::load_ticket_object( $post_id );
+
+		if ( ! $ticket instanceof Ticket_Object ) {
+			$this->fire_ticket_deleted_action( $post_id, $is_full_deletion, null, null );
+			return;
+		}
+
+		$parent_id = $ticket->get_event_id();
+
+		if ( ! $parent_id ) {
+			$this->fire_ticket_deleted_action( $post_id, $is_full_deletion, null, null );
+			return;
+		}
+
+		$syncable_tickets = tribe( Ticket_Data::class )->get_sync_able_tickets_of_event( $parent_id );
+
+		$this->fire_ticket_deleted_action( $post_id, $is_full_deletion, $parent_id, count( $syncable_tickets ) > 1 );
+	}
+
+	/**
+	 * Fire the ticket-able post change action.
+	 *
+	 * @since TBD
+	 *
+	 * @param int     $post_id   The post ID.
+	 * @param WP_Post $post      The post object.
+	 * @param bool    $is_update Whether the post is being updated.
+	 *
+	 * @return void
+	 */
+	public function fire_ticket_able_post_change_action( int $post_id, WP_Post $post, bool $is_update ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
+
+		if ( ! in_array( $post->post_type, (array) tribe_get_option( 'ticket-enabled-post-types', [] ), true ) ) {
+			return;
+		}
+
+		$ticket_data = $this->get_ticket_data_by_provider( $post_id );
+
+		$has_syncable_tickets = ! empty( $ticket_data->get_sync_able_tickets_of_event( $post_id ) );
+
+		/**
+		 * Fires when a ticket-able post is upserted.
+		 *
+		 * @since TBD
+		 *
+		 * @param int     $post_id              The post ID.
+		 * @param WP_Post $post                 The post object.
+		 * @param bool    $is_update            Whether the post is being updated.
+		 * @param bool    $has_syncable_tickets Whether the post has sync-able tickets.
+		 */
+		do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post, $is_update, $has_syncable_tickets );
+
+		if ( $is_update ) {
+			/**
+			 * Fires when a ticket-able post is updated.
+			 *
+			 * @since TBD
+			 *
+			 * @param int     $post_id              The post ID.
+			 * @param WP_Post $post                 The post object.
+			 * @param bool    $has_syncable_tickets Whether the post has sync-able tickets.
+			 */
+			do_action( 'tec_tickets_ticket_able_post_updated', $post_id, $post, $has_syncable_tickets );
+			return;
+		}
+
+		/**
+		 * Fires when a ticket-able post is created.
+		 *
+		 * @since TBD
+		 *
+		 * @param int     $post_id              The post ID.
+		 * @param WP_Post $post                 The post object.
+		 * @param bool    $has_syncable_tickets Whether the post has sync-able tickets.
+		 */
+		do_action( 'tec_tickets_ticket_able_post_created', $post_id, $post, $has_syncable_tickets );
+	}
+
+	/**
+	 * Get the ticket data by provider.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return Ticket_Data The ticket data.
+	 */
+	private function get_ticket_data_by_provider( int $post_id ): Ticket_Data {
+		$provider = Tickets::get_event_ticket_provider_object( $post_id );
+
+		if ( $provider instanceof Commerce_Ticket_Provider ) {
+			return tribe( Commerce_Ticket_Data::class );
+		}
+
+		return tribe( Ticket_Data::class );
+	}
+
+	/**
+	 * Fire the ticket deleted action.
+	 *
+	 * @since TBD
+	 *
+	 * @param int   $post_id                   The post ID.
+	 * @param bool  $is_full_deletion          Whether the post is being fully deleted.
+	 * @param ?int  $parent_id                 The parent ID.
+	 * @param ?bool $has_more_syncable_tickets Whether the post has more sync-able tickets.
+	 */
+	private function fire_ticket_deleted_action( int $post_id, bool $is_full_deletion, ?int $parent_id, ?bool $has_more_syncable_tickets ): void {
+		/**
+		 * Fires when a ticket is deleted.
+		 *
+		 * @since TBD
+		 *
+		 * @param int  $post_id                    The post ID.
+		 * @param bool $is_full_deletion           Whether the post is being fully deleted.
+		 * @param ?int $parent_id                  The parent ID.
+		 * @param ?bool $has_more_syncable_tickets Whether the post has more sync-able tickets.
+		 */
+		do_action( 'tec_tickets_ticket_deleted', $post_id, $is_full_deletion, $parent_id, $has_more_syncable_tickets );
+	}
+}

--- a/src/Tickets/Ticket_Data.php
+++ b/src/Tickets/Ticket_Data.php
@@ -275,4 +275,51 @@ class Ticket_Data {
 		 */
 		return (int) apply_filters( 'tec_tickets_ticket_about_to_go_to_sale_seconds', 20 * MINUTE_IN_SECONDS, $ticket_id );
 	}
+
+	/**
+	 * Get the sync-able tickets of an event.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $event_id The event ID.
+	 *
+	 * @return array The syncable tickets.
+	 */
+	public function get_sync_able_tickets_of_event( int $event_id ): array {
+		$cache_key = 'tec_tickets_' . self::class . '_' . $event_id;
+		$cache     = tribe_cache();
+
+		if ( ! empty( $cache[ $cache_key ] ) && is_array( $cache[ $cache_key ] ) ) {
+			return $cache[ $cache_key ];
+		}
+
+		$tickets_stats = $this->get_posts_tickets_data( $event_id );
+
+		if (
+			empty( $tickets_stats['tickets_on_sale'] ) &&
+			empty( $tickets_stats['tickets_about_to_go_to_sale'] ) &&
+			empty( $tickets_stats['tickets_have_ended_sales'] )
+		) {
+			return [];
+		}
+
+		$ticket_ids = array_unique(
+			array_merge(
+				$tickets_stats['tickets_on_sale'],
+				$tickets_stats['tickets_about_to_go_to_sale'],
+				$tickets_stats['tickets_have_ended_sales']
+			)
+		);
+
+		$tickets = array_filter(
+			array_map(
+				fn ( $ticket_id ) => $this->load_ticket_object( $ticket_id ),
+				$ticket_ids
+			)
+		);
+
+		$cache[ $cache_key ] = $tickets;
+
+		return $tickets;
+	}
 }

--- a/tests/_support/Commerce/TicketsCommerce/Ticket_Maker.php
+++ b/tests/_support/Commerce/TicketsCommerce/Ticket_Maker.php
@@ -90,7 +90,7 @@ trait Ticket_Maker {
 	protected function create_about_to_be_on_sale_tc_ticket( $post_id, $price = 1, array $overrides = [] ) {
 		return $this->create_tc_ticket( $post_id, $price, array_merge( $overrides, [
 			'ticket_start_date' => gmdate( 'Y-m-d' ),
-			'ticket_start_time' => gmdate( 'H:i:s', time() + MINUTE_IN_SECONDS - Ticket_Data::get_ticket_about_to_go_to_sale_seconds( $post_id ) ),
+			'ticket_start_time' => gmdate( 'H:i:s', time() + Ticket_Data::get_ticket_about_to_go_to_sale_seconds( $post_id ) - MINUTE_IN_SECONDS ),
 			'ticket_end_date'   => '2150-03-01',
 			'ticket_end_time'   => '20:00:00',
 		] ) );

--- a/tests/integration/TEC/Tickets/Ticket_Able_Post_Actions_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Able_Post_Actions_Test.php
@@ -1,0 +1,395 @@
+<?php
+
+namespace TEC\Tickets;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
+use Tribe\Tests\Traits\With_Uopz;
+use Generator;
+use Closure;
+
+class Ticket_Able_Post_Actions_Test extends Controller_Test_Case {
+	use With_Uopz;
+	use Ticket_Maker;
+	use Order_Maker;
+	use With_Tickets_Commerce;
+
+	protected string $controller_class = Ticket_Able_Post_Actions::class;
+
+	protected static array $back_up_actions = [];
+
+	/**
+	 * @before
+	 */
+	public function take_backup(): void {
+		global $wp_actions;
+
+		self::$back_up_actions = $wp_actions;
+		$wp_actions = [];
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_backup(): void {
+		global $wp_actions;
+
+		$wp_actions = self::$back_up_actions;
+	}
+
+	/**
+	 * @test
+	 * @dataProvider fire_ticket_able_post_change_action_data_provider
+	 */
+	public function it_should_fire_ticket_able_post_change_action( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $expected_actions, $unexpected_actions ] = $fixture();
+
+		foreach ( $expected_actions as $action => $count ) {
+			$this->assertSame(
+				$count,
+				did_action( $action ),
+				"Expected action '{$action}' to fire {$count} time(s), got " . did_action( $action ) . '.'
+			);
+		}
+
+		foreach ( $unexpected_actions as $action ) {
+			$this->assertSame(
+				0,
+				did_action( $action ),
+				"Expected action '{$action}' to NOT fire."
+			);
+		}
+	}
+
+	public function fire_ticket_able_post_change_action_data_provider(): Generator {
+		yield 'creating a ticket-enabled post fires upserted and created actions' => [
+			function (): array {
+				static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				return [
+					[
+						'tec_tickets_ticket_able_post_upserted' => 1,
+						'tec_tickets_ticket_able_post_created'  => 1,
+					],
+					[
+						'tec_tickets_ticket_able_post_updated',
+					],
+				];
+			},
+		];
+
+		yield 'updating a ticket-enabled post fires upserted and updated actions' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				// Reset counts after creation.
+				global $wp_actions;
+				$wp_actions = [];
+
+				wp_update_post( [
+					'ID'         => $post_id,
+					'post_title' => 'Updated title',
+				] );
+
+				return [
+					[
+						'tec_tickets_ticket_able_post_upserted' => 1,
+						'tec_tickets_ticket_able_post_updated'  => 1,
+					],
+					[
+						'tec_tickets_ticket_able_post_created',
+					],
+				];
+			},
+		];
+
+		yield 'non-ticket-enabled post type does not fire actions' => [
+			function (): array {
+				register_post_type( 'not_ticketed', [ 'public' => true ] );
+				static::factory()->post->create( [
+					'post_status' => 'publish',
+					'post_type'   => 'not_ticketed',
+				] );
+
+				return [
+					[],
+					[
+						'tec_tickets_ticket_able_post_upserted',
+						'tec_tickets_ticket_able_post_created',
+						'tec_tickets_ticket_able_post_updated',
+					],
+				];
+			},
+		];
+
+		yield 'revision does not fire actions' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				global $wp_actions;
+				$wp_actions = [];
+
+				$this->set_fn_return( 'wp_is_post_revision', true );
+
+				wp_update_post( [
+					'ID'         => $post_id,
+					'post_title' => 'Updated title',
+				] );
+
+				return [
+					[],
+					[
+						'tec_tickets_ticket_able_post_upserted',
+						'tec_tickets_ticket_able_post_created',
+						'tec_tickets_ticket_able_post_updated',
+					],
+				];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider fire_ticket_able_post_upserted_params_data_provider
+	 */
+	public function it_should_pass_correct_params_to_upserted_action( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$captured = [];
+		add_action( 'tec_tickets_ticket_able_post_upserted', function ( $post_id, $post, $is_update, $has_syncable_tickets ) use ( &$captured ) {
+			$captured = compact( 'post_id', 'post', 'is_update', 'has_syncable_tickets' );
+		}, 10, 4 );
+
+		[ $expected_post_id, $expected_is_update, $expected_has_syncable ] = $fixture();
+
+		$this->assertSame( $expected_post_id, $captured['post_id'] );
+		$this->assertSame( $expected_is_update, $captured['is_update'] );
+		$this->assertSame( $expected_has_syncable, $captured['has_syncable_tickets'] );
+	}
+
+	public function fire_ticket_able_post_upserted_params_data_provider(): Generator {
+		yield 'new post without tickets passes has_syncable_tickets as false' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				return [ $post_id, false, false ];
+			},
+		];
+
+		yield 'new post with on-sale ticket passes has_syncable_tickets as true' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				global $wp_actions;
+				$wp_actions = [];
+
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				wp_update_post( [
+					'ID'         => $post_id,
+					'post_title' => 'Updated title',
+				] );
+
+				return [ $post_id, true, true ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider fire_ticket_or_ticket_able_post_deleted_data_provider
+	 */
+	public function it_should_fire_ticket_or_ticket_able_post_deleted( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $expected_actions, $unexpected_actions ] = $fixture();
+
+		foreach ( $expected_actions as $action => $count ) {
+			$this->assertSame(
+				$count,
+				did_action( $action ),
+				"Expected action '{$action}' to fire {$count} time(s), got " . did_action( $action ) . '.'
+			);
+		}
+
+		foreach ( $unexpected_actions as $action ) {
+			$this->assertSame(
+				0,
+				did_action( $action ),
+				"Expected action '{$action}' to NOT fire."
+			);
+		}
+	}
+
+	public function fire_ticket_or_ticket_able_post_deleted_data_provider(): Generator {
+		yield 'trashing a ticket-enabled post fires ticket_able_post_deleted' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [
+					[
+						'tec_tickets_ticket_able_post_deleted' => 1,
+					],
+					[
+						'tec_tickets_ticket_deleted',
+					],
+				];
+			},
+		];
+
+		yield 'trashing a ticket fires ticket_deleted' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'wp_trash_post', $ticket_id );
+
+				return [
+					[
+						'tec_tickets_ticket_deleted' => 1,
+					],
+					[
+						'tec_tickets_ticket_able_post_deleted',
+					],
+				];
+			},
+		];
+
+		yield 'non-existent post does not fire any action' => [
+			function (): array {
+				do_action( 'wp_trash_post', PHP_INT_MAX );
+
+				return [
+					[],
+					[
+						'tec_tickets_ticket_able_post_deleted',
+						'tec_tickets_ticket_deleted',
+					],
+				];
+			},
+		];
+
+		yield 'draft post does not fire any action' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'draft' ] );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [
+					[],
+					[
+						'tec_tickets_ticket_able_post_deleted',
+						'tec_tickets_ticket_deleted',
+					],
+				];
+			},
+		];
+
+		yield 'non-ticket-enabled post type does not fire any action' => [
+			function (): array {
+				register_post_type( 'unrelated_type', [ 'public' => true ] );
+				$post_id = static::factory()->post->create( [
+					'post_status' => 'publish',
+					'post_type'   => 'unrelated_type',
+				] );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [
+					[],
+					[
+						'tec_tickets_ticket_able_post_deleted',
+						'tec_tickets_ticket_deleted',
+					],
+				];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider fire_ticket_deleted_params_data_provider
+	 */
+	public function it_should_pass_correct_params_to_ticket_deleted( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$captured = [];
+		add_action( 'tec_tickets_ticket_deleted', function ( $post_id, $is_full_deletion, $parent_id, $has_more_syncable_tickets ) use ( &$captured ) {
+			$captured = compact( 'post_id', 'is_full_deletion', 'parent_id', 'has_more_syncable_tickets' );
+		}, 10, 4 );
+
+		[ $expected ] = $fixture();
+
+		$this->assertSame( $expected['post_id'], $captured['post_id'] );
+		$this->assertSame( $expected['is_full_deletion'], $captured['is_full_deletion'] );
+		$this->assertSame( $expected['parent_id'], $captured['parent_id'] );
+		$this->assertSame( $expected['has_more_syncable_tickets'], $captured['has_more_syncable_tickets'] );
+	}
+
+	public function fire_ticket_deleted_params_data_provider(): Generator {
+		yield 'trashing single ticket passes has_more_syncable_tickets as false' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'wp_trash_post', $ticket_id );
+
+				return [
+					[
+						'post_id'                    => $ticket_id,
+						'is_full_deletion'           => false,
+						'parent_id'                  => $post_id,
+						'has_more_syncable_tickets'  => false,
+					],
+				];
+			},
+		];
+
+		yield 'trashing ticket with siblings passes has_more_syncable_tickets as true' => [
+			function (): array {
+				$post_id    = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id1 = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$ticket_id2 = $this->create_on_sale_tc_ticket( $post_id, 20 );
+
+				do_action( 'wp_trash_post', $ticket_id1 );
+
+				return [
+					[
+						'post_id'                    => $ticket_id1,
+						'is_full_deletion'           => false,
+						'parent_id'                  => $post_id,
+						'has_more_syncable_tickets'  => true,
+					],
+				];
+			},
+		];
+
+		yield 'deleting ticket via before_delete_post passes is_full_deletion as true' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'before_delete_post', $ticket_id );
+
+				return [
+					[
+						'post_id'                    => $ticket_id,
+						'is_full_deletion'           => true,
+						'parent_id'                  => $post_id,
+						'has_more_syncable_tickets'  => false,
+					],
+				];
+			},
+		];
+	}
+}

--- a/tests/integration/TEC/Tickets/Ticket_Able_Post_Actions_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Able_Post_Actions_Test.php
@@ -264,20 +264,6 @@ class Ticket_Able_Post_Actions_Test extends Controller_Test_Case {
 			},
 		];
 
-		yield 'non-existent post does not fire any action' => [
-			function (): array {
-				do_action( 'wp_trash_post', PHP_INT_MAX );
-
-				return [
-					[],
-					[
-						'tec_tickets_ticket_able_post_deleted',
-						'tec_tickets_ticket_deleted',
-					],
-				];
-			},
-		];
-
 		yield 'draft post does not fire any action' => [
 			function (): array {
 				$post_id = static::factory()->post->create( [ 'post_status' => 'draft' ] );
@@ -379,7 +365,7 @@ class Ticket_Able_Post_Actions_Test extends Controller_Test_Case {
 				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
 				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
 
-				do_action( 'before_delete_post', $ticket_id );
+				do_action( 'before_delete_post', $ticket_id, get_post( $ticket_id ) );
 
 				return [
 					[

--- a/tests/integration/TEC/Tickets/Ticket_Data_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Data_Test.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace TEC\Tickets;
+
+use lucatume\WPBrowser\TestCase\WPTestCase as WPBrowserTestCase;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
+use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
+use Closure;
+use Generator;
+
+class Ticket_Data_Test extends WPBrowserTestCase {
+	use Ticket_Maker;
+	use Order_Maker;
+	use RSVP_Ticket_Maker;
+	use With_Tickets_Commerce;
+
+	/**
+	 * @test
+	 */
+	public function it_should_get_sync_able_tickets_of_event(): void {
+		$post = self::factory()->post->create();
+		$ticket_id_1 = $this->create_on_sale_tc_ticket( $post, 10 );
+		$ticket_id_2 = $this->create_about_to_be_on_sale_tc_ticket( $post, 20 );
+		$ticket_id_3 = $this->create_pre_sale_tc_ticket( $post, 30 );
+		$ticket_id_4 = $this->create_after_sales_tc_ticket( $post, 40 );
+
+		$ticket_data = tribe( Ticket_Data::class );
+
+		$tickets = $ticket_data->get_sync_able_tickets_of_event( $post );
+
+		$ticket_ids = array_map( fn( $ticket ) => $ticket->ID, $tickets );
+
+		$this->assertCount( 3, $tickets );
+		$this->assertContains( $ticket_id_1, $ticket_ids );
+		$this->assertContains( $ticket_id_2, $ticket_ids );
+		$this->assertNotContains( $ticket_id_3, $ticket_ids );
+		$this->assertContains( $ticket_id_4, $ticket_ids );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider load_ticket_object_data_provider
+	 */
+	public function it_should_load_ticket_object( Closure $fixture ): void {
+		[ $ticket_id, $should_load ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$result      = $ticket_data->load_ticket_object( $ticket_id );
+
+		if ( $should_load ) {
+			$this->assertInstanceOf( Ticket_Object::class, $result );
+			$this->assertEquals( $ticket_id, $result->ID );
+		} else {
+			$this->assertNull( $result );
+		}
+	}
+
+	public function load_ticket_object_data_provider(): Generator {
+		yield 'valid TC ticket loads successfully' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				return [ $ticket_id, true ];
+			},
+		];
+
+		yield 'non-existent ticket returns null' => [
+			function (): array {
+				return [ PHP_INT_MAX, false ];
+			},
+		];
+
+		yield 'valid RSVP ticket loads successfully' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_rsvp_ticket( $post_id );
+
+				return [ $ticket_id, true ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_posts_tickets_data_provider
+	 */
+	public function it_should_get_posts_tickets( Closure $fixture ): void {
+		[ $post_id, $expected_ticket_ids ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$tickets     = iterator_to_array( $ticket_data->get_posts_tickets( $post_id ) );
+		$ticket_ids  = array_map( fn( Ticket_Object $ticket ) => $ticket->ID, $tickets );
+
+		$this->assertCount( count( $expected_ticket_ids ), $tickets );
+
+		foreach ( $expected_ticket_ids as $expected_id ) {
+			$this->assertContains( $expected_id, $ticket_ids );
+		}
+	}
+
+	public function get_posts_tickets_data_provider(): Generator {
+		yield 'post with multiple TC tickets returns all' => [
+			function (): array {
+				$post_id    = static::factory()->post->create();
+				$ticket_id1 = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$ticket_id2 = $this->create_on_sale_tc_ticket( $post_id, 20 );
+
+				return [ $post_id, [ $ticket_id1, $ticket_id2 ] ];
+			},
+		];
+
+		yield 'post without tickets returns empty' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+
+				return [ $post_id, [] ];
+			},
+		];
+
+		yield 'RSVP tickets are excluded' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$tc_ticket = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$this->create_rsvp_ticket( $post_id );
+
+				return [ $post_id, [ $tc_ticket ] ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_posts_rsvp_data_provider
+	 */
+	public function it_should_get_posts_rsvp( Closure $fixture ): void {
+		[ $post_id, $expected_rsvp_id ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$rsvp        = $ticket_data->get_posts_rsvp( $post_id );
+
+		if ( $expected_rsvp_id ) {
+			$this->assertInstanceOf( Ticket_Object::class, $rsvp );
+			$this->assertEquals( $expected_rsvp_id, $rsvp->ID );
+		} else {
+			$this->assertNull( $rsvp );
+		}
+	}
+
+	public function get_posts_rsvp_data_provider(): Generator {
+		yield 'post with RSVP returns it' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+				$rsvp_id = $this->create_rsvp_ticket( $post_id );
+
+				return [ $post_id, $rsvp_id ];
+			},
+		];
+
+		yield 'post without RSVP returns null' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+
+				return [ $post_id, null ];
+			},
+		];
+
+		yield 'post with only TC ticket returns null' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				return [ $post_id, null ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_posts_tickets_data_stats_provider
+	 */
+	public function it_should_get_posts_tickets_data( Closure $fixture ): void {
+		[ $post_id, $expected ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$data        = $ticket_data->get_posts_tickets_data( $post_id );
+
+		$this->assertSame( $expected['ticket_count'], $data['ticket_count'] );
+		$this->assertCount( count( $expected['tickets_on_sale'] ), $data['tickets_on_sale'] );
+		$this->assertCount( count( $expected['tickets_have_not_started_sales'] ), $data['tickets_have_not_started_sales'] );
+		$this->assertCount( count( $expected['tickets_have_ended_sales'] ), $data['tickets_have_ended_sales'] );
+		$this->assertCount( count( $expected['tickets_about_to_go_to_sale'] ), $data['tickets_about_to_go_to_sale'] );
+
+		foreach ( $expected['tickets_on_sale'] as $id ) {
+			$this->assertContains( $id, $data['tickets_on_sale'] );
+		}
+
+		foreach ( $expected['tickets_have_ended_sales'] as $id ) {
+			$this->assertContains( $id, $data['tickets_have_ended_sales'] );
+		}
+
+		foreach ( $expected['tickets_about_to_go_to_sale'] as $id ) {
+			$this->assertContains( $id, $data['tickets_about_to_go_to_sale'] );
+		}
+
+		foreach ( $expected['tickets_have_not_started_sales'] as $id ) {
+			$this->assertContains( $id, $data['tickets_have_not_started_sales'] );
+		}
+	}
+
+	public function get_posts_tickets_data_stats_provider(): Generator {
+		yield 'post with no tickets returns zeroed data' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+
+				return [
+					$post_id,
+					[
+						'ticket_count'                   => 0,
+						'tickets_on_sale'                => [],
+						'tickets_have_not_started_sales' => [],
+						'tickets_have_ended_sales'       => [],
+						'tickets_about_to_go_to_sale'    => [],
+					],
+				];
+			},
+		];
+
+		yield 'post with mixed ticket states returns correct stats' => [
+			function (): array {
+				$post_id     = static::factory()->post->create();
+				$on_sale     = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$about_to    = $this->create_about_to_be_on_sale_tc_ticket( $post_id, 20 );
+				$pre_sale    = $this->create_pre_sale_tc_ticket( $post_id, 30 );
+				$after_sales = $this->create_after_sales_tc_ticket( $post_id, 40 );
+
+				return [
+					$post_id,
+					[
+						'ticket_count'                   => 4,
+						'tickets_on_sale'                => [ $on_sale ],
+						'tickets_have_not_started_sales' => [ $about_to, $pre_sale ],
+						'tickets_have_ended_sales'       => [ $after_sales ],
+						'tickets_about_to_go_to_sale'    => [ $about_to ],
+					],
+				];
+			},
+		];
+
+		yield 'post with only on-sale tickets' => [
+			function (): array {
+				$post_id  = static::factory()->post->create();
+				$ticket_1 = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$ticket_2 = $this->create_on_sale_tc_ticket( $post_id, 20 );
+
+				return [
+					$post_id,
+					[
+						'ticket_count'                   => 2,
+						'tickets_on_sale'                => [ $ticket_1, $ticket_2 ],
+						'tickets_have_not_started_sales' => [],
+						'tickets_have_ended_sales'       => [],
+						'tickets_about_to_go_to_sale'    => [],
+					],
+				];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_posts_rsvps_data_provider
+	 */
+	public function it_should_get_posts_rsvps_data( Closure $fixture ): void {
+		[ $post_id, $expected_count ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$data        = $ticket_data->get_posts_rsvps_data( $post_id );
+
+		$this->assertSame( $expected_count, $data['ticket_count'] );
+		$this->assertArrayHasKey( 'availability', $data );
+		$this->assertArrayHasKey( 'tickets_on_sale', $data );
+		$this->assertArrayHasKey( 'tickets_have_not_started_sales', $data );
+		$this->assertArrayHasKey( 'tickets_have_ended_sales', $data );
+		$this->assertArrayHasKey( 'tickets_about_to_go_to_sale', $data );
+	}
+
+	public function get_posts_rsvps_data_provider(): Generator {
+		yield 'post with RSVP returns count of 1' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+				$this->create_rsvp_ticket( $post_id );
+
+				return [ $post_id, 1 ];
+			},
+		];
+
+		yield 'post without RSVP returns count of 0' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+
+				return [ $post_id, 0 ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_ticket_about_to_go_to_sale_seconds_data_provider
+	 */
+	public function it_should_get_ticket_about_to_go_to_sale_seconds( Closure $fixture ): void {
+		[ $ticket_id, $expected_seconds ] = $fixture();
+
+		$result = Ticket_Data::get_ticket_about_to_go_to_sale_seconds( $ticket_id );
+
+		$this->assertSame( $expected_seconds, $result );
+	}
+
+	public function get_ticket_about_to_go_to_sale_seconds_data_provider(): Generator {
+		yield 'default is 20 minutes' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				return [ $ticket_id, 20 * MINUTE_IN_SECONDS ];
+			},
+		];
+
+		yield 'filter overrides the default' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				add_filter( 'tec_tickets_ticket_about_to_go_to_sale_seconds', fn() => 5 * MINUTE_IN_SECONDS );
+
+				return [ $ticket_id, 5 * MINUTE_IN_SECONDS ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider get_sync_able_tickets_of_event_data_provider
+	 */
+	public function it_should_get_sync_able_tickets_of_event_with_various_states( Closure $fixture ): void {
+		[ $post_id, $expected_ids, $excluded_ids ] = $fixture();
+
+		$ticket_data = tribe( Ticket_Data::class );
+		$tickets     = $ticket_data->get_sync_able_tickets_of_event( $post_id );
+		$ticket_ids  = array_map( fn( $ticket ) => $ticket->ID, $tickets );
+
+		$this->assertCount( count( $expected_ids ), $tickets );
+
+		foreach ( $expected_ids as $id ) {
+			$this->assertContains( $id, $ticket_ids );
+		}
+
+		foreach ( $excluded_ids as $id ) {
+			$this->assertNotContains( $id, $ticket_ids );
+		}
+	}
+
+	public function get_sync_able_tickets_of_event_data_provider(): Generator {
+		yield 'post with no tickets returns empty' => [
+			function (): array {
+				$post_id = static::factory()->post->create();
+
+				return [ $post_id, [], [] ];
+			},
+		];
+
+		yield 'only pre-sale tickets returns empty' => [
+			function (): array {
+				$post_id  = static::factory()->post->create();
+				$pre_sale = $this->create_pre_sale_tc_ticket( $post_id, 10 );
+
+				return [ $post_id, [], [ $pre_sale ] ];
+			},
+		];
+
+		yield 'on-sale and after-sales are sync-able, pre-sale is not' => [
+			function (): array {
+				$post_id     = static::factory()->post->create();
+				$on_sale     = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$pre_sale    = $this->create_pre_sale_tc_ticket( $post_id, 20 );
+				$after_sales = $this->create_after_sales_tc_ticket( $post_id, 30 );
+
+				return [ $post_id, [ $on_sale, $after_sales ], [ $pre_sale ] ];
+			},
+		];
+
+		yield 'about-to-go-on-sale tickets are sync-able' => [
+			function (): array {
+				$post_id  = static::factory()->post->create();
+				$about_to = $this->create_about_to_be_on_sale_tc_ticket( $post_id, 10 );
+
+				return [ $post_id, [ $about_to ], [] ];
+			},
+		];
+	}
+}

--- a/tests/square_integration/Syncs/Listeners_Test.php
+++ b/tests/square_integration/Syncs/Listeners_Test.php
@@ -137,7 +137,7 @@ class Listeners_Test extends Controller_Test_Case {
 				}
 
 				$post = get_post( $post_id );
-				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+				do_action( 'save_post', $post_id, $post, true );
 
 				return [ $post_id, true ];
 			},
@@ -148,7 +148,7 @@ class Listeners_Test extends Controller_Test_Case {
 				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
 
 				$post = get_post( $post_id );
-				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+				do_action( 'save_post', $post_id, $post, true );
 
 				return [ $post_id, false ];
 			},
@@ -163,7 +163,7 @@ class Listeners_Test extends Controller_Test_Case {
 				] );
 
 				$post = get_post( $post_id );
-				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+				do_action( 'save_post', $post_id, $post, true );
 
 				return [ $post_id, false ];
 			},
@@ -177,7 +177,7 @@ class Listeners_Test extends Controller_Test_Case {
 				$this->set_fn_return( 'wp_is_post_revision', true );
 
 				$post = get_post( $post_id );
-				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+				do_action( 'save_post', $post_id, $post, true );
 
 				return [ $post_id, false ];
 			},
@@ -208,14 +208,6 @@ class Listeners_Test extends Controller_Test_Case {
 	}
 
 	public function schedule_sync_on_delete_data_provider(): Generator {
-		yield 'non-existent post does not schedule' => [
-			function (): array {
-				do_action( 'wp_trash_post', PHP_INT_MAX );
-
-				return [ null, null ];
-			},
-		];
-
 		yield 'draft post does not schedule' => [
 			function (): array {
 				$post_id = static::factory()->post->create( [ 'post_status' => 'draft' ] );

--- a/tests/square_integration/Syncs/Listeners_Test.php
+++ b/tests/square_integration/Syncs/Listeners_Test.php
@@ -1,0 +1,625 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Gateways\Square\Syncs;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Traits\With_Square_Sync_Enabled;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use TEC\Tickets\Commerce\Gateways\Square\Syncs\Controller as Syncs_Controller;
+use TEC\Tickets\Commerce\Gateways\Square\Syncs\Objects\Item;
+use TEC\Tickets\Commerce\Gateways\Square\Settings;
+use TEC\Tickets\Commerce\Settings as Commerce_Settings;
+use TEC\Tickets\Commerce\Meta as Commerce_Meta;
+use Tribe__Settings_Manager as Settings_Manager;
+use Closure;
+use Generator;
+use WP_Post;
+
+class Listeners_Test extends Controller_Test_Case {
+	use With_Uopz;
+	use With_Square_Sync_Enabled;
+	use Ticket_Maker;
+	use Order_Maker;
+
+	protected string $controller_class = Listeners::class;
+
+	/**
+	 * @test
+	 * @dataProvider schedule_sync_data_provider
+	 */
+	public function it_should_schedule_sync( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $parent_id, $should_schedule ] = $fixture();
+
+		if ( $should_schedule ) {
+			$this->assertTrue(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to be scheduled.'
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ?? 0 ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to NOT be scheduled.'
+			);
+		}
+	}
+
+	public function schedule_sync_data_provider(): Generator {
+		yield 'ticket with remote object ID schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				do_action( 'tec_tickets_ticket_upserted', $ticket_id, $post_id );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'ticket without remote object ID and sync completed schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				$ticket_able_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+				foreach ( $ticket_able_post_types as $ptype ) {
+					Commerce_Settings::set( Syncs_Controller::OPTION_SYNC_ACTIONS_COMPLETED, time(), [ $ptype ] );
+				}
+
+				do_action( 'tec_tickets_ticket_upserted', $ticket_id, $post_id );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'ticket without remote object ID and sync not completed does not schedule sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'tec_tickets_ticket_upserted', $ticket_id, $post_id );
+
+				return [ $post_id, false ];
+			},
+		];
+
+		yield 'null parent ID does not schedule sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'tec_tickets_ticket_upserted', $ticket_id, null );
+
+				return [ null, false ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_sync_on_save_data_provider
+	 */
+	public function it_should_schedule_sync_on_save( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $post_id, $should_schedule ] = $fixture();
+
+		if ( $should_schedule ) {
+			$this->assertTrue(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $post_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to be scheduled.'
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $post_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to NOT be scheduled.'
+			);
+		}
+	}
+
+	public function schedule_sync_on_save_data_provider(): Generator {
+		yield 'post with on-sale ticket and sync completed schedules sync' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				// Mark initial sync as completed so is_object_syncable returns true.
+				$ticket_able_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+				foreach ( $ticket_able_post_types as $ptype ) {
+					Commerce_Settings::set( Syncs_Controller::OPTION_SYNC_ACTIONS_COMPLETED, time(), [ $ptype ] );
+				}
+
+				$post = get_post( $post_id );
+				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'post without tickets does not schedule sync' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+				$post = get_post( $post_id );
+				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+
+				return [ $post_id, false ];
+			},
+		];
+
+		yield 'post with non-ticket-enabled post type does not schedule sync' => [
+			function (): array {
+				register_post_type( 'not_ticketed', [ 'public' => true ] );
+				$post_id = static::factory()->post->create( [
+					'post_status' => 'publish',
+					'post_type'   => 'not_ticketed',
+				] );
+
+				$post = get_post( $post_id );
+				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+
+				return [ $post_id, false ];
+			},
+		];
+
+		yield 'revision does not schedule sync' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				$this->set_fn_return( 'wp_is_post_revision', true );
+
+				$post = get_post( $post_id );
+				do_action( 'tec_tickets_ticket_able_post_upserted', $post_id, $post );
+
+				return [ $post_id, false ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_sync_on_delete_data_provider
+	 */
+	public function it_should_schedule_sync_on_delete( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $expected_hook, $expected_args ] = $fixture();
+
+		if ( $expected_hook ) {
+			$this->assertTrue(
+				as_has_scheduled_action( $expected_hook, $expected_args, Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				"Expected action '{$expected_hook}' to be scheduled."
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_DELETE_EVENT_ACTION, null, Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected no delete action to be scheduled.'
+			);
+		}
+	}
+
+	public function schedule_sync_on_delete_data_provider(): Generator {
+		yield 'non-existent post does not schedule' => [
+			function (): array {
+				do_action( 'wp_trash_post', PHP_INT_MAX );
+
+				return [ null, null ];
+			},
+		];
+
+		yield 'draft post does not schedule' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'draft' ] );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [ null, null ];
+			},
+		];
+
+		yield 'post type not in ticket-enabled types does not schedule' => [
+			function (): array {
+				register_post_type( 'unrelated_type', [ 'public' => true ] );
+				$post_id = static::factory()->post->create( [
+					'post_status' => 'publish',
+					'post_type'   => 'unrelated_type',
+				] );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [ null, null ];
+			},
+		];
+
+		yield 'ticket-enabled post without remote ID does not schedule' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [ null, null ];
+			},
+		];
+
+		yield 'ticket-enabled post with remote ID schedules deletion' => [
+			function (): array {
+				$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $post_id, Item::SQUARE_ID_META, 'square_event_123' );
+
+				do_action( 'wp_trash_post', $post_id );
+
+				return [ Items_Sync::HOOK_SYNC_DELETE_EVENT_ACTION, [ 0, 'square_event_123' ] ];
+			},
+		];
+
+		yield 'last sync-able ticket trashed schedules deletion for parent event' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_ticket_123' );
+				Commerce_Meta::set( $post_id, Item::SQUARE_ID_META, 'square_event_456' );
+
+				do_action( 'wp_trash_post', $ticket_id );
+
+				// The parent event should be scheduled for deletion since this was the last sync-able ticket.
+				return [ Items_Sync::HOOK_SYNC_DELETE_EVENT_ACTION, [ 0, 'square_event_456' ] ];
+			},
+		];
+
+		yield 'ticket trashed with multiple sync-able tickets schedules deletion for ticket only' => [
+			function (): array {
+				$post_id    = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id1 = $this->create_on_sale_tc_ticket( $post_id, 10 );
+				$ticket_id2 = $this->create_on_sale_tc_ticket( $post_id, 20 );
+
+				Commerce_Meta::set( $ticket_id1, Item::SQUARE_ID_META, 'square_ticket_1' );
+				Commerce_Meta::set( $ticket_id2, Item::SQUARE_ID_META, 'square_ticket_2' );
+
+				do_action( 'wp_trash_post', $ticket_id1 );
+
+				// Only the ticket should be deleted, not the parent event.
+				return [ Items_Sync::HOOK_SYNC_DELETE_EVENT_ACTION, [ 0, 'square_ticket_1' ] ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_sync_on_date_start_data_provider
+	 */
+	public function it_should_schedule_sync_on_date_start( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $parent_id, $should_schedule ] = $fixture();
+
+		if ( $should_schedule ) {
+			$this->assertTrue(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to be scheduled on date start.'
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to NOT be scheduled on date start.'
+			);
+		}
+	}
+
+	public function schedule_sync_on_date_start_data_provider(): Generator {
+		yield 'its_happening is true and ticket is synced schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				$post_parent = get_post( $post_id );
+
+				do_action( 'tec_tickets_ticket_start_date_trigger', $ticket_id, true, time() + HOUR_IN_SECONDS, $post_parent );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'its_happening is false but within about-to-go-on-sale window schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				$post_parent = get_post( $post_id );
+
+				// Timestamp close enough that time() >= $timestamp - about_to_go_to_sale_seconds.
+				$timestamp = time() + 5;
+
+				do_action( 'tec_tickets_ticket_start_date_trigger', $ticket_id, false, $timestamp, $post_parent );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'its_happening is false and outside about-to-go-on-sale window does not schedule' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				$post_parent = get_post( $post_id );
+
+				// Timestamp far in the future.
+				$timestamp = time() + DAY_IN_SECONDS;
+
+				do_action( 'tec_tickets_ticket_start_date_trigger', $ticket_id, false, $timestamp, $post_parent );
+
+				return [ $post_id, false ];
+			},
+		];
+
+		yield 'ticket not syncable does not schedule' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				$post_parent = get_post( $post_id );
+
+				do_action( 'tec_tickets_ticket_start_date_trigger', $ticket_id, true, time(), $post_parent );
+
+				return [ $post_id, false ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_sync_on_date_end_data_provider
+	 */
+	public function it_should_schedule_sync_on_date_end( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $parent_id, $should_schedule ] = $fixture();
+
+		if ( $should_schedule ) {
+			$this->assertTrue(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to be scheduled on date end.'
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to NOT be scheduled on date end.'
+			);
+		}
+	}
+
+	public function schedule_sync_on_date_end_data_provider(): Generator {
+		yield 'its_happening is true and ticket has remote ID schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				$post_parent = get_post( $post_id );
+
+				do_action( 'tec_tickets_ticket_end_date_trigger', $ticket_id, true, time(), $post_parent );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'its_happening is false does not schedule' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				$post_parent = get_post( $post_id );
+
+				do_action( 'tec_tickets_ticket_end_date_trigger', $ticket_id, false, time(), $post_parent );
+
+				return [ $post_id, false ];
+			},
+		];
+
+		yield 'ticket without remote ID does not schedule' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				$post_parent = get_post( $post_id );
+
+				do_action( 'tec_tickets_ticket_end_date_trigger', $ticket_id, true, time(), $post_parent );
+
+				return [ $post_id, false ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_ticket_sync_on_out_of_sync_data_provider
+	 */
+	public function it_should_schedule_ticket_sync_on_out_of_sync( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $ticket_id, $quantity, $state ] = $fixture();
+
+		$this->assertTrue(
+			as_has_scheduled_action( Inventory_Sync::HOOK_CHECK_TICKET_INVENTORY_SYNC, [ $ticket_id, $quantity, $state ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+			'Expected inventory sync check to be scheduled.'
+		);
+	}
+
+	public function schedule_ticket_sync_on_out_of_sync_data_provider(): Generator {
+		yield 'out of sync ticket schedules inventory check' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				do_action( 'tec_tickets_commerce_square_ticket_out_of_sync', $ticket_id, 5, 'IN_STOCK' );
+
+				return [ $ticket_id, 5, 'IN_STOCK' ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider schedule_ticket_sync_on_stock_changed_data_provider
+	 */
+	public function it_should_schedule_ticket_sync_on_stock_changed( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		[ $parent_id, $should_schedule ] = $fixture();
+
+		if ( $should_schedule ) {
+			$this->assertTrue(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, [ $parent_id ], Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to be scheduled on stock change.'
+			);
+		} else {
+			$this->assertFalse(
+				as_has_scheduled_action( Items_Sync::HOOK_SYNC_EVENT_ACTION, null, Syncs_Controller::AS_SYNC_ACTION_GROUP ),
+				'Expected sync to NOT be scheduled on stock change.'
+			);
+		}
+	}
+
+	public function schedule_ticket_sync_on_stock_changed_data_provider(): Generator {
+		yield 'valid ticket with remote ID schedules sync' => [
+			function (): array {
+				$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+				$ticket_id = $this->create_on_sale_tc_ticket( $post_id, 10 );
+
+				Commerce_Meta::set( $ticket_id, Item::SQUARE_ID_META, 'square_123' );
+
+				do_action( 'tec_tickets_ticket_stock_changed', $ticket_id );
+
+				return [ $post_id, true ];
+			},
+		];
+
+		yield 'invalid ticket ID does not schedule sync' => [
+			function (): array {
+				do_action( 'tec_tickets_ticket_stock_changed', PHP_INT_MAX );
+
+				return [ null, false ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider reset_sync_status_data_provider
+	 */
+	public function it_should_reset_sync_status_on_settings_change( Closure $fixture ): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$did_action_before = did_action( Listeners::HOOK_SYNC_RESET_SYNCED_POST_TYPE );
+
+		[ $expected_reset_action_count ] = $fixture();
+
+		remove_all_actions( 'tec_shutdown' );
+		do_action( 'tec_shutdown' );
+
+		$did_action_after = did_action( Listeners::HOOK_SYNC_RESET_SYNCED_POST_TYPE );
+
+		$this->assertSame(
+			$expected_reset_action_count,
+			$did_action_after - $did_action_before,
+			"Expected reset action to fire {$expected_reset_action_count} time(s)."
+		);
+	}
+
+	public function reset_sync_status_data_provider(): Generator {
+		yield 'sync disabled triggers global reset' => [
+			function (): array {
+				$old_options = Settings_Manager::get_options();
+
+				$new_options = $old_options;
+				unset( $new_options[ Settings::OPTION_INVENTORY_SYNC ] );
+
+				do_action( 'tec_common_settings_manager_pre_set_options', $new_options, $old_options );
+
+				return [ 1 ];
+			},
+		];
+
+		yield 'same post types does not trigger reset' => [
+			function (): array {
+				$old_options = Settings_Manager::get_options();
+				$new_options = $old_options;
+
+				$new_options[ Settings::OPTION_INVENTORY_SYNC ] = true;
+
+				do_action( 'tec_common_settings_manager_pre_set_options', $new_options, $old_options );
+
+				return [ 0 ];
+			},
+		];
+
+		yield 'removed post type triggers per-type reset' => [
+			function (): array {
+				$ticket_able_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+
+				$old_options = Settings_Manager::get_options();
+				$old_options['ticket-enabled-post-types'] = $ticket_able_post_types;
+
+				$new_options = $old_options;
+				$new_options[ Settings::OPTION_INVENTORY_SYNC ] = true;
+
+				// Remove a post type.
+				array_pop( $ticket_able_post_types );
+				$new_options['ticket-enabled-post-types'] = $ticket_able_post_types;
+
+				do_action( 'tec_common_settings_manager_pre_set_options', $new_options, $old_options );
+
+				return [ 1 ];
+			},
+		];
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_unsync_on_merchant_disconnected(): void {
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$did_action_before = did_action( Listeners::HOOK_SYNC_RESET_SYNCED_POST_TYPE );
+
+		do_action( 'tec_tickets_commerce_square_merchant_disconnected' );
+
+		remove_all_actions( 'tec_shutdown' );
+		do_action( 'tec_shutdown' );
+
+		$did_action_after = did_action( Listeners::HOOK_SYNC_RESET_SYNCED_POST_TYPE );
+
+		$this->assertGreaterThan(
+			$did_action_before,
+			$did_action_after,
+			'Expected reset action to fire after merchant disconnect.'
+		);
+	}
+}

--- a/tests/square_integration/Syncs/Regulator_Test.php
+++ b/tests/square_integration/Syncs/Regulator_Test.php
@@ -197,6 +197,4 @@ class Regulator_Test extends Controller_Test_Case {
 
 		return as_get_scheduled_actions( $args );
 	}
-
-	protected function assert_rescheduled_after_rate_limit() {}
 }

--- a/tests/square_integration/Syncs/Syncs_Controller_Test.php
+++ b/tests/square_integration/Syncs/Syncs_Controller_Test.php
@@ -91,27 +91,6 @@ class Syncs_Controller_Test extends Controller_Test_Case {
 	/**
 	 * @test
 	 */
-	public function it_should_get_sync_able_tickets_of_event(): void {
-		$post = self::factory()->post->create();
-		$ticket_id_1 = $this->create_on_sale_tc_ticket( $post, 10 );
-		$ticket_id_2 = $this->create_about_to_be_on_sale_tc_ticket( $post, 20 );
-		$ticket_id_3 = $this->create_pre_sale_tc_ticket( $post, 30 );
-		$ticket_id_4 = $this->create_after_sales_tc_ticket( $post, 40 );
-
-		$tickets = Controller::get_sync_able_tickets_of_event( $post );
-
-		$ticket_ids = array_map( fn( $ticket ) => $ticket->ID, $tickets );
-
-		$this->assertCount( 3, $tickets );
-		$this->assertContains( $ticket_id_1, $ticket_ids );
-		$this->assertContains( $ticket_id_2, $ticket_ids );
-		$this->assertNotContains( $ticket_id_3, $ticket_ids );
-		$this->assertContains( $ticket_id_4, $ticket_ids );
-	}
-
-	/**
-	 * @test
-	 */
 	public function it_should_get_ticket_able_post_types_to_sync(): void {
 		$ptypes = Controller::ticket_able_post_types_to_sync();
 


### PR DESCRIPTION
### 🎫 Ticket

SOFT-3451
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Documentation [here](https://docs.google.com/document/d/1cNA12rgQ9PPT6D0vqwPv1E7rAlhUH86p87HRHyePR00/edit?tab=t.nr1o1ebl8cxd#heading=h.z1pswaeubkp7) has also been updated.

**QA will also need to verify existing Square functionality** that remains unchanged based on the abstractions that took place per the list below.

Specifically what has been abstracted:

- `get_sync_able_tickets_of_event` method was moved to be part of the `Ticket_Data` class.
- `Ticket_Able_Post_Actions` class introduced which is now firing `tec_tickets_ticket_able_post_deleted`, `tec_tickets_ticket_deleted`, `tec_tickets_ticket_able_post_upserted`, `tec_tickets_ticket_able_post_updated` and `tec_tickets_ticket_able_post_created`.
- Square listeners for ticket-able post type changes was moved to listen for `tec_tickets_ticket_able_post_upserted.
- Square listeners for ticket-able and ticket deletions were moved to listen for `tec_tickets_ticket_able_post_deleted` and `tec_tickets_ticket_deleted` respectably.

Additional test coverage was added for already existing functionality (square listeners) to ensure that we continue to fire those as expected.

Of course, test coverage for the new abstractions has been included as well.

### 🎥 Artifacts <!-- if applicable-->
Low level changes, so only their tests or the implementation of the introduced actions can serve as artifact.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
