### PR TITLE
[SOFT-3334] Frontend: IAC-aware RSVP flow and TC-RSVP plumbing

### DIFF
--- a/src/Tickets/Admin/Tickets/List_Table.php
+++ b/src/Tickets/Admin/Tickets/List_Table.php
@@ -22,6 +22,7 @@ use Tribe__Tickets__Main;
 use WP_Post;
 use WP_Query;
 use TEC\Events_Pro\Custom_Tables\V1\Links\Provider as Custom_Tables_Links_Provider;
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 
 /**
  * Class List_Table.
@@ -439,15 +440,23 @@ class List_Table extends WP_List_Table {
 			return get_the_title( $item );
 		}
 
+		$ticket_name = $item->name;
+
+		// TC-RSVP tickets created before titles were enforced may have an empty name.
+		// Fall back to the generic "RSVP" label so the list always shows a meaningful value.
+		if ( empty( $ticket_name ) && method_exists( $item, 'type' ) && RSVP_V2_Constants::TC_RSVP_TYPE === $item->type() ) {
+			$ticket_name = _x( 'RSVP', 'Default TC-RSVP ticket name in the All Tickets list', 'event-tickets' );
+		}
+
 		$event = $item->get_event();
 		if ( ! $event ) {
-			return esc_html( $item->name );
+			return esc_html( $ticket_name );
 		}
 
 		$edit_post_link = sprintf(
 			'<a href="%s" class="tec-tickets-admin-tickets-table-event-link" target="_blank" rel="nofollow noopener">%s</a>',
 			esc_url( $this->get_event_edit_url( $event->ID ) ),
-			esc_html( $item->name )
+			esc_html( $ticket_name )
 		);
 
 		$template = $this->get_template();

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -87,7 +87,15 @@ class Frontend {
 			return $content;
 		}
 
-		// Allow extensions (e.g. ET+) to populate additional ticket properties such as IAC from meta.
+		/**
+		 * Filters a TC-RSVP ticket object to allow extensions to populate additional properties.
+		 *
+		 * @since TBD
+		 *
+		 * @param Tribe__Tickets__Ticket_Object $ticket    The ticket object.
+		 * @param int                           $event_id  The event post ID.
+		 * @param int                           $ticket_id The ticket post ID.
+		 */
 		$rsvp = apply_filters( 'tec_tickets_commerce_get_ticket_legacy', $rsvp, $post->ID, $rsvp->ID );
 
 		$rsvp_template_args = [

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -87,6 +87,9 @@ class Frontend {
 			return $content;
 		}
 
+		// Allow extensions (e.g. ET+) to populate additional ticket properties such as IAC from meta.
+		$rsvp = apply_filters( 'tec_tickets_commerce_get_ticket_legacy', $rsvp, $post->ID, $rsvp->ID );
+
 		$rsvp_template_args = [
 			'rsvp'          => $rsvp,
 			'post_id'       => $post->ID,
@@ -259,17 +262,9 @@ class Frontend {
 	 * @return bool True if the post has TC-RSVP tickets, false otherwise.
 	 */
 	private function post_has_tc_rsvp_tickets( int $post_id ): bool {
-		$tickets = $this->module->get_tickets( $post_id );
-
-		foreach ( $tickets as $ticket ) {
-			$ticket_type = get_post_meta( $ticket->ID, '_type', true );
-
-			if ( Constants::TC_RSVP_TYPE === $ticket_type ) {
-				return true;
-			}
-		}
-
-		return false;
+		return tribe( 'tickets.ticket-repository.rsvp' )
+			->by( 'event', $post_id )
+			->found();
 	}
 
 	/**

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -9,6 +9,7 @@
 
 use Tribe__Date_Utils as Dates;
 use Tribe__Repository__Interface as Repository_Interface;
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 
 // phpcs:disable StellarWP.Classes.ValidClassName.NotSnakeCase
 
@@ -310,6 +311,11 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		$post_id = (int) get_post_meta( $ticket_id, $this->get_event_key(), true );
 
+		// Fallback for TC-RSVP tickets which use a different event relation meta key.
+		if ( ! $post_id ) {
+			$post_id = (int) tribe_tickets( 'rsvp' )->get_event_id( $ticket_id );
+		}
+
 		// No post found, something went wrong.
 		if ( 0 === $post_id ) {
 			return '';
@@ -458,10 +464,14 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		// Add the rendering attributes into global context.
 		$template->add_template_globals( $args );
 
-		$html  = $template->template( 'v2/components/loader/loader', [ 'classes' => [] ], false );
-		$html .= $template->template( 'v2/rsvp/content', $args, false );
+		$html = $template->template( 'v2/components/loader/loader', [ 'classes' => [] ], false );
 
-		return $html;
+		// Use the TC-RSVP commerce template for TC-RSVP tickets.
+		$content_template = $ticket instanceof \Tribe__Tickets__Ticket_Object && RSVP_V2_Constants::TC_RSVP_TYPE === $ticket->type()
+			? 'v2/commerce/rsvp/content'
+			: 'v2/rsvp/content';
+
+		return $html . $template->template( $content_template, $args, false );
 	}
 
 	/**
@@ -2034,6 +2044,21 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		 * @param int                           $ticket_id The ticket ID.
 		 */
 		$ticket = apply_filters( 'tribe_tickets_rsvp_get_ticket', $ticket, $event_id, $ticket_id );
+
+		// For TC-RSVP tickets, fire the TC legacy filter so extensions (e.g. ET+) can populate
+		// additional properties such as IAC from meta.
+		if ( $ticket instanceof \Tribe__Tickets__Ticket_Object && RSVP_V2_Constants::TC_RSVP_TYPE === $ticket->type() ) {
+			/**
+			 * Filters a TC-RSVP ticket object to allow extensions to populate additional properties.
+			 *
+			 * @since TBD
+			 *
+			 * @param Tribe__Tickets__Ticket_Object $ticket    The ticket object.
+			 * @param int                           $event_id  The event post ID.
+			 * @param int                           $ticket_id The ticket post ID.
+			 */
+			$ticket = apply_filters( 'tec_tickets_commerce_get_ticket_legacy', $ticket, $event_id, $ticket_id );
+		}
 
 		// Set cache after filter is applied.
 		if ( $ticket instanceof \Tribe__Tickets__Ticket_Object ) {

--- a/src/resources/js/commerce/rsvp-block.js
+++ b/src/resources/js/commerce/rsvp-block.js
@@ -70,12 +70,12 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.bindGoing = function ( $container ) {
+		const rsvpId = $container.data( 'rsvp-id' );
 		let data = {
 			action: 'tribe_tickets_rsvp_handle',
 			ticket_id: rsvpId,
 			nonce: TecRsvp.nonces.rsvpHandle,
 		};
-		const rsvpId = $container.data( 'rsvp-id' );
 		const $goingButton = $container.find( obj.selectors.goingButton );
 
 		$goingButton.each( function ( index, button ) {
@@ -101,12 +101,12 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.bindNotGoing = function ( $container ) {
+		const rsvpId = $container.data( 'rsvp-id' );
 		let data = {
 			action: 'tribe_tickets_rsvp_handle',
 			ticket_id: rsvpId,
 			nonce: TecRsvp.nonces.rsvpHandle,
 		};
-		const rsvpId = $container.data( 'rsvp-id' );
 		const $notGoingButton = $container.find( obj.selectors.notGoingButton );
 
 		$notGoingButton.each( function ( index, button ) {

--- a/src/resources/js/commerce/rsvp-block.js
+++ b/src/resources/js/commerce/rsvp-block.js
@@ -49,6 +49,39 @@ window.tribe.tickets.rsvp.block = {};
 	};
 
 	/**
+	 * Returns the localStorage key for IAC for a given RSVP ticket ID.
+	 *
+	 * @since TBD
+	 *
+	 * @param {string|number} rsvpId The RSVP ticket ID.
+	 * @return {string}
+	 */
+	obj.iacStorageKey = function ( rsvpId ) {
+		return 'tec_rsvp_iac_' + rsvpId;
+	};
+
+	/**
+	 * Returns true when Individual Attendee Collection is active for this container.
+	 *
+	 * IAC is first read from localStorage (written by the admin modal save in
+	 * iac-admin.js) so the frontend can reflect a change immediately — before
+	 * the server-rendered `data-iac` attribute is updated on the next page load
+	 * after a post save. localStorage is cleared automatically in obj.ready()
+	 * once the server-rendered value catches up.
+	 *
+	 * @since TBD
+	 *
+	 * @param {jQuery} $container jQuery object of the RSVP container.
+	 * @return {boolean}
+	 */
+	obj.hasIac = function ( $container ) {
+		const rsvpId = $container.data( 'rsvp-id' );
+		const storedIac = rsvpId ? localStorage.getItem( obj.iacStorageKey( rsvpId ) ) : null;
+		const iac = storedIac !== null ? storedIac : $container.data( 'iac' );
+		return iac && iac !== 'none';
+	};
+
+	/**
 	 * Binds events for the going button.
 	 *
 	 * @since TBD
@@ -63,12 +96,22 @@ window.tribe.tickets.rsvp.block = {};
 
 		$goingButton.each( function ( index, button ) {
 			$( button ).on( 'click', function () {
-				data = {
-					action: 'tribe_tickets_rsvp_handle',
-					ticket_id: rsvpId,
-					step: 'going',
-					nonce: TecRsvp.nonces.rsvpHandle,
-				};
+				if ( obj.hasIac( $container ) ) {
+					data = {
+						action: 'tribe_tickets_rsvp_handle',
+						ticket_id: rsvpId,
+						step: 'ari',
+						going: 'going',
+						nonce: TecRsvp.nonces.rsvpHandle,
+					};
+				} else {
+					data = {
+						action: 'tribe_tickets_rsvp_handle',
+						ticket_id: rsvpId,
+						step: 'going',
+						nonce: TecRsvp.nonces.rsvpHandle,
+					};
+				}
 
 				tribe.tickets.rsvp.manager.request( data, $container );
 			} );
@@ -90,12 +133,22 @@ window.tribe.tickets.rsvp.block = {};
 
 		$notGoingButton.each( function ( index, button ) {
 			$( button ).on( 'click', function () {
-				data = {
-					action: 'tribe_tickets_rsvp_handle',
-					ticket_id: rsvpId,
-					step: 'not-going',
-					nonce: TecRsvp.nonces.rsvpHandle,
-				};
+				if ( obj.hasIac( $container ) ) {
+					data = {
+						action: 'tribe_tickets_rsvp_handle',
+						ticket_id: rsvpId,
+						step: 'ari',
+						going: 'not-going',
+						nonce: TecRsvp.nonces.rsvpHandle,
+					};
+				} else {
+					data = {
+						action: 'tribe_tickets_rsvp_handle',
+						ticket_id: rsvpId,
+						step: 'not-going',
+						nonce: TecRsvp.nonces.rsvpHandle,
+					};
+				}
 
 				tribe.tickets.rsvp.manager.request( data, $container );
 			} );
@@ -288,6 +341,31 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.ready = function () {
+		/*
+		 * Clear stale IAC localStorage entries. When the admin saves IAC via the
+		 * modal, the new value is written to localStorage so the frontend can reflect
+		 * it immediately (see iac-admin.js and obj.hasIac). Once the post is saved
+		 * and the page reloads, the server-rendered `data-iac` attribute reflects the
+		 * database value. At that point the localStorage entry is no longer needed
+		 * and is removed so the two sources cannot drift apart over time.
+		 */
+		$( obj.selectors.container ).each( function () {
+			const $container = $( this );
+			const rsvpId = $container.data( 'rsvp-id' );
+			if ( ! rsvpId ) {
+				return;
+			}
+			const key = obj.iacStorageKey( rsvpId );
+			const storedIac = localStorage.getItem( key );
+			if ( storedIac === null ) {
+				return;
+			}
+			const serverIac = $container.data( 'iac' ) || 'none';
+			if ( storedIac === serverIac ) {
+				localStorage.removeItem( key );
+			}
+		} );
+
 		$document.on( 'afterSetup.tribeTicketsRsvp', tribe.tickets.rsvp.manager.selectors.container, obj.init );
 	};
 

--- a/src/resources/js/commerce/rsvp-block.js
+++ b/src/resources/js/commerce/rsvp-block.js
@@ -49,25 +49,7 @@ window.tribe.tickets.rsvp.block = {};
 	};
 
 	/**
-	 * Returns the localStorage key for IAC for a given RSVP ticket ID.
-	 *
-	 * @since TBD
-	 *
-	 * @param {string|number} rsvpId The RSVP ticket ID.
-	 * @return {string}
-	 */
-	obj.iacStorageKey = function ( rsvpId ) {
-		return 'tec_rsvp_iac_' + rsvpId;
-	};
-
-	/**
 	 * Returns true when Individual Attendee Collection is active for this container.
-	 *
-	 * IAC is first read from localStorage (written by the admin modal save in
-	 * iac-admin.js) so the frontend can reflect a change immediately — before
-	 * the server-rendered `data-iac` attribute is updated on the next page load
-	 * after a post save. localStorage is cleared automatically in obj.ready()
-	 * once the server-rendered value catches up.
 	 *
 	 * @since TBD
 	 *
@@ -75,9 +57,7 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {boolean}
 	 */
 	obj.hasIac = function ( $container ) {
-		const rsvpId = $container.data( 'rsvp-id' );
-		const storedIac = rsvpId ? localStorage.getItem( obj.iacStorageKey( rsvpId ) ) : null;
-		const iac = storedIac !== null ? storedIac : $container.data( 'iac' );
+		const iac = $container.data( 'iac' );
 		return iac && iac !== 'none';
 	};
 
@@ -90,27 +70,21 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.bindGoing = function ( $container ) {
-		let data = {};
+		let data = {
+			action: 'tribe_tickets_rsvp_handle',
+			ticket_id: rsvpId,
+			nonce: TecRsvp.nonces.rsvpHandle,
+		};
 		const rsvpId = $container.data( 'rsvp-id' );
 		const $goingButton = $container.find( obj.selectors.goingButton );
 
 		$goingButton.each( function ( index, button ) {
 			$( button ).on( 'click', function () {
 				if ( obj.hasIac( $container ) ) {
-					data = {
-						action: 'tribe_tickets_rsvp_handle',
-						ticket_id: rsvpId,
-						step: 'ari',
-						going: 'going',
-						nonce: TecRsvp.nonces.rsvpHandle,
-					};
+					data.step = 'ari';
+					data.going = 'going';
 				} else {
-					data = {
-						action: 'tribe_tickets_rsvp_handle',
-						ticket_id: rsvpId,
-						step: 'going',
-						nonce: TecRsvp.nonces.rsvpHandle,
-					};
+					data.step = 'going';
 				}
 
 				tribe.tickets.rsvp.manager.request( data, $container );
@@ -127,27 +101,22 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.bindNotGoing = function ( $container ) {
-		let data = {};
+		let data = {
+			action: 'tribe_tickets_rsvp_handle',
+			ticket_id: rsvpId,
+			nonce: TecRsvp.nonces.rsvpHandle,
+		};
 		const rsvpId = $container.data( 'rsvp-id' );
 		const $notGoingButton = $container.find( obj.selectors.notGoingButton );
 
 		$notGoingButton.each( function ( index, button ) {
 			$( button ).on( 'click', function () {
 				if ( obj.hasIac( $container ) ) {
-					data = {
-						action: 'tribe_tickets_rsvp_handle',
-						ticket_id: rsvpId,
-						step: 'ari',
-						going: 'not-going',
-						nonce: TecRsvp.nonces.rsvpHandle,
-					};
+					data.step = 'ari';
+					data.going = 'not-going';
 				} else {
-					data = {
-						action: 'tribe_tickets_rsvp_handle',
-						ticket_id: rsvpId,
-						step: 'not-going',
-						nonce: TecRsvp.nonces.rsvpHandle,
-					};
+					data.step = 'not-going';
+
 				}
 
 				tribe.tickets.rsvp.manager.request( data, $container );
@@ -341,31 +310,6 @@ window.tribe.tickets.rsvp.block = {};
 	 * @return {void}
 	 */
 	obj.ready = function () {
-		/*
-		 * Clear stale IAC localStorage entries. When the admin saves IAC via the
-		 * modal, the new value is written to localStorage so the frontend can reflect
-		 * it immediately (see iac-admin.js and obj.hasIac). Once the post is saved
-		 * and the page reloads, the server-rendered `data-iac` attribute reflects the
-		 * database value. At that point the localStorage entry is no longer needed
-		 * and is removed so the two sources cannot drift apart over time.
-		 */
-		$( obj.selectors.container ).each( function () {
-			const $container = $( this );
-			const rsvpId = $container.data( 'rsvp-id' );
-			if ( ! rsvpId ) {
-				return;
-			}
-			const key = obj.iacStorageKey( rsvpId );
-			const storedIac = localStorage.getItem( key );
-			if ( storedIac === null ) {
-				return;
-			}
-			const serverIac = $container.data( 'iac' ) || 'none';
-			if ( storedIac === serverIac ) {
-				localStorage.removeItem( key );
-			}
-		} );
-
 		$document.on( 'afterSetup.tribeTicketsRsvp', tribe.tickets.rsvp.manager.selectors.container, obj.init );
 	};
 

--- a/src/views/v2/commerce/rsvp.php
+++ b/src/views/v2/commerce/rsvp.php
@@ -47,6 +47,7 @@ if ( empty( $active_rsvps ) ) {
 	<div
 		class="tribe-tickets__rsvp-wrapper"
 		data-rsvp-id="<?php echo esc_attr( $rsvp->ID ); ?>"
+		data-iac="<?php echo esc_attr( $rsvp->iac ); ?>"
 	>
 		<?php $this->template( 'v2/components/loader/loader' ); ?>
 		<?php $this->template( 'v2/commerce/rsvp/content', [ 'rsvp' => $rsvp ] ); ?>

--- a/src/views/v2/commerce/rsvp/actions/rsvp.php
+++ b/src/views/v2/commerce/rsvp/actions/rsvp.php
@@ -19,10 +19,6 @@
 defined( 'ABSPATH' ) || die();
 ?>
 <div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		<?php esc_html_e( 'RSVP Here', 'event-tickets' ); ?>
-	</span>
-
 	<?php $this->template( 'v2/commerce/rsvp/actions/rsvp/going', [ 'rsvp' => $rsvp ] ); ?>
 
 	<?php $this->template( 'v2/commerce/rsvp/actions/rsvp/not-going', [ 'rsvp' => $rsvp ] ); ?>

--- a/src/views/v2/commerce/rsvp/actions/success/toggle.php
+++ b/src/views/v2/commerce/rsvp/actions/success/toggle.php
@@ -16,12 +16,14 @@
  * @var string                        $opt_in_nonce         The nonce for opt-in AJAX requests.
  * @var boolean                       $opt_in_checked       Whether the opt-in field should be checked.
  *
+ * @var boolean|null                   $is_going             Whether the attendee is going. Null when unknown.
+ *
  * @since 5.0.0
  * @version 5.0.0
  */
 
 defined( 'ABSPATH' ) || die();
-if ( $opt_in_toggle_hidden ) {
+if ( $opt_in_toggle_hidden || false === $is_going ) {
 	return;
 }
 

--- a/src/views/v2/commerce/rsvp/actions/success/toggle.php
+++ b/src/views/v2/commerce/rsvp/actions/success/toggle.php
@@ -16,7 +16,7 @@
  * @var string                        $opt_in_nonce         The nonce for opt-in AJAX requests.
  * @var boolean                       $opt_in_checked       Whether the opt-in field should be checked.
  *
- * @var boolean|null                   $is_going             Whether the attendee is going. Null when unknown.
+ * @var bool|null                   $is_going             Whether the attendee is going. Null when unknown.
  *
  * @since 5.0.0
  * @version 5.0.0

--- a/src/views/v2/commerce/rsvp/actions/success/toggle.php
+++ b/src/views/v2/commerce/rsvp/actions/success/toggle.php
@@ -19,7 +19,7 @@
  * @var bool|null                   $is_going             Whether the attendee is going. Null when unknown.
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version TBD
  */
 
 defined( 'ABSPATH' ) || die();

--- a/src/views/v2/commerce/rsvp/ari/form/template/fields.php
+++ b/src/views/v2/commerce/rsvp/ari/form/template/fields.php
@@ -17,7 +17,11 @@
  */
 
 defined( 'ABSPATH' ) || die();
-if ( ! $rsvp->has_meta_enabled() ) {
+
+$iac_active = ! empty( $rsvp->iac ) && 'none' !== $rsvp->iac;
+$has_meta   = $rsvp->has_meta_enabled();
+
+if ( ! $iac_active && ! $has_meta ) {
 	return;
 }
 ?>
@@ -25,6 +29,7 @@ if ( ! $rsvp->has_meta_enabled() ) {
 
 	<?php $this->template( 'v2/commerce/rsvp/ari/form/error', [ 'rsvp' => $rsvp ] ); ?>
 
+	<?php if ( $has_meta ) : ?>
 	<?php
 		/**
 		 * Allows injection of meta fields in the RSVP ARI form template.
@@ -36,4 +41,5 @@ if ( ! $rsvp->has_meta_enabled() ) {
 		 */
 		$this->do_entry_point( 'rsvp_attendee_fields_template' );
 	?>
+	<?php endif; ?>
 </div>

--- a/src/views/v2/commerce/rsvp/attendees/attendee/name.php
+++ b/src/views/v2/commerce/rsvp/attendees/attendee/name.php
@@ -20,12 +20,14 @@
  * @version 5.7.1
  */
 
+use TEC\Tickets\Commerce\Attendee;
+
 defined( 'ABSPATH' ) || die();
 if ( empty( $attendees ) || empty( $attendee_id ) ) {
 	return;
 }
 
-$attendee_name = get_post_meta( $attendee_id, tribe( Tribe__Tickets__RSVP::class )->full_name, true );
+$attendee_name = get_post_meta( $attendee_id, Attendee::$full_name_meta_key, true );
 if ( empty( $attendee_name ) ) {
 	return;
 }

--- a/src/views/v2/commerce/rsvp/details/title.php
+++ b/src/views/v2/commerce/rsvp/details/title.php
@@ -19,5 +19,5 @@
 defined( 'ABSPATH' ) || die();
 ?>
 <h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	<?php echo esc_html( $rsvp->name ); ?>
+	<?php echo esc_html( tribe_get_rsvp_label_singular( 'rsvp_block_details_title' ) ); ?>
 </h3>

--- a/tests/rsvp_v2_integration/RSVP/V2/Classic_Editor_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Classic_Editor_Test.php
@@ -343,7 +343,6 @@ class Classic_Editor_Test extends WPTestCase {
 		tribe( Classic_Editor::class )->save_rsvp_on_post_save( $post_id );
 
 		$_POST = $saved_post;
-		remove_filter( 'tec_tickets_rsvp_v2_classic_save_data', $callback );
 
 		return $captured;
 	}

--- a/tests/rsvp_v2_integration/RSVP/V2/Commerce_Templates_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Commerce_Templates_Test.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe__Tickets__RSVP as Legacy_RSVP;
+
+/**
+ * Integration snapshot tests for TC-RSVP commerce templates rendered via production code paths.
+ */
+class Commerce_Templates_Test extends WPTestCase {
+	use SnapshotAssertions;
+	use Ticket_Maker;
+
+	/**
+	 * Replaces post IDs with placeholders for stable snapshots.
+	 *
+	 * @param string $snapshot The snapshot HTML.
+	 * @param array  $ids      Map of placeholder name to post ID value.
+	 *
+	 * @return string The snapshot with placeholders.
+	 */
+	private function placehold_post_ids( string $snapshot, array $ids ): string {
+		$ids = array_filter( $ids, static fn( $id ) => $id !== null );
+
+		$html = str_replace(
+			array_map( 'strval', array_values( $ids ) ),
+			array_map( static fn( string $name ) => "{{ $name }}", array_keys( $ids ) ),
+			$snapshot
+		);
+
+		return preg_replace( '/id="tc-rsvp[^"]+"/', 'id="{{ BLOCK_HTML_ID }}"', $html );
+	}
+
+	public function test_rsvp_wrapper_outputs_data_iac_attribute(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$rsvp      = tribe( Module::class )->get_ticket( $post_id, $ticket_id );
+
+		add_filter(
+			'tec_tickets_commerce_get_ticket_legacy',
+			static function ( $ticket ) {
+				$ticket->iac = 'required';
+
+				return $ticket;
+			},
+			10,
+			3
+		);
+
+		$template = tribe( 'tickets.editor.template' );
+		// Mirrors Tickets_View::get_rsvp_block() global context before the frontend filter runs.
+		$template->set( 'threshold', tribe( 'tickets.editor.blocks.rsvp' )->get_threshold( $post_id ) );
+
+		$html = apply_filters(
+			'tec_tickets_front_end_rsvp_form_template_content',
+			'',
+			[
+				'active_rsvps' => [ $rsvp ],
+			],
+			$template,
+			get_post( $post_id ),
+			false
+		);
+
+		$this->assertNotEmpty( $html, 'Frontend RSVP template should render TC-RSVP output.' );
+
+		$html = $this->placehold_post_ids(
+			$html,
+			[
+				'POST_ID'   => $post_id,
+				'TICKET_ID' => $ticket_id,
+			]
+		);
+
+		$this->assertMatchesHtmlSnapshot( $html );
+	}
+
+	public function test_details_title_uses_rsvp_label_singular(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, [ 'ticket_name' => 'Custom Ticket Name' ] );
+
+		$html = tribe( Legacy_RSVP::class )->render_rsvp_step( $ticket_id, 'rsvp' );
+
+		$this->assertNotEmpty( $html, 'render_rsvp_step should render TC-RSVP commerce content.' );
+
+		$html = $this->placehold_post_ids(
+			$html,
+			[
+				'POST_ID'   => $post_id,
+				'TICKET_ID' => $ticket_id,
+			]
+		);
+
+		$this->assertMatchesHtmlSnapshot( $html );
+	}
+}

--- a/tests/rsvp_v2_integration/RSVP/V2/Legacy_RSVP_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Legacy_RSVP_Test.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as Classic_RSVP_Ticket_Maker;
+use Tribe__Tickets__RSVP as Legacy_RSVP;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
+
+/**
+ * Tests for legacy RSVP module behavior with TC-RSVP tickets.
+ */
+class Legacy_RSVP_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Classic_RSVP_Ticket_Maker;
+
+	/**
+	 * @var Legacy_RSVP
+	 */
+	private Legacy_RSVP $rsvp;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->rsvp = tribe( Legacy_RSVP::class );
+	}
+
+	public function test_get_ticket_applies_commerce_legacy_filter_for_tc_rsvp(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$filter_called = false;
+		$filter        = function ( $ticket, $event_id, $filtered_ticket_id ) use ( &$filter_called, $post_id, $ticket_id ) {
+			$filter_called = true;
+			$this->assertSame( $post_id, $event_id );
+			$this->assertSame( $ticket_id, $filtered_ticket_id );
+			$this->assertInstanceOf( Ticket_Object::class, $ticket );
+			$ticket->iac = 'required';
+
+			return $ticket;
+		};
+
+		add_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter, 10, 3 );
+
+		wp_cache_flush();
+
+		$ticket = $this->rsvp->get_ticket( $post_id, $ticket_id );
+
+		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
+
+		$this->assertInstanceOf( Ticket_Object::class, $ticket );
+		$this->assertSame( Constants::TC_RSVP_TYPE, $ticket->type() );
+		$this->assertTrue( $filter_called, 'Legacy commerce filter should run for TC-RSVP tickets.' );
+		$this->assertSame( 'required', $ticket->iac );
+	}
+
+	public function test_get_ticket_does_not_apply_commerce_legacy_filter_for_classic_rsvp(): void {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Test Event',
+				'status'     => 'publish',
+				'start_date' => '2026-01-01 00:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$ticket_id = $this->create_rsvp_ticket( $event_id, [ 'post_title' => 'Classic RSVP' ] );
+
+		$filter_called = false;
+		$filter        = function () use ( &$filter_called ) {
+			$filter_called = true;
+
+			return func_get_arg( 0 );
+		};
+
+		add_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter, 10, 3 );
+
+		$this->rsvp->get_ticket( $event_id, $ticket_id );
+
+		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
+
+		$this->assertFalse( $filter_called, 'Legacy commerce filter should not run for classic RSVP tickets.' );
+	}
+
+	public function test_render_rsvp_step_resolves_event_from_commerce_meta(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		// TC-RSVP tickets relate to events via commerce meta, not legacy RSVP meta.
+		delete_post_meta( $ticket_id, $this->rsvp->get_event_key() );
+
+		$html = $this->rsvp->render_rsvp_step( $ticket_id, 'rsvp' );
+
+		$this->assertNotEmpty( $html, 'Should render when event is resolved via commerce meta fallback.' );
+		$this->assertStringContainsString( 'tribe-tickets__rsvp-actions-rsvp', $html );
+	}
+
+	public function test_render_rsvp_step_uses_commerce_content_template_for_tc_rsvp(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$html = $this->rsvp->render_rsvp_step( $ticket_id, 'rsvp' );
+
+		$this->assertStringContainsString( 'tribe-tickets__rsvp-actions-rsvp', $html );
+		$this->assertStringNotContainsString( 'RSVP Here', $html, 'Commerce template should not render the legacy heading.' );
+	}
+
+	public function test_frontend_filter_applies_commerce_legacy_filter_before_rendering(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$rsvp      = tribe( Module::class )->get_ticket( $post_id, $ticket_id );
+
+		$filter_called = false;
+		$filter        = function ( $ticket, $event_id, $filtered_ticket_id ) use ( &$filter_called, $post_id, $ticket_id ) {
+			$filter_called = true;
+			$this->assertSame( $post_id, $event_id );
+			$this->assertSame( $ticket_id, $filtered_ticket_id );
+			$ticket->iac = 'allowed';
+
+			return $ticket;
+		};
+
+		add_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter, 10, 3 );
+
+		$result = apply_filters(
+			'tec_tickets_front_end_rsvp_form_template_content',
+			'',
+			[
+				'active_rsvps' => [ $rsvp ],
+			],
+			tribe( 'tickets.editor.template' ),
+			get_post( $post_id ),
+			false
+		);
+
+		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
+
+		$this->assertTrue( $filter_called, 'Frontend should apply the legacy commerce filter for TC-RSVP tickets.' );
+		$this->assertStringContainsString( 'data-iac="allowed"', $result );
+	}
+}

--- a/tests/rsvp_v2_integration/RSVP/V2/Legacy_RSVP_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Legacy_RSVP_Test.php
@@ -43,11 +43,11 @@ class Legacy_RSVP_Test extends WPTestCase {
 
 		add_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter, 10, 3 );
 
-		wp_cache_flush();
+		// Commerce and Legacy RSVP share the `tec_tickets` object cache; clear it so get_ticket()
+		// rebuilds the ticket and runs the legacy filter registered above.
+		wp_cache_delete( (int) $ticket_id, 'tec_tickets' );
 
 		$ticket = $this->rsvp->get_ticket( $post_id, $ticket_id );
-
-		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
 
 		$this->assertInstanceOf( Ticket_Object::class, $ticket );
 		$this->assertSame( Constants::TC_RSVP_TYPE, $ticket->type() );
@@ -77,8 +77,6 @@ class Legacy_RSVP_Test extends WPTestCase {
 		add_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter, 10, 3 );
 
 		$this->rsvp->get_ticket( $event_id, $ticket_id );
-
-		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
 
 		$this->assertFalse( $filter_called, 'Legacy commerce filter should not run for classic RSVP tickets.' );
 	}
@@ -133,8 +131,6 @@ class Legacy_RSVP_Test extends WPTestCase {
 			get_post( $post_id ),
 			false
 		);
-
-		remove_filter( 'tec_tickets_commerce_get_ticket_legacy', $filter );
 
 		$this->assertTrue( $filter_called, 'Frontend should apply the legacy commerce filter for TC-RSVP tickets.' );
 		$this->assertStringContainsString( 'data-iac="allowed"', $result );

--- a/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
@@ -14,9 +14,7 @@ use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 class List_Table_Test extends WPTestCase {
 	use Ticket_Maker;
 
-	public function setUp(): void {
-		parent::setUp();
-
+	public function test_column_name_falls_back_to_rsvp_label_for_empty_tc_rsvp_name(): void {
 		add_filter(
 			'tec_tickets_admin_tickets_table_provider_info',
 			static function () {
@@ -30,9 +28,7 @@ class List_Table_Test extends WPTestCase {
 				];
 			}
 		);
-	}
 
-	public function test_column_name_falls_back_to_rsvp_label_for_empty_tc_rsvp_name(): void {
 		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
 		$ticket_id = $this->create_tc_rsvp_ticket(
 			$post_id,

--- a/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Admin\Tickets\List_Table;
+use TEC\Tickets\Commerce as TicketsCommerce;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+
+/**
+ * Tests for All Tickets list table behavior with TC-RSVP tickets.
+ */
+class List_Table_Test extends WPTestCase {
+	use Ticket_Maker;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter(
+			'tec_tickets_admin_tickets_table_provider_info',
+			static function () {
+				return [
+					TicketsCommerce\Module::class => [
+						'title'              => 'Tickets Commerce',
+						'event_meta_key'     => TicketsCommerce\Attendee::$event_relation_meta_key,
+						'attendee_post_type' => TicketsCommerce\Attendee::POSTTYPE,
+						'ticket_post_type'   => TicketsCommerce\Ticket::POSTTYPE,
+					],
+				];
+			}
+		);
+	}
+
+	public function test_column_name_falls_back_to_rsvp_label_for_empty_tc_rsvp_name(): void {
+		$post_id   = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket(
+			$post_id,
+			[
+				'ticket_name' => '',
+			]
+		);
+
+		$ticket = tribe( Module::class )->get_ticket( $post_id, $ticket_id );
+		$this->assertSame( '', $ticket->name );
+
+		$list_table = new List_Table();
+		$html       = $list_table->column_name( $ticket );
+
+		$expected_label = _x( 'RSVP', 'Default TC-RSVP ticket name in the All Tickets list', 'event-tickets' );
+
+		$this->assertStringContainsString( esc_html( $expected_label ), $html );
+	}
+}

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Commerce_Templates_Test__test_details_title_uses_rsvp_label_singular__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Commerce_Templates_Test__test_details_title_uses_rsvp_label_singular__0.snapshot.html
@@ -1,0 +1,76 @@
+<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+</div>
+
+
+
+	
+	<div class="tribe-tickets__rsvp tribe-common-g-row tribe-common-g-row--gutters">
+
+		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
+	<div class="tribe-tickets__rsvp-details">
+		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
+	RSVP</h3>
+
+		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
+	<p>Test TC ticket description for {{ POST_ID }}</p>
+</div>
+
+		<div class="tribe-tickets__rsvp-attendance">
+	<span  class="tribe-tickets__rsvp-attendance-number tribe-common-h4" >
+		0	</span>
+	<span class="tribe-tickets__rsvp-attendance-going tribe-common-h7 tribe-common-h--alt tribe-common-b3--min-medium">
+		Going	</span>
+</div>
+
+		<div class="tribe-tickets__rsvp-availability tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
+			<span class="tribe-tickets__rsvp-availability-quantity tribe-common-b2--bold"> 100 </span> remaining	
+	</div>
+	</div>
+</div>
+
+		<div class="tribe-tickets__rsvp-actions-wrapper tribe-common-g-col">
+	<div class="tribe-tickets__rsvp-actions">
+
+		
+			<div class="tribe-tickets__rsvp-actions-rsvp">
+	
+<div class="tribe-tickets__rsvp-actions-rsvp-going">
+	<button
+		class="tribe-common-c-btn tribe-tickets__rsvp-actions-button-going tribe-common-b1 tribe-common-b2--min-medium"
+		type="submit"
+			>
+		Going	</button>
+</div>
+
+	
+</div>
+
+			</div>
+
+</div>
+
+		
+	</div>
+
+	

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Commerce_Templates_Test__test_rsvp_wrapper_outputs_data_iac_attribute__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Commerce_Templates_Test__test_rsvp_wrapper_outputs_data_iac_attribute__0.snapshot.html
@@ -1,0 +1,89 @@
+
+<div
+	id="{{ BLOCK_HTML_ID }}"
+	class="tribe-common event-tickets"
+>
+	<div
+		class="tribe-tickets__rsvp-wrapper"
+		data-rsvp-id="{{ TICKET_ID }}"
+		data-iac="required"
+	>
+		<div  class="tribe-tickets-loader__dots tribe-common-c-loader tribe-common-a11y-hidden" >
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--first" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--second" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+	<svg
+	 class="tribe-common-c-svgicon tribe-common-c-svgicon--dot tribe-common-c-loader__dot tribe-common-c-loader__dot--third" 	aria-hidden="true"
+	viewBox="0 0 15 15"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	<circle cx="7.5" cy="7.5" r="7.5"/>
+</svg>
+</div>
+		
+
+
+	
+	<div class="tribe-tickets__rsvp tribe-common-g-row tribe-common-g-row--gutters">
+
+		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
+	<div class="tribe-tickets__rsvp-details">
+		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
+	RSVP</h3>
+
+		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
+	<p>Test TC ticket description for {{ POST_ID }}</p>
+</div>
+
+		<div class="tribe-tickets__rsvp-attendance">
+	<span  class="tribe-tickets__rsvp-attendance-number tribe-common-h4" >
+		0	</span>
+	<span class="tribe-tickets__rsvp-attendance-going tribe-common-h7 tribe-common-h--alt tribe-common-b3--min-medium">
+		Going	</span>
+</div>
+
+		<div class="tribe-tickets__rsvp-availability tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
+			<span class="tribe-tickets__rsvp-availability-quantity tribe-common-b2--bold"> 100 </span> remaining	
+	</div>
+	</div>
+</div>
+
+		<div class="tribe-tickets__rsvp-actions-wrapper tribe-common-g-col">
+	<div class="tribe-tickets__rsvp-actions">
+
+		
+			<div class="tribe-tickets__rsvp-actions-rsvp">
+	
+<div class="tribe-tickets__rsvp-actions-rsvp-going">
+	<button
+		class="tribe-common-c-btn tribe-tickets__rsvp-actions-button-going tribe-common-b1 tribe-common-b2--min-medium"
+		type="submit"
+			>
+		Going	</button>
+</div>
+
+	
+</div>
+
+			</div>
+
+</div>
+
+		
+	</div>
+
+	
+
+	</div>
+</div>

--- a/tests/rsvp_v2_jest/commerce/rsvp-block.spec.js
+++ b/tests/rsvp_v2_jest/commerce/rsvp-block.spec.js
@@ -1,0 +1,141 @@
+/**
+ * Tests for TC-RSVP block IAC-aware AJAX routing.
+ */
+
+describe( 'RSVP block IAC routing', () => {
+	let obj;
+	let requestMock;
+
+	beforeEach( () => {
+		jest.resetModules();
+
+		window.tribe = {
+			tickets: {
+				rsvp: {
+					manager: {
+						request: jest.fn(),
+					},
+				},
+			},
+		};
+
+		window.TecRsvp = {
+			nonces: {
+				rsvpHandle: 'test-nonce',
+			},
+		};
+
+		// Load the module after globals are set.
+		require( '../../../src/resources/js/commerce/rsvp-block.js' );
+		obj = window.tribe.tickets.rsvp.block;
+		requestMock = window.tribe.tickets.rsvp.manager.request;
+	} );
+
+	describe( 'hasIac', () => {
+		it.each( [
+			[ 'none', false ],
+			[ '', false ],
+			[ undefined, false ],
+			[ 'required', true ],
+			[ 'allowed', true ],
+		] )( 'returns %s -> %s', ( iacValue, expected ) => {
+			const $container = jQuery( '<div>' ).data( 'iac', iacValue );
+
+			if ( expected ) {
+				expect( obj.hasIac( $container ) ).toBeTruthy();
+			} else {
+				expect( obj.hasIac( $container ) ).toBeFalsy();
+			}
+		} );
+	} );
+
+	describe( 'bindGoing', () => {
+		it( 'routes to the going step when IAC is inactive', () => {
+			const $container = jQuery(
+				'<div class="tribe-tickets__rsvp-wrapper" data-rsvp-id="42" data-iac="none">' +
+					'<button class="tribe-tickets__rsvp-actions-button-going"></button>' +
+				'</div>'
+			);
+
+			obj.bindGoing( $container );
+			$container.find( obj.selectors.goingButton ).trigger( 'click' );
+
+			expect( requestMock ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'tribe_tickets_rsvp_handle',
+					ticket_id: 42,
+					step: 'going',
+					nonce: 'test-nonce',
+				} ),
+				$container
+			);
+		} );
+
+		it( 'routes to ARI when IAC is active', () => {
+			const $container = jQuery(
+				'<div class="tribe-tickets__rsvp-wrapper" data-rsvp-id="42" data-iac="required">' +
+					'<button class="tribe-tickets__rsvp-actions-button-going"></button>' +
+				'</div>'
+			);
+
+			obj.bindGoing( $container );
+			$container.find( obj.selectors.goingButton ).trigger( 'click' );
+
+			expect( requestMock ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'tribe_tickets_rsvp_handle',
+					ticket_id: 42,
+					step: 'ari',
+					going: 'going',
+					nonce: 'test-nonce',
+				} ),
+				$container
+			);
+		} );
+	} );
+
+	describe( 'bindNotGoing', () => {
+		it( 'routes to the not-going step when IAC is inactive', () => {
+			const $container = jQuery(
+				'<div class="tribe-tickets__rsvp-wrapper" data-rsvp-id="99" data-iac="none">' +
+					'<button class="tribe-tickets__rsvp-actions-button-not-going"></button>' +
+				'</div>'
+			);
+
+			obj.bindNotGoing( $container );
+			$container.find( obj.selectors.notGoingButton ).trigger( 'click' );
+
+			expect( requestMock ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'tribe_tickets_rsvp_handle',
+					ticket_id: 99,
+					step: 'not-going',
+					nonce: 'test-nonce',
+				} ),
+				$container
+			);
+		} );
+
+		it( 'routes to ARI when IAC is active', () => {
+			const $container = jQuery(
+				'<div class="tribe-tickets__rsvp-wrapper" data-rsvp-id="99" data-iac="allowed">' +
+					'<button class="tribe-tickets__rsvp-actions-button-not-going"></button>' +
+				'</div>'
+			);
+
+			obj.bindNotGoing( $container );
+			$container.find( obj.selectors.notGoingButton ).trigger( 'click' );
+
+			expect( requestMock ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					action: 'tribe_tickets_rsvp_handle',
+					ticket_id: 99,
+					step: 'ari',
+					going: 'not-going',
+					nonce: 'test-nonce',
+				} ),
+				$container
+			);
+		} );
+	} );
+} );

--- a/tests/wpunit/TEC/Tickets/RSVP/V2/Commerce_Templates_Test.php
+++ b/tests/wpunit/TEC/Tickets/RSVP/V2/Commerce_Templates_Test.php
@@ -13,6 +13,8 @@ use Tribe__Tickets__Ticket_Object as Ticket_Object;
 
 /**
  * Tests for TC-RSVP commerce view templates touched by SOFT-3334.
+ *
+ * Snapshot tests that exercise production render paths live in the rsvp_v2_integration suite.
  */
 class Commerce_Templates_Test extends WPTestCase {
 	use Ticket_Maker;
@@ -33,56 +35,6 @@ class Commerce_Templates_Test extends WPTestCase {
 		$this->assertInstanceOf( Ticket_Object::class, $ticket );
 
 		return $ticket;
-	}
-
-	public function test_rsvp_wrapper_outputs_data_iac_attribute(): void {
-		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
-		$ticket  = $this->create_ticket_object( $post_id );
-		$ticket->iac = 'required';
-
-		$template = $this->get_template();
-		$template->add_template_globals(
-			[
-				'post_id'    => $post_id,
-				'step'       => '',
-				'must_login' => false,
-				'threshold'  => 0,
-			]
-		);
-
-		$html = $template->template(
-			'v2/commerce/rsvp',
-			[
-				'rsvp'          => $ticket,
-				'post_id'       => $post_id,
-				'active_rsvps'  => [ $ticket ],
-				'block_html_id' => 'rsvp-block-test',
-				'step'          => '',
-				'must_login'    => false,
-			],
-			false
-		);
-
-		$this->assertStringContainsString(
-			sprintf( 'data-iac="%s"', esc_attr( $ticket->iac ) ),
-			$html
-		);
-	}
-
-	public function test_details_title_uses_rsvp_label_singular(): void {
-		$post_id = static::factory()->post->create();
-		$ticket  = $this->create_ticket_object( $post_id, [ 'ticket_name' => 'Custom Ticket Name' ] );
-
-		$html = $this->get_template()->template(
-			'v2/commerce/rsvp/details/title',
-			[ 'rsvp' => $ticket ],
-			false
-		);
-
-		$expected_label = tribe_get_rsvp_label_singular( 'rsvp_block_details_title' );
-
-		$this->assertStringContainsString( esc_html( $expected_label ), $html );
-		$this->assertStringNotContainsString( 'Custom Ticket Name', $html );
 	}
 
 	public function test_success_toggle_does_not_render_when_not_going(): void {

--- a/tests/wpunit/TEC/Tickets/RSVP/V2/Commerce_Templates_Test.php
+++ b/tests/wpunit/TEC/Tickets/RSVP/V2/Commerce_Templates_Test.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Closure;
+use Codeception\TestCase\WPTestCase;
+use Generator;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe__Template;
+use Tribe__Tickets__Main;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
+
+/**
+ * Tests for TC-RSVP commerce view templates touched by SOFT-3334.
+ */
+class Commerce_Templates_Test extends WPTestCase {
+	use Ticket_Maker;
+
+	private function get_template(): Tribe__Template {
+		$template = new Tribe__Template();
+		$template->set_template_origin( Tribe__Tickets__Main::instance() );
+		$template->set_template_folder( 'src/views' );
+		$template->set_template_context_extract( true );
+		$template->set_template_folder_lookup( true );
+
+		return $template;
+	}
+
+	private function create_ticket_object( int $post_id, array $overrides = [] ): Ticket_Object {
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, $overrides );
+		$ticket    = tribe( Module::class )->get_ticket( $post_id, $ticket_id );
+		$this->assertInstanceOf( Ticket_Object::class, $ticket );
+
+		return $ticket;
+	}
+
+	public function test_rsvp_wrapper_outputs_data_iac_attribute(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket  = $this->create_ticket_object( $post_id );
+		$ticket->iac = 'required';
+
+		$template = $this->get_template();
+		$template->add_template_globals(
+			[
+				'post_id'    => $post_id,
+				'step'       => '',
+				'must_login' => false,
+				'threshold'  => 0,
+			]
+		);
+
+		$html = $template->template(
+			'v2/commerce/rsvp',
+			[
+				'rsvp'          => $ticket,
+				'post_id'       => $post_id,
+				'active_rsvps'  => [ $ticket ],
+				'block_html_id' => 'rsvp-block-test',
+				'step'          => '',
+				'must_login'    => false,
+			],
+			false
+		);
+
+		$this->assertStringContainsString(
+			sprintf( 'data-iac="%s"', esc_attr( $ticket->iac ) ),
+			$html
+		);
+	}
+
+	public function test_details_title_uses_rsvp_label_singular(): void {
+		$post_id = static::factory()->post->create();
+		$ticket  = $this->create_ticket_object( $post_id, [ 'ticket_name' => 'Custom Ticket Name' ] );
+
+		$html = $this->get_template()->template(
+			'v2/commerce/rsvp/details/title',
+			[ 'rsvp' => $ticket ],
+			false
+		);
+
+		$expected_label = tribe_get_rsvp_label_singular( 'rsvp_block_details_title' );
+
+		$this->assertStringContainsString( esc_html( $expected_label ), $html );
+		$this->assertStringNotContainsString( 'Custom Ticket Name', $html );
+	}
+
+	public function test_success_toggle_does_not_render_when_not_going(): void {
+		$post_id = static::factory()->post->create();
+		$ticket  = $this->create_ticket_object( $post_id );
+
+		$html = $this->get_template()->template(
+			'v2/commerce/rsvp/actions/success/toggle',
+			[
+				'rsvp'                 => $ticket,
+				'opt_in_toggle_hidden' => false,
+				'opt_in_checked'       => false,
+				'opt_in_attendee_ids'  => '',
+				'opt_in_nonce'         => '',
+				'is_going'             => false,
+			],
+			false
+		);
+
+		$this->assertSame( '', $html );
+	}
+
+	public function test_success_toggle_renders_when_going(): void {
+		$post_id = static::factory()->post->create();
+		$ticket  = $this->create_ticket_object( $post_id );
+
+		$html = $this->get_template()->template(
+			'v2/commerce/rsvp/actions/success/toggle',
+			[
+				'rsvp'                 => $ticket,
+				'opt_in_toggle_hidden' => false,
+				'opt_in_checked'       => false,
+				'opt_in_attendee_ids'  => '',
+				'opt_in_nonce'         => '',
+				'is_going'             => true,
+			],
+			false
+		);
+
+		$this->assertStringContainsString( 'tribe-tickets__rsvp-actions-success-going-toggle', $html );
+	}
+
+	public function ari_fields_template_provider(): Generator {
+		yield 'iac active without meta still renders form shell' => [
+			function (): Ticket_Object {
+				$post_id = static::factory()->post->create();
+				$ticket  = tribe( Module::class )->get_ticket(
+					$post_id,
+					$this->create_tc_rsvp_ticket( $post_id )
+				);
+				$ticket->iac = 'required';
+
+				return $ticket;
+			},
+			true,
+		];
+
+		yield 'no iac and no meta renders nothing' => [
+			function (): Ticket_Object {
+				$post_id = static::factory()->post->create();
+
+				return $this->create_ticket_object( $post_id );
+			},
+			false,
+		];
+	}
+
+	/**
+	 * @dataProvider ari_fields_template_provider
+	 */
+	public function test_ari_fields_template_respects_iac( Closure $ticket_factory, bool $should_render ): void {
+		$ticket = $ticket_factory();
+
+		$html = $this->get_template()->template(
+			'v2/commerce/rsvp/ari/form/template/fields',
+			[
+				'rsvp'    => $ticket,
+				'post_id' => static::factory()->post->create(),
+			],
+			false
+		);
+
+		if ( $should_render ) {
+			$this->assertStringContainsString( 'tribe-tickets__form', $html );
+		} else {
+			$this->assertSame( '', trim( $html ) );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- IAC-aware frontend RSVP: route going/not-going through ARI when IAC is active
- Output `data-iac` on RSVP wrapper for JS detection
- TC-RSVP ticket discovery via repository; fallback admin list label

Part 1 of 2 in the SOFT-3334 ET stack. Pair with ET+ #2074 for IAC save QA.

**Downstream:** `split/soft-3334-et-02-block-iac` (stacked on this branch)

🎥 Artifacts
https://www.loom.com/share/e1b2566ae5a0443f831b2fcbd24b0956