### PR TITLE
Backfill RSVP V2 test coverage (metabox order, responses info, attendee report)

### DIFF
--- a/tests/rsvp_v2_integration.suite.dist.yml
+++ b/tests/rsvp_v2_integration.suite.dist.yml
@@ -15,6 +15,7 @@ modules:
       domain: %WP_DOMAIN%
       adminEmail: admin@tribe.localhost
       title: 'Event Tickets RSVP v2 Tests'
+      theme: twentytwenty
       configFile: tests/rsvp_v2_integration/config.php
       plugins:
         - the-events-calendar/the-events-calendar.php

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -136,89 +136,104 @@ class Attendees_Test extends WPTestCase {
 		}
 	}
 
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_returns_args_unchanged_when_context_is_not_get_my_tickets_link_data(): void {
-		$post_id = static::factory()->post->create();
-		$this->create_tc_rsvp_ticket( $post_id );
+	/**
+	 * Each fixture returns [ $args, $post_id, $user_id, $context ]; the flag is whether the
+	 * RSVP-exclusion filter should be added for that combination.
+	 */
+	public static function exclude_rsvp_tickets_data_provider(): array {
+		return [
+			'unchanged for non-matching context' => [
+				function () {
+					$post_id = static::factory()->post->create();
+					$this->create_tc_rsvp_ticket( $post_id );
 
-		$attendees = tribe( Attendees::class );
-		$args      = [ 'by' => [ 'event' => $post_id ] ];
+					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'other_context' ];
+				},
+				false,
+			],
 
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, null, 'other_context' );
+			'unchanged for null context' => [
+				function () {
+					$post_id = static::factory()->post->create();
+					$this->create_tc_rsvp_ticket( $post_id );
 
-		$this->assertEquals( $args, $result );
-		$this->assertArrayNotHasKey( 'meta_not_equals', $result['by'] );
-	}
+					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, null ];
+				},
+				false,
+			],
 
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_returns_args_unchanged_when_context_is_null(): void {
-		$post_id = static::factory()->post->create();
-		$this->create_tc_rsvp_ticket( $post_id );
+			'adds filter for tc provider' => [
+				function () {
+					$post_id = static::factory()->post->create();
+					$this->create_tc_rsvp_ticket( $post_id );
 
-		$attendees = tribe( Attendees::class );
-		$args      = [ 'by' => [ 'event' => $post_id ] ];
+					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'get_my_tickets_link_data' ];
+				},
+				true,
+			],
 
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, null, null );
+			'preserves existing args' => [
+				function () {
+					$post_id = static::factory()->post->create();
+					$this->create_tc_rsvp_ticket( $post_id );
 
-		$this->assertEquals( $args, $result );
-		$this->assertArrayNotHasKey( 'meta_not_equals', $result['by'] );
-	}
+					return [
+						[ 'by' => [ 'event' => $post_id, 'status' => 'completed' ] ],
+						$post_id,
+						null,
+						'get_my_tickets_link_data',
+					];
+				},
+				true,
+			],
 
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_adds_meta_not_equals_filter_for_tc_provider(): void {
-		$post_id = static::factory()->post->create();
-		$this->create_tc_rsvp_ticket( $post_id );
+			'adds filter with user id' => [
+				function () {
+					$post_id = static::factory()->post->create();
+					$user_id = static::factory()->user->create();
+					$this->create_tc_rsvp_ticket( $post_id );
 
-		$attendees = tribe( Attendees::class );
-		$args      = [ 'by' => [ 'event' => $post_id ] ];
+					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, $user_id, 'get_my_tickets_link_data' ];
+				},
+				true,
+			],
 
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, null, 'get_my_tickets_link_data' );
+			'adds filter for post without provider' => [
+				function () {
+					// No ticket created, so no provider. An empty provider means TC.
+					$post_id = static::factory()->post->create();
 
-		$this->assertArrayHasKey( 'meta_not_equals', $result['by'] );
-		$this->assertEquals( [ '_type', Constants::TC_RSVP_TYPE ], $result['by']['meta_not_equals'] );
-	}
-
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_preserves_existing_args(): void {
-		$post_id = static::factory()->post->create();
-		$this->create_tc_rsvp_ticket( $post_id );
-
-		$attendees = tribe( Attendees::class );
-		$args      = [
-			'by' => [
-				'event'  => $post_id,
-				'status' => 'completed',
+					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'get_my_tickets_link_data' ];
+				},
+				true,
 			],
 		];
