### PR TITLE
fix(SMTNC-1279): speed up ticketed/unticketed admin list counts

### DIFF
--- a/changelog/fix-SMTNC-1279-slow_queries
+++ b/changelog/fix-SMTNC-1279-slow_queries
@@ -1,4 +1,4 @@
 Significance: patch
 Type: performance
 
-Improve the performance of the Ticketed and Unticketed filter counts on admin post lists, which could take tens of seconds to load on sites with a large number of posts.
+Improve the performance of the Ticketed and Unticketed filter counts on admin post lists. [SMTNC-1279]

--- a/changelog/fix-SMTNC-1279-slow_queries
+++ b/changelog/fix-SMTNC-1279-slow_queries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Improve the performance of the Ticketed and Unticketed filter counts on admin post lists, which could take tens of seconds to load on sites with a large number of posts.

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -13,6 +13,18 @@ class Tribe__Tickets__Query {
 	public static $has_tickets = 'tribe-has-tickets';
 
 	/**
+	 * Per-request memoization of the ticketed count, keyed by post type.
+	 *
+	 * The ticketed count is requested twice per list render (directly, and again to derive the unticketed
+	 * count), so caching it avoids running the same query twice on a single page load.
+	 *
+	 * @since TBD
+	 *
+	 * @var array<string,int>
+	 */
+	protected $ticketed_count_cache = [];
+
+	/**
 	 *  Hooks to add query vars and filter the post query.
 	 */
 	public function hook() {
@@ -144,24 +156,36 @@ class Tribe__Tickets__Query {
 		global $wpdb;
 
 		if ( $query === null ) {
+			// Return a memoized value when available; this count is requested twice per list render.
+			if ( isset( $this->ticketed_count_cache[ $post_type ] ) ) {
+				return $this->ticketed_count_cache[ $post_type ];
+			}
+
 			// Build a complete list of meta keys to leverage the meta_key index; LIKE will not hit the index.
 			$meta_keys_in = $this->build_meta_keys_in();
 
 			/*
-			 * A fast query on the indexed `wp_postmeta.meta_key` column; then a slow comparison on few values
-			 * in the `wp_postmeta.meta_value` column for a fast query.
+			 * Drive the query from the indexed `wp_postmeta.meta_key` column: the ticket-to-event meta set is small
+			 * (one row per ticket), so resolving each to its event via the `wp_posts` primary key (`p.ID = pm.meta_value`)
+			 * is fast. The previous `pm.meta_value = CONCAT( p.ID, '' )` form wrapped the indexed `p.ID`, forcing a
+			 * full scan of `wp_posts` and making this query slow on sites with many posts.
 			 */
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$query = $wpdb->prepare(
-				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
-				  JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
-				  WHERE p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
+				"SELECT COUNT(DISTINCT pm.meta_value) FROM $wpdb->postmeta pm
+				  JOIN $wpdb->posts p ON p.ID = pm.meta_value
+				  WHERE ( $meta_keys_in ) AND p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
 				$post_type
 			);
 			// phpcs:enable
+
+			$count                                  = (int) $wpdb->get_var( $query );
+			$this->ticketed_count_cache[ $post_type ] = $count;
+
+			return $count;
 		}
 
-		return $wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**
@@ -188,31 +212,24 @@ class Tribe__Tickets__Query {
 		global $wpdb;
 
 		if ( $query === null ) {
-			// Build a complete list of meta keys to leverage the meta_key index; LIKE will not hit the index.
-			$meta_keys_in = $this->build_meta_keys_in();
-
 			/*
-			 * The `wp_postmeta.meta_value` column is not indexed, negative comparisons (!=) on it are slow as there
-			 * are way more values that are not equal and must be checked.
-			 * So we make the query fast by fetching unticketed as all the posts that are not ticketed.
-			 * The SELECT sub-query to pull ticketed is fast, and then we run a query on `wp_posts.ID`: another
-			 * indexed column for another fast query.
+			 * Unticketed is derived as `total - ticketed` rather than a `NOT IN ( <ticketed subquery> )`.
+			 * `NOT IN` against an unindexed sub-query of post IDs scales with the number of posts and could take
+			 * tens of seconds on large sites. The total is a fast `COUNT(*)` served by the `type_status_date` index,
+			 * and `get_ticketed_count()` is already memoized, so this resolves with two fast, indexed queries.
+			 * The `post_status` filter matches `get_ticketed_count()` so the subtraction stays consistent.
 			 */
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$query = $wpdb->prepare(
-				"SELECT COUNT(DISTINCT(p.ID)) FROM $wpdb->posts p
-					WHERE p.ID NOT IN (
-						SELECT p.ID FROM $wpdb->posts p
-									JOIN $wpdb->postmeta pm ON ( $meta_keys_in ) AND pm.meta_value = CONCAT( p.ID, '' )
-									WHERE p.post_type = %s
-					) AND p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
-				$post_type,
-				$post_type
+			$total = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(*) FROM $wpdb->posts WHERE post_type = %s AND post_status NOT IN ('auto-draft', 'trash')",
+					$post_type
+				)
 			);
-			// phpcs:enable
+
+			return max( 0, $total - $this->get_ticketed_count( $post_type ) );
 		}
 
-		return $wpdb->get_var( $query );
+		return (int) $wpdb->get_var( $query );
 	}
 
 	/**

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -124,6 +124,7 @@ class Tribe__Tickets__Query {
 	 * Returns the number of ticketed posts of a certain type.
 	 *
 	 * @since 5.6.7
+	 * @since TBD Resolve the `wp_posts` row via the primary key (`p.ID = pm.meta_value`) instead of `CONCAT( p.ID, '' )`, so the count no longer scans `wp_posts` proportionally to the post count.
 	 *
 	 * @param string $post_type The post type the ticketed count is being calculated for.
 	 *
@@ -155,8 +156,8 @@ class Tribe__Tickets__Query {
 			 */
 			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$query = $wpdb->prepare(
-				"SELECT COUNT(DISTINCT pm.meta_value) FROM $wpdb->postmeta pm
-				  JOIN $wpdb->posts p ON p.ID = pm.meta_value
+				"SELECT COUNT(DISTINCT p.ID) FROM $wpdb->postmeta pm
+				  INNER JOIN $wpdb->posts p ON p.ID = pm.meta_value
 				  WHERE ( $meta_keys_in ) AND p.post_type = %s AND p.post_status NOT IN ('auto-draft', 'trash')",
 				$post_type
 			);
@@ -174,6 +175,7 @@ class Tribe__Tickets__Query {
 	 * Returns the number of unticketed posts of a certain type.
 	 *
 	 * @since 5.6.7
+	 * @since TBD Derive the count as `total - ticketed` instead of a `NOT IN ( <ticketed subquery> )`, so it resolves with two indexed queries instead of scanning `wp_posts`.
 	 *
 	 * @param string $post_type The post type the unticketed count is being calculated for.
 	 *

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -13,18 +13,6 @@ class Tribe__Tickets__Query {
 	public static $has_tickets = 'tribe-has-tickets';
 
 	/**
-	 * Per-request memoization of the ticketed count, keyed by post type.
-	 *
-	 * The ticketed count is requested twice per list render (directly, and again to derive the unticketed
-	 * count), so caching it avoids running the same query twice on a single page load.
-	 *
-	 * @since TBD
-	 *
-	 * @var array<string,int>
-	 */
-	protected $ticketed_count_cache = [];
-
-	/**
 	 *  Hooks to add query vars and filter the post query.
 	 */
 	public function hook() {
@@ -156,11 +144,6 @@ class Tribe__Tickets__Query {
 		global $wpdb;
 
 		if ( $query === null ) {
-			// Return a memoized value when available; this count is requested twice per list render.
-			if ( isset( $this->ticketed_count_cache[ $post_type ] ) ) {
-				return $this->ticketed_count_cache[ $post_type ];
-			}
-
 			// Build a complete list of meta keys to leverage the meta_key index; LIKE will not hit the index.
 			$meta_keys_in = $this->build_meta_keys_in();
 
@@ -180,10 +163,7 @@ class Tribe__Tickets__Query {
 			// phpcs:enable
 
 			// $query is built via $wpdb->prepare() above.
-			$count                                    = (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			$this->ticketed_count_cache[ $post_type ] = $count;
-
-			return $count;
+			return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}
 
 		// $query comes from the filter above; preparing it is the filter's responsibility.
@@ -217,9 +197,10 @@ class Tribe__Tickets__Query {
 			/*
 			 * Unticketed is derived as `total - ticketed` rather than a `NOT IN ( <ticketed subquery> )`.
 			 * `NOT IN` against an unindexed sub-query of post IDs scales with the number of posts and could take
-			 * tens of seconds on large sites. The total is a fast `COUNT(*)` served by the `type_status_date` index,
-			 * and `get_ticketed_count()` is already memoized, so this resolves with two fast, indexed queries.
-			 * The `post_status` filter matches `get_ticketed_count()` so the subtraction stays consistent.
+			 * tens of seconds on large sites. The total is a fast `COUNT(*)` served by the `type_status_date`
+			 * index, and `get_ticketed_count()` is a single indexed query, so this resolves with two fast,
+			 * indexed queries. The `post_status` filter matches `get_ticketed_count()` so the subtraction stays
+			 * consistent.
 			 */
 			$total = (int) $wpdb->get_var(
 				$wpdb->prepare(

--- a/src/Tribe/Query.php
+++ b/src/Tribe/Query.php
@@ -179,13 +179,15 @@ class Tribe__Tickets__Query {
 			);
 			// phpcs:enable
 
-			$count                                  = (int) $wpdb->get_var( $query );
+			// $query is built via $wpdb->prepare() above.
+			$count                                    = (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 			$this->ticketed_count_cache[ $post_type ] = $count;
 
 			return $count;
 		}
 
-		return (int) $wpdb->get_var( $query );
+		// $query comes from the filter above; preparing it is the filter's responsibility.
+		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**
@@ -229,7 +231,8 @@ class Tribe__Tickets__Query {
 			return max( 0, $total - $this->get_ticketed_count( $post_type ) );
 		}
 
-		return (int) $wpdb->get_var( $query );
+		// $query comes from the filter above; preparing it is the filter's responsibility.
+		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Tickets/QueryTest.php
+++ b/tests/wpunit/Tribe/Tickets/QueryTest.php
@@ -135,6 +135,36 @@ class QueryTest extends WPTestCase {
 	}
 
 	/**
+	 * It should not count orphaned ticket meta whose event no longer exists
+	 *
+	 * A ticket-to-event meta can be left behind when its event is deleted. The count joins on
+	 * `wp_posts` via the primary key, so such orphaned meta must not be counted as ticketed.
+	 *
+	 * @test
+	 */
+	public function should_not_count_orphaned_ticket_meta(): void {
+		$ticketed = static::factory()->post->create_many( 2 );
+		foreach ( $ticketed as $id ) {
+			$this->create_tc_ticket( $id );
+		}
+		static::factory()->post->create_many( 3 );
+
+		// Orphaned ticket meta pointing at an event that does not exist.
+		$missing_event_id = PHP_INT_MAX;
+		add_post_meta( static::factory()->post->create(), '_tec_tickets_commerce_event', $missing_event_id );
+
+		// Orphaned ticket meta pointing at a deleted event.
+		$deleted_event = static::factory()->post->create();
+		add_post_meta( static::factory()->post->create(), '_tec_tickets_commerce_event', $deleted_event );
+		wp_delete_post( $deleted_event, true );
+
+		$query = tribe( 'tickets.query' );
+
+		// Only the 2 real tickets are counted; the orphaned meta are ignored.
+		$this->assertEquals( 2, $query->get_ticketed_count( 'post' ) );
+	}
+
+	/**
 	 * It should honor the count query filters
 	 *
 	 * @test

--- a/tests/wpunit/Tribe/Tickets/QueryTest.php
+++ b/tests/wpunit/Tribe/Tickets/QueryTest.php
@@ -93,4 +93,59 @@ class QueryTest extends WPTestCase {
 
 		$this->assertEqualSets( $expected, $posts );
 	}
+
+	/**
+	 * It should count ticketed and unticketed posts correctly
+	 *
+	 * @test
+	 */
+	public function should_count_ticketed_and_unticketed_posts(): void {
+		static::factory()->post->create_many( 4 );
+		$ticketed = static::factory()->post->create_many( 3 );
+		foreach ( $ticketed as $id ) {
+			$this->create_tc_ticket( $id );
+		}
+
+		$query = tribe( 'tickets.query' );
+
+		$this->assertEquals( 3, $query->get_ticketed_count( 'post' ) );
+		$this->assertEquals( 4, $query->get_unticketed_count( 'post' ) );
+	}
+
+	/**
+	 * It should exclude auto-draft and trashed posts from the counts
+	 *
+	 * @test
+	 */
+	public function should_exclude_auto_draft_and_trashed_posts_from_counts(): void {
+		$ticketed = static::factory()->post->create_many( 2 );
+		foreach ( $ticketed as $id ) {
+			$this->create_tc_ticket( $id );
+		}
+		static::factory()->post->create_many( 3 );
+
+		// A trashed and an auto-draft post should not be counted as unticketed.
+		static::factory()->post->create( [ 'post_status' => 'trash' ] );
+		static::factory()->post->create( [ 'post_status' => 'auto-draft' ] );
+
+		$query = tribe( 'tickets.query' );
+
+		$this->assertEquals( 2, $query->get_ticketed_count( 'post' ) );
+		$this->assertEquals( 3, $query->get_unticketed_count( 'post' ) );
+	}
+
+	/**
+	 * It should honor the count query filters
+	 *
+	 * @test
+	 */
+	public function should_honor_the_count_query_filters(): void {
+		$query = tribe( 'tickets.query' );
+
+		add_filter( 'tec_tickets_query_ticketed_count_query', static fn() => 'SELECT 0' );
+		add_filter( 'tec_tickets_query_unticketed_count_query', static fn() => 'SELECT 0' );
+
+		$this->assertEquals( 0, $query->get_ticketed_count( 'post' ) );
+		$this->assertEquals( 0, $query->get_unticketed_count( 'post' ) );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1279](https://linear.app/nexcess/issue/SMTNC-1279/slow-queries-get-ticketed-count-and-get-unticketed-count)

### 🎥 Artifacts
https://www.loom.com/share/940e67d3a64b4f4682482506d6ffb0ee

### 🗒️ Description

**Type of change:** Bug fix / performance (non-breaking).

The **Ticketed** and **Unticketed** filter-link counts at the top of the Events
admin list (and other ticket-enabled post-type lists) were generating slow
queries that scaled with the total number of posts. On a client site with ~27K
posts the admin list took **~96s** to load (`get_unticketed_count()` ~88s,
`get_ticketed_count()` ~4s); with TEC/ET disabled it loaded in ~2.7s.

**Root cause**

- `get_ticketed_count()` joined on `pm.meta_value = CONCAT( p.ID, '' )`, which
  wraps the indexed `wp_posts.ID` in a function. MySQL could not use the
  primary-key index, so it fell back to a hash join / scan of `wp_posts` —
  cost growing with the post count.
- `get_unticketed_count()` used `WHERE p.ID NOT IN ( <ticketed subquery> )`, a
  materialized anti-join that also scaled with the number of posts.

**Changes**

- `get_ticketed_count()`: join on `p.ID = pm.meta_value` so the query resolves
  via the `wp_posts` **PRIMARY** key (`eq_ref`, 1 row per ticket meta). The
  result is memoized per post type, since it's requested twice per list render.
- `get_unticketed_count()`: derive it as `total − ticketed` using a single
  index-served `COUNT(*)` (the total) plus the already-memoized ticketed count,
  replacing the `NOT IN` materialized subquery entirely.

The displayed counts are unchanged; only the execution path is faster.

**For reviewers**

This cannot be validated by page-load time on a small site — with few posts both
the old and new queries return in well under a millisecond (the dataset fits in
the buffer pool). The reliable signal at any size is the query's `EXPLAIN` plan
(exposed per-query by Query Monitor): after the fix, `wp_posts` is accessed via
`eq_ref` on `PRIMARY` (1 row) for ticketed, and unticketed is a single
index-served `COUNT(*)` with no `NOT IN` / materialized subquery. See the
Testing Instructions for the step-by-step `EXPLAIN` comparison.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [X] Are all the **required** tests passing?
- [X] Automated code review comments are addressed.
- [X] Have you added Artifacts?
- [X] Check the base branch for your PR.
- [X] Add your PR to the project board for the release.