-
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, null, 'get_my_tickets_link_data' );
-
-		$this->assertEquals( $post_id, $result['by']['event'] );
-		$this->assertEquals( 'completed', $result['by']['status'] );
-		$this->assertArrayHasKey( 'meta_not_equals', $result['by'] );
 	}
 
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_works_with_user_id(): void {
-		$post_id = static::factory()->post->create();
-		$user_id = static::factory()->user->create();
-		$this->create_tc_rsvp_ticket( $post_id );
+	/**
+	 * @dataProvider exclude_rsvp_tickets_data_provider
+	 */
+	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count( Closure $fixture, bool $adds_filter ): void {
+		[ $args, $post_id, $user_id, $context ] = Closure::bind( $fixture, $this, self::class )();
 
 		$attendees = tribe( Attendees::class );
-		$args      = [ 'by' => [ 'event' => $post_id ] ];
 
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, $user_id, 'get_my_tickets_link_data' );
+		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, $user_id, $context );
+
+		if ( ! $adds_filter ) {
+			$this->assertEquals( $args, $result );
+			$this->assertArrayNotHasKey( 'meta_not_equals', $result['by'] );
+
+			return;
+		}
 
 		$this->assertArrayHasKey( 'meta_not_equals', $result['by'] );
 		$this->assertEquals( [ '_type', Constants::TC_RSVP_TYPE ], $result['by']['meta_not_equals'] );
-	}
 
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count_adds_filter_for_post_without_provider(): void {
-		$post_id = static::factory()->post->create();
-		// No ticket created, so no provider. An empty provider means TC.
-
-		$attendees = tribe( Attendees::class );
-		$args      = [ 'by' => [ 'event' => $post_id ] ];
-
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, null, 'get_my_tickets_link_data' );
-
-		$this->assertArrayHasKey( 'meta_not_equals', $result['by'] );
-		$this->assertEquals( [ '_type', Constants::TC_RSVP_TYPE ], $result['by']['meta_not_equals'] );
+		// The original `by` args are preserved alongside the added filter.
+		foreach ( $args['by'] as $key => $value ) {
+			$this->assertEquals( $value, $result['by'][ $key ] );
+		}
 	}
 
 	public function test_get_rsvp_attendees_by_id_bails_when_attendees_already_filtered(): void {
@@ -256,74 +271,162 @@ class Attendees_Test extends WPTestCase {
 		];
 	}
 
-	public function test_modify_status_display_returns_label_unchanged_for_non_rsvp_item(): void {
+	/**
+	 * Each fixture returns an attendees-table row item for which the status label should be
+	 * returned unchanged (non-RSVP rows, or RSVP rows that carry no attendee ID).
+	 */
+	public static function modify_status_display_unchanged_data_provider(): array {
+		return [
+			'non-rsvp item' => [
+				function () {
+					return [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+				},
+			],
+
+			'rsvp item without attendee id' => [
+				function () {
+					return [ 'ticket_type' => Constants::TC_RSVP_TYPE ];
+				},
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider modify_status_display_unchanged_data_provider
+	 */
+	public function test_modify_status_display_returns_label_unchanged( Closure $fixture ): void {
+		$item      = Closure::bind( $fixture, $this, self::class )();
 		$attendees = tribe( Attendees::class );
-		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
 
 		$this->assertSame( 'ORIGINAL', $attendees->modify_status_display( 'ORIGINAL', $item ) );
 	}
 
-	public function test_modify_status_display_returns_label_unchanged_without_attendee_id(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = [ 'ticket_type' => Constants::TC_RSVP_TYPE ];
+	/**
+	 * Each fixture returns an RSVP row item; the test asserts the rendered label, its CSS class
+	 * and, where relevant, a label that must NOT appear.
+	 */
+	public static function modify_status_display_label_data_provider(): array {
+		return [
+			'going label' => [
+				function () {
+					return $this->make_rsvp_item( 'yes' );
+				},
+				'Going',
+				'tec-tickets__admin-table-attendees-order-status--going',
+				'Not Going',
+			],
 
-		$this->assertSame( 'ORIGINAL', $attendees->modify_status_display( 'ORIGINAL', $item ) );
+			'not going label' => [
+				function () {
+					return $this->make_rsvp_item( 'no' );
+				},
+				'Not Going',
+				'tec-tickets__admin-table-attendees-order-status--not-going',
+				null,
+			],
+
+			'resolves attendee from id key' => [
+				function () {
+					return $this->make_rsvp_item( 'yes', 'ID' );
+				},
+				'Going',
+				'tec-tickets__admin-table-attendees-order-status--going',
+				'Not Going',
+			],
+		];
 	}
 
-	public function test_modify_status_display_shows_going_label(): void {
+	/**
+	 * @dataProvider modify_status_display_label_data_provider
+	 */
+	public function test_modify_status_display_shows_label( Closure $fixture, string $expected_label, string $expected_class, ?string $not_expected ): void {
+		$item      = Closure::bind( $fixture, $this, self::class )();
 		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'yes' );
 
 		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
 
-		$this->assertStringContainsString( 'Going', $output );
-		$this->assertStringNotContainsString( 'Not Going', $output );
-		$this->assertStringContainsString( 'tec-tickets__admin-table-attendees-order-status--going', $output );
+		$this->assertStringContainsString( $expected_label, $output );
+		$this->assertStringContainsString( $expected_class, $output );
+
+		if ( null !== $not_expected ) {
+			$this->assertStringNotContainsString( $not_expected, $output );
+		}
 	}
 
-	public function test_modify_status_display_shows_not_going_label(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'no' );
+	/**
+	 * Each fixture returns a row item; the expected value is what the check-in cell should render
+	 * for it (content is hidden only for "not going" RSVP attendees).
+	 */
+	public static function modify_checkin_display_data_provider(): array {
+		return [
+			'non-rsvp item keeps content' => [
+				function () {
+					return [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+				},
+				'CONTENT',
+			],
 
-		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
+			'going attendee keeps content' => [
+				function () {
+					return $this->make_rsvp_item( 'yes' );
+				},
+				'CONTENT',
+			],
 
-		$this->assertStringContainsString( 'Not Going', $output );
-		$this->assertStringContainsString( 'tec-tickets__admin-table-attendees-order-status--not-going', $output );
+			'not going attendee hides content' => [
+				function () {
+					return $this->make_rsvp_item( 'no' );
+				},
+				'',
+			],
+		];
 	}
 
-	public function test_modify_status_display_resolves_attendee_from_id_key(): void {
+	/**
+	 * @dataProvider modify_checkin_display_data_provider
+	 */
+	public function test_modify_checkin_display( Closure $fixture, string $expected ): void {
+		$item      = Closure::bind( $fixture, $this, self::class )();
 		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'yes', 'ID' );
 
-		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
-
-		$this->assertStringContainsString( 'Going', $output );
+		$this->assertSame( $expected, $attendees->modify_checkin_display( 'CONTENT', $item ) );
 	}
 
-	public function test_modify_checkin_display_keeps_content_for_non_rsvp_item(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+	/**
+	 * Each fixture returns a row item; the flag is whether the check-in row action should survive
+	 * (it is removed only for "not going" RSVP attendees). The delete action is always kept.
+	 */
+	public static function modify_row_actions_data_provider(): array {
+		return [
+			'going attendee keeps checkin' => [
+				function () {
+					return $this->make_rsvp_item( 'yes' );
+				},
+				true,
+			],
 
-		$this->assertSame( 'CONTENT', $attendees->modify_checkin_display( 'CONTENT', $item ) );
+			'not going attendee loses checkin' => [
+				function () {
+					return $this->make_rsvp_item( 'no' );
+				},
+				false,
+			],
+
+			'non-rsvp item unchanged' => [
+				function () {
+					return [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+				},
+				true,
+			],
+		];
 	}
 
-	public function test_modify_checkin_display_keeps_content_for_going_attendee(): void {
+	/**
+	 * @dataProvider modify_row_actions_data_provider
+	 */
+	public function test_modify_row_actions( Closure $fixture, bool $keeps_checkin ): void {
+		$item      = Closure::bind( $fixture, $this, self::class )();
 		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'yes' );
-
-		$this->assertSame( 'CONTENT', $attendees->modify_checkin_display( 'CONTENT', $item ) );
-	}
-
-	public function test_modify_checkin_display_hides_content_for_not_going_attendee(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'no' );
-
-		$this->assertSame( '', $attendees->modify_checkin_display( 'CONTENT', $item ) );
-	}
-
-	public function test_modify_row_actions_keeps_checkin_for_going_attendee(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'yes' );
 		$actions   = [
 			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
 			'delete'          => '<a class="delete">Delete</a>',
@@ -331,32 +434,12 @@ class Attendees_Test extends WPTestCase {
 
 		$result = $attendees->modify_row_actions( $actions, $item );
 
-		$this->assertArrayHasKey( 'tickets_checkin', $result );
 		$this->assertArrayHasKey( 'delete', $result );
-	}
 
-	public function test_modify_row_actions_removes_checkin_for_not_going_attendee(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = $this->make_rsvp_item( 'no' );
-		$actions   = [
-			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
-			'delete'          => '<a class="delete">Delete</a>',
-		];
-
-		$result = $attendees->modify_row_actions( $actions, $item );
-
-		$this->assertArrayNotHasKey( 'tickets_checkin', $result );
-		$this->assertArrayHasKey( 'delete', $result );
-	}
-
-	public function test_modify_row_actions_leaves_actions_unchanged_for_non_rsvp_item(): void {
-		$attendees = tribe( Attendees::class );
-		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
-		$actions   = [
-			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
-			'delete'          => '<a class="delete">Delete</a>',
-		];
-
-		$this->assertSame( $actions, $attendees->modify_row_actions( $actions, $item ) );
+		if ( $keeps_checkin ) {
+			$this->assertArrayHasKey( 'tickets_checkin', $result );
+		} else {
+			$this->assertArrayNotHasKey( 'tickets_checkin', $result );
+		}
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -233,4 +233,130 @@ class Attendees_Test extends WPTestCase {
 
 		$this->assertSame( $pre_filtered_value, $result );
 	}
+
+	/**
+	 * Creates a TC RSVP attendee and returns an attendees-table row item pointing at it.
+	 *
+	 * @param string $rsvp_status The RSVP status meta to stamp ('yes' or 'no').
+	 * @param string $id_key      Which row key carries the attendee ID ('attendee_id' or 'ID').
+	 *
+	 * @return array<string,mixed> The row item.
+	 */
+	private function make_rsvp_item( string $rsvp_status, string $id_key = 'attendee_id' ): array {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$attendee_id = 'no' === $rsvp_status
+			? $this->create_not_going_tc_rsvp_attendees( 1, $ticket_id, $post_id )[0]
+			: $this->create_going_tc_rsvp_attendees( 1, $ticket_id, $post_id )[0];
+
+		return [
+			'ticket_type' => Constants::TC_RSVP_TYPE,
+			$id_key       => $attendee_id,
+		];
+	}
+
+	public function test_modify_status_display_returns_label_unchanged_for_non_rsvp_item(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+
+		$this->assertSame( 'ORIGINAL', $attendees->modify_status_display( 'ORIGINAL', $item ) );
+	}
+
+	public function test_modify_status_display_returns_label_unchanged_without_attendee_id(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = [ 'ticket_type' => Constants::TC_RSVP_TYPE ];
+
+		$this->assertSame( 'ORIGINAL', $attendees->modify_status_display( 'ORIGINAL', $item ) );
+	}
+
+	public function test_modify_status_display_shows_going_label(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'yes' );
+
+		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
+
+		$this->assertStringContainsString( 'Going', $output );
+		$this->assertStringNotContainsString( 'Not Going', $output );
+		$this->assertStringContainsString( 'tec-tickets__admin-table-attendees-order-status--going', $output );
+	}
+
+	public function test_modify_status_display_shows_not_going_label(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'no' );
+
+		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
+
+		$this->assertStringContainsString( 'Not Going', $output );
+		$this->assertStringContainsString( 'tec-tickets__admin-table-attendees-order-status--not-going', $output );
+	}
+
+	public function test_modify_status_display_resolves_attendee_from_id_key(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'yes', 'ID' );
+
+		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
+
+		$this->assertStringContainsString( 'Going', $output );
+	}
+
+	public function test_modify_checkin_display_keeps_content_for_non_rsvp_item(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+
+		$this->assertSame( 'CONTENT', $attendees->modify_checkin_display( 'CONTENT', $item ) );
+	}
+
+	public function test_modify_checkin_display_keeps_content_for_going_attendee(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'yes' );
+
+		$this->assertSame( 'CONTENT', $attendees->modify_checkin_display( 'CONTENT', $item ) );
+	}
+
+	public function test_modify_checkin_display_hides_content_for_not_going_attendee(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'no' );
+
+		$this->assertSame( '', $attendees->modify_checkin_display( 'CONTENT', $item ) );
+	}
+
+	public function test_modify_row_actions_keeps_checkin_for_going_attendee(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'yes' );
+		$actions   = [
+			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
+			'delete'          => '<a class="delete">Delete</a>',
+		];
+
+		$result = $attendees->modify_row_actions( $actions, $item );
+
+		$this->assertArrayHasKey( 'tickets_checkin', $result );
+		$this->assertArrayHasKey( 'delete', $result );
+	}
+
+	public function test_modify_row_actions_removes_checkin_for_not_going_attendee(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = $this->make_rsvp_item( 'no' );
+		$actions   = [
+			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
+			'delete'          => '<a class="delete">Delete</a>',
+		];
+
+		$result = $attendees->modify_row_actions( $actions, $item );
+
+		$this->assertArrayNotHasKey( 'tickets_checkin', $result );
+		$this->assertArrayHasKey( 'delete', $result );
+	}
+
+	public function test_modify_row_actions_leaves_actions_unchanged_for_non_rsvp_item(): void {
+		$attendees = tribe( Attendees::class );
+		$item      = [ 'ticket_type' => 'default', 'attendee_id' => 123 ];
+		$actions   = [
+			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',
+			'delete'          => '<a class="delete">Delete</a>',
+		];
+
+		$this->assertSame( $actions, $attendees->modify_row_actions( $actions, $item ) );
+	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -15,7 +15,7 @@ class Attendees_Test extends WPTestCase {
 	use Attendee_Maker;
 	use Order_Maker;
 
-	public static function get_rsvp_attendees_data_provider(): array {
+	public function get_rsvp_attendees_data_provider(): array {
 		return [
 			'no attendees' => [
 				function () {
@@ -100,7 +100,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider get_rsvp_attendees_data_provider
 	 */
 	public function test_get_rsvp_attendees_by_id_with_ticket_id( Closure $fixture ): void {
-		[ , $ticket_id, , $expected_attendees_ids ] = Closure::bind( $fixture, $this, self::class )();
+		[ , $ticket_id, , $expected_attendees_ids ] = $fixture();
 
 		$attendees = tribe( Attendees::class );
 
@@ -113,7 +113,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider get_rsvp_attendees_data_provider
 	 */
 	public function test_get_rsvp_attendees_by_id_with_post_id( Closure $fixture ): void {
-		[ $post_id, , , $expected_attendees_ids ] = Closure::bind( $fixture, $this, self::class )();
+		[ $post_id, , , $expected_attendees_ids ] = $fixture();
 
 		$attendees = tribe( Attendees::class );
 
@@ -126,7 +126,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider get_rsvp_attendees_data_provider
 	 */
 	public function test_get_rsvp_attendees_by_id_with_order_id( Closure $fixture ): void {
-		[ $post_id, , $order_ids ] = Closure::bind( $fixture, $this, self::class )();
+		[ $post_id, , $order_ids ] = $fixture();
 
 		$attendees = tribe( Attendees::class );
 
@@ -140,7 +140,7 @@ class Attendees_Test extends WPTestCase {
 	 * Each fixture returns [ $args, $post_id, $user_id, $context ]; the flag is whether the
 	 * RSVP-exclusion filter should be added for that combination.
 	 */
-	public static function exclude_rsvp_tickets_data_provider(): array {
+	public function exclude_rsvp_tickets_data_provider(): array {
 		return [
 			'unchanged for non-matching context' => [
 				function () {
@@ -214,7 +214,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider exclude_rsvp_tickets_data_provider
 	 */
 	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count( Closure $fixture, bool $adds_filter ): void {
-		[ $args, $post_id, $user_id, $context ] = Closure::bind( $fixture, $this, self::class )();
+		[ $args, $post_id, $user_id, $context ] = $fixture();
 
 		$attendees = tribe( Attendees::class );
 
@@ -275,7 +275,7 @@ class Attendees_Test extends WPTestCase {
 	 * Each fixture returns an attendees-table row item for which the status label should be
 	 * returned unchanged (non-RSVP rows, or RSVP rows that carry no attendee ID).
 	 */
-	public static function modify_status_display_unchanged_data_provider(): array {
+	public function modify_status_display_unchanged_data_provider(): array {
 		return [
 			'non-rsvp item' => [
 				function () {
@@ -295,7 +295,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider modify_status_display_unchanged_data_provider
 	 */
 	public function test_modify_status_display_returns_label_unchanged( Closure $fixture ): void {
-		$item      = Closure::bind( $fixture, $this, self::class )();
+		$item      = $fixture();
 		$attendees = tribe( Attendees::class );
 
 		$this->assertSame( 'ORIGINAL', $attendees->modify_status_display( 'ORIGINAL', $item ) );
@@ -305,7 +305,7 @@ class Attendees_Test extends WPTestCase {
 	 * Each fixture returns an RSVP row item; the test asserts the rendered label, its CSS class
 	 * and, where relevant, a label that must NOT appear.
 	 */
-	public static function modify_status_display_label_data_provider(): array {
+	public function modify_status_display_label_data_provider(): array {
 		return [
 			'going label' => [
 				function () {
@@ -340,7 +340,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider modify_status_display_label_data_provider
 	 */
 	public function test_modify_status_display_shows_label( Closure $fixture, string $expected_label, string $expected_class, ?string $not_expected ): void {
-		$item      = Closure::bind( $fixture, $this, self::class )();
+		$item      = $fixture();
 		$attendees = tribe( Attendees::class );
 
 		$output = $attendees->modify_status_display( 'ORIGINAL', $item );
@@ -357,7 +357,7 @@ class Attendees_Test extends WPTestCase {
 	 * Each fixture returns a row item; the expected value is what the check-in cell should render
 	 * for it (content is hidden only for "not going" RSVP attendees).
 	 */
-	public static function modify_checkin_display_data_provider(): array {
+	public function modify_checkin_display_data_provider(): array {
 		return [
 			'non-rsvp item keeps content' => [
 				function () {
@@ -386,7 +386,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider modify_checkin_display_data_provider
 	 */
 	public function test_modify_checkin_display( Closure $fixture, string $expected ): void {
-		$item      = Closure::bind( $fixture, $this, self::class )();
+		$item      = $fixture();
 		$attendees = tribe( Attendees::class );
 
 		$this->assertSame( $expected, $attendees->modify_checkin_display( 'CONTENT', $item ) );
@@ -396,7 +396,7 @@ class Attendees_Test extends WPTestCase {
 	 * Each fixture returns a row item; the flag is whether the check-in row action should survive
 	 * (it is removed only for "not going" RSVP attendees). The delete action is always kept.
 	 */
-	public static function modify_row_actions_data_provider(): array {
+	public function modify_row_actions_data_provider(): array {
 		return [
 			'going attendee keeps checkin' => [
 				function () {
@@ -425,7 +425,7 @@ class Attendees_Test extends WPTestCase {
 	 * @dataProvider modify_row_actions_data_provider
 	 */
 	public function test_modify_row_actions( Closure $fixture, bool $keeps_checkin ): void {
-		$item      = Closure::bind( $fixture, $this, self::class )();
+		$item      = $fixture();
 		$attendees = tribe( Attendees::class );
 		$actions   = [
 			'tickets_checkin' => '<a class="tickets_checkin">Check In</a>',

--- a/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
@@ -10,12 +10,36 @@ use TEC\Tickets\Commerce\Module as Commerce;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 use Tribe\Tests\Traits\With_Clock_Mock;
 use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
 use Tribe__Date_Utils as Date_Utils;
+use Tribe__Tickets__Main;
 
 class Metabox_Test extends WPTestCase {
 	use SnapshotAssertions;
 	use Ticket_Maker;
+	use Order_Maker;
 	use With_Uopz;
+
+	/**
+	 * Backup of the global $wp_meta_boxes, restored after each test.
+	 *
+	 * @var mixed
+	 */
+	private $wp_meta_boxes_backup;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_meta_boxes;
+		$this->wp_meta_boxes_backup = $wp_meta_boxes;
+	}
+
+	public function tearDown(): void {
+		global $wp_meta_boxes;
+		$wp_meta_boxes = $this->wp_meta_boxes_backup;
+
+		parent::tearDown();
+	}
 
 	public function render_data_provider(): Generator {
 		yield 'post without RSVP' => [
@@ -135,5 +159,223 @@ class Metabox_Test extends WPTestCase {
 		$html_from_obj = $metabox->render( $post );
 
 		$this->assertSame( $html_from_int, $html_from_obj );
+	}
+
+	/**
+	 * Returns the first ticket-enabled post type, used to seed the metabox global.
+	 *
+	 * @return string
+	 */
+	private function first_ticketable_post_type(): string {
+		$post_types = Tribe__Tickets__Main::instance()->post_types();
+
+		return (string) reset( $post_types );
+	}
+
+	/**
+	 * Seeds the global $wp_meta_boxes `normal`/`high` group for a post type.
+	 *
+	 * @param string               $post_type The post type to seed.
+	 * @param array<string,mixed>  $boxes     Map of box id => box definition, in registration order.
+	 *
+	 * @return void
+	 */
+	private function seed_meta_boxes( string $post_type, array $boxes ): void {
+		global $wp_meta_boxes;
+
+		$wp_meta_boxes = [
+			$post_type => [
+				'normal' => [
+					'high' => $boxes,
+				],
+			],
+		];
+	}
+
+	/**
+	 * @test
+	 *
+	 * Tickets, RSVP, and (e.g.) Waitlist all register into normal/high. When another box
+	 * lands between Tickets and RSVP, the RSVP box should be moved to sit right after Tickets.
+	 */
+	public function it_should_move_the_rsvp_box_directly_after_the_tickets_box(): void {
+		$post_type = $this->first_ticketable_post_type();
+
+		$this->seed_meta_boxes(
+			$post_type,
+			[
+				'tribetickets'              => [ 'id' => 'tribetickets' ],
+				'tribe-waitlist'            => [ 'id' => 'tribe-waitlist' ],
+				'tec-tickets-commerce-rsvp' => [ 'id' => 'tec-tickets-commerce-rsvp' ],
+			]
+		);
+
+		tribe( Metabox::class )->reorder_after_tickets_metabox( $post_type );
+
+		global $wp_meta_boxes;
+		$this->assertSame(
+			[ 'tribetickets', 'tec-tickets-commerce-rsvp', 'tribe-waitlist' ],
+			array_keys( $wp_meta_boxes[ $post_type ]['normal']['high'] )
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * When the RSVP box already follows the Tickets box, the order must be left untouched.
+	 */
+	public function it_should_be_a_no_op_when_rsvp_already_follows_tickets(): void {
+		$post_type = $this->first_ticketable_post_type();
+
+		$this->seed_meta_boxes(
+			$post_type,
+			[
+				'tribetickets'              => [ 'id' => 'tribetickets' ],
+				'tec-tickets-commerce-rsvp' => [ 'id' => 'tec-tickets-commerce-rsvp' ],
+				'tribe-waitlist'            => [ 'id' => 'tribe-waitlist' ],
+			]
+		);
+
+		tribe( Metabox::class )->reorder_after_tickets_metabox( $post_type );
+
+		global $wp_meta_boxes;
+		$this->assertSame(
+			[ 'tribetickets', 'tec-tickets-commerce-rsvp', 'tribe-waitlist' ],
+			array_keys( $wp_meta_boxes[ $post_type ]['normal']['high'] )
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * The reorder must bail on post types that cannot have tickets, leaving their boxes alone.
+	 */
+	public function it_should_bail_for_a_non_ticketable_post_type(): void {
+		$post_type = 'tec_not_ticketable';
+
+		$this->seed_meta_boxes(
+			$post_type,
+			[
+				'tribetickets'              => [ 'id' => 'tribetickets' ],
+				'tribe-waitlist'            => [ 'id' => 'tribe-waitlist' ],
+				'tec-tickets-commerce-rsvp' => [ 'id' => 'tec-tickets-commerce-rsvp' ],
+			]
+		);
+
+		tribe( Metabox::class )->reorder_after_tickets_metabox( $post_type );
+
+		global $wp_meta_boxes;
+		$this->assertSame(
+			[ 'tribetickets', 'tribe-waitlist', 'tec-tickets-commerce-rsvp' ],
+			array_keys( $wp_meta_boxes[ $post_type ]['normal']['high'] )
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * With no RSVP box registered there is nothing to move, so the group is left untouched.
+	 */
+	public function it_should_bail_when_the_rsvp_box_is_missing(): void {
+		$post_type = $this->first_ticketable_post_type();
+
+		$this->seed_meta_boxes(
+			$post_type,
+			[
+				'tribetickets'   => [ 'id' => 'tribetickets' ],
+				'tribe-waitlist' => [ 'id' => 'tribe-waitlist' ],
+			]
+		);
+
+		tribe( Metabox::class )->reorder_after_tickets_metabox( $post_type );
+
+		global $wp_meta_boxes;
+		$this->assertSame(
+			[ 'tribetickets', 'tribe-waitlist' ],
+			array_keys( $wp_meta_boxes[ $post_type ]['normal']['high'] )
+		);
+	}
+
+	/**
+	 * Captures the echoed output of Metabox::display_responses_info().
+	 *
+	 * @param int|\WP_Post $post_id     The event the RSVP is attached to.
+	 * @param string       $ticket_type The ticket type the form is being rendered for.
+	 * @param int|null     $rsvp_id     The RSVP ticket ID, or null when adding a new RSVP.
+	 *
+	 * @return string The trimmed output.
+	 */
+	private function capture_responses_info( $post_id, string $ticket_type, $rsvp_id ): string {
+		ob_start();
+		tribe( Metabox::class )->display_responses_info( $post_id, $ticket_type, $rsvp_id );
+
+		return trim( (string) ob_get_clean() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_render_the_response_count_and_view_attendees_link(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$rsvp_id = $this->create_tc_rsvp_ticket( $post_id );
+		$this->create_order( [ $rsvp_id => 3 ] );
+
+		$output = $this->capture_responses_info( $post_id, Constants::TC_RSVP_TYPE, $rsvp_id );
+
+		$this->assertStringContainsString( 'tec-tickets-rsvp-responses-info__wrap', $output );
+		$this->assertMatchesRegularExpression( '/tec-tickets-rsvp-total-count">\s*3\s*</', $output );
+		$this->assertStringContainsString( 'View Attendees', $output );
+		// "Not going" tooltip stays hidden unless show_not_going is enabled.
+		$this->assertStringNotContainsString( 'dashicons-info', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_show_the_not_going_tooltip_when_show_not_going_is_enabled(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$rsvp_id = $this->create_tc_rsvp_ticket( $post_id );
+		update_post_meta( $rsvp_id, Constants::SHOW_NOT_GOING_META_KEY, '1' );
+		$this->create_order( [ $rsvp_id => 1 ] );
+
+		$output = $this->capture_responses_info( $post_id, Constants::TC_RSVP_TYPE, $rsvp_id );
+
+		$this->assertStringContainsString( 'dashicons-info', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_render_responses_info_for_a_non_rsvp_ticket_type(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$rsvp_id = $this->create_tc_rsvp_ticket( $post_id );
+		$this->create_order( [ $rsvp_id => 1 ] );
+
+		$output = $this->capture_responses_info( $post_id, 'default', $rsvp_id );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_render_responses_info_without_an_rsvp_id(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$output = $this->capture_responses_info( $post_id, Constants::TC_RSVP_TYPE, null );
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_render_responses_info_when_there_are_no_responses(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$rsvp_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$output = $this->capture_responses_info( $post_id, Constants::TC_RSVP_TYPE, $rsvp_id );
+
+		$this->assertSame( '', $output );
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
@@ -20,27 +20,6 @@ class Metabox_Test extends WPTestCase {
 	use Order_Maker;
 	use With_Uopz;
 
-	/**
-	 * Backup of the global $wp_meta_boxes, restored after each test.
-	 *
-	 * @var mixed
-	 */
-	private $wp_meta_boxes_backup;
-
-	public function setUp(): void {
-		parent::setUp();
-
-		global $wp_meta_boxes;
-		$this->wp_meta_boxes_backup = $wp_meta_boxes;
-	}
-
-	public function tearDown(): void {
-		global $wp_meta_boxes;
-		$wp_meta_boxes = $this->wp_meta_boxes_backup;
-
-		parent::tearDown();
-	}
-
 	public function render_data_provider(): Generator {
 		yield 'post without RSVP' => [
 			function (): array {

--- a/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Metabox_Test.php
@@ -323,7 +323,7 @@ class Metabox_Test extends WPTestCase {
 		$output = $this->capture_responses_info( $post_id, Constants::TC_RSVP_TYPE, $rsvp_id );
 
 		$this->assertStringContainsString( 'tec-tickets-rsvp-responses-info__wrap', $output );
-		$this->assertMatchesRegularExpression( '/tec-tickets-rsvp-total-count">\s*3\s*</', $output );
+		$this->assertRegExp( '/tec-tickets-rsvp-total-count">\s*3\s*</', $output );
 		$this->assertStringContainsString( 'View Attendees', $output );
 		// "Not going" tooltip stays hidden unless show_not_going is enabled.
 		$this->assertStringNotContainsString( 'dashicons-info', $output );


### PR DESCRIPTION
Follow-up test coverage requested on three merged RSVP V2 PRs:
- [SOFT-3430](https://linear.app/nexcess/issue/SOFT-3430) — metabox order (#4216)
- [SOFT-3431](https://linear.app/nexcess/issue/SOFT-3431) — responses count + View Attendees link (#4217)
- [SOFT-3432](https://linear.app/nexcess/issue/SOFT-3432) — Going/Not Going status + hide check-in (#4218)

## Description

Test-only follow-up — no production code changes. Backfills coverage for three RSVP V2 features that merged into `bucket/rsvp-merge` without dedicated tests.

- **`Metabox::reorder_after_tickets_metabox` (#4216):** verifies the RSVP box is moved to sit directly after the Tickets box, is a no-op when it already follows Tickets, and bails for non-ticketable post types or when a box is missing. (Reviewer asked whether reordering respects user preferences — the function only adjusts the default registration order; WordPress applies each user's saved order separately at render. These tests lock in the default-order behavior.)
- **`Metabox::display_responses_info` (#4217):** verifies it renders the response count + View Attendees link, shows the "not going" tooltip only when `show_not_going` is enabled, and renders nothing for a non-RSVP ticket type, a missing RSVP id, or zero responses.
- **Attendees report modifiers (#4218):** `modify_status_display` (Going / Not Going pill), `modify_checkin_display` (check-in hidden for not-going), and `modify_row_actions` (check-in action dropped for not-going), plus attendee-id resolution via the `ID` fallback and non-RSVP passthrough.

## Testing steps

1. `slic run rsvp_v2_integration RSVP/V2/Metabox_Test.php`
2. `slic run rsvp_v2_integration RSVP/V2/Attendees_Test.php`
3. Both suites should pass.

[skip-changelog]
