### PR TITLE
fix: render RSVP V2 attendee name on confirmation [SOFT-3632]

### DIFF
--- a/src/views/v2/commerce/rsvp/attendees/attendee/name.php
+++ b/src/views/v2/commerce/rsvp/attendees/attendee/name.php
@@ -16,9 +16,12 @@
  * @var int $attendee_id The attendee ID.
  *
  * @since 5.7.1
+ * @since TBD Read the attendee name from the Tickets Commerce meta key used by RSVP V2, with fallbacks.
  *
- * @version 5.7.1
+ * @version TBD
  */
+
+use TEC\Tickets\Commerce\Attendee;
 
 defined( 'ABSPATH' ) || die();
 if ( empty( $attendees ) || empty( $attendee_id ) ) {
@@ -26,6 +29,17 @@ if ( empty( $attendees ) || empty( $attendee_id ) ) {
 }
 
 $attendee_name = get_post_meta( $attendee_id, tribe( Tribe__Tickets__RSVP::class )->full_name, true );
+
+// RSVP V2 creates Tickets Commerce attendees, which store the holder name under a different meta key.
+if ( empty( $attendee_name ) ) {
+	$attendee_name = get_post_meta( $attendee_id, Attendee::$full_name_meta_key, true );
+}
+
+// Final fallback to the attendee post title, which is also set to the holder name on creation.
+if ( empty( $attendee_name ) ) {
+	$attendee_name = get_the_title( $attendee_id );
+}
+
 if ( empty( $attendee_name ) ) {
 	return;
 }

--- a/tests/wpunit/TEC/Tickets/RSVP/V2/Attendees_Template_Test.php
+++ b/tests/wpunit/TEC/Tickets/RSVP/V2/Attendees_Template_Test.php
@@ -11,6 +11,7 @@ use Closure;
 use Codeception\TestCase\WPTestCase;
 use Generator;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use TEC\Tickets\Commerce\Attendee;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
@@ -92,6 +93,45 @@ class Attendees_Template_Test extends WPTestCase {
 				] );
 
 				return [ $post_id, $ticket_id, $attendee_ids, false, false ];
+			},
+		];
+
+		// RSVP V2 attendees only store the holder name under the Tickets Commerce meta key,
+		// not the legacy `_tribe_rsvp_full_name` key. The name template should read it from there.
+		yield 'attendees going with tickets commerce name meta' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+				$attendee_ids = $this->create_going_tc_rsvp_attendees( 2, $ticket_id, $post_id, [
+					'full_name'  => 'Commerce Name Holder',
+					'post_title' => 'Commerce Name Holder',
+				] );
+
+				// Intentionally leave the legacy `_tribe_rsvp_full_name` meta empty: the maker
+				// only sets the Tickets Commerce `full_name` meta, which is what V2 attendees use.
+
+				return [ $post_id, $ticket_id, $attendee_ids, true, true ];
+			},
+		];
+
+		// When neither name meta key is populated, the template falls back to the attendee post title.
+		yield 'attendees going falls back to post title' => [
+			function (): array {
+				$post_id   = static::factory()->post->create();
+				$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+				$attendee_ids = $this->create_going_tc_rsvp_attendees( 2, $ticket_id, $post_id, [
+					'post_title' => 'Post Title Holder',
+				] );
+
+				// Clear both name meta keys so only the post title remains as a source.
+				foreach ( $attendee_ids as $attendee_id ) {
+					delete_post_meta( $attendee_id, Attendee::$full_name_meta_key );
+					delete_post_meta( $attendee_id, '_tribe_rsvp_full_name' );
+				}
+
+				return [ $post_id, $ticket_id, $attendee_ids, true, true ];
 			},
 		];
 	}

--- a/tests/wpunit/TEC/Tickets/RSVP/V2/__snapshots__/Attendees_Template_Test__it_should_respect_is_going_in_attendees_template__attendees going falls back to post title__0.snapshot.html
+++ b/tests/wpunit/TEC/Tickets/RSVP/V2/__snapshots__/Attendees_Template_Test__it_should_respect_is_going_in_attendees_template__attendees going falls back to post title__0.snapshot.html
@@ -1,0 +1,24 @@
+<div class="tribe-tickets__rsvp-attendees-wrapper tribe-common-g-row">
+	<div class="tec-tickets__attendees-list-wrapper tribe-tickets__rsvp-attendees tribe-common-b1 tribe-common-g-col">
+		<h4 class="tribe-common-h4 tribe-common-h6--min-medium">
+	Your RSVPs</h4>
+		<div class="tec-tickets__attendees-list">
+							<div class="tec-tickets__attendees-list-item">
+					<div class="tec-tickets__attendees-list-item-attendee-details tribe-common-b1">
+	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
+	Post Title Holder</div>
+	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
+	Test TC ticket for {{ POST_ID }}</div>
+</div>
+				</div>
+							<div class="tec-tickets__attendees-list-item">
+					<div class="tec-tickets__attendees-list-item-attendee-details tribe-common-b1">
+	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
+	Post Title Holder</div>
+	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
+	Test TC ticket for {{ POST_ID }}</div>
+</div>
+				</div>
+					</div>
+	</div>
+</div>

--- a/tests/wpunit/TEC/Tickets/RSVP/V2/__snapshots__/Attendees_Template_Test__it_should_respect_is_going_in_attendees_template__attendees going with tickets commerce name meta__0.snapshot.html
+++ b/tests/wpunit/TEC/Tickets/RSVP/V2/__snapshots__/Attendees_Template_Test__it_should_respect_is_going_in_attendees_template__attendees going with tickets commerce name meta__0.snapshot.html
@@ -1,0 +1,24 @@
+<div class="tribe-tickets__rsvp-attendees-wrapper tribe-common-g-row">
+	<div class="tec-tickets__attendees-list-wrapper tribe-tickets__rsvp-attendees tribe-common-b1 tribe-common-g-col">
+		<h4 class="tribe-common-h4 tribe-common-h6--min-medium">
+	Your RSVPs</h4>
+		<div class="tec-tickets__attendees-list">
+							<div class="tec-tickets__attendees-list-item">
+					<div class="tec-tickets__attendees-list-item-attendee-details tribe-common-b1">
+	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
+	Commerce Name Holder</div>
+	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
+	Test TC ticket for {{ POST_ID }}</div>
+</div>
+				</div>
+							<div class="tec-tickets__attendees-list-item">
+					<div class="tec-tickets__attendees-list-item-attendee-details tribe-common-b1">
+	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
+	Commerce Name Holder</div>
+	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
+	Test TC ticket for {{ POST_ID }}</div>
+</div>
+				</div>
+					</div>
+	</div>
+</div>


### PR DESCRIPTION
## Ticket
[SOFT-3632](https://linear.app/nexcess/issue/SOFT-3632)

## Description

After a successful RSVP, the "Your RSVPs" confirmation list showed each attendee row as just the ticket label **"RSVP"** instead of the guest's name (e.g. "RSVP / RSVP" for two guests).

Each row renders two lines — `attendee/name.php` (guest name) and `attendee/rsvp.php` (ticket title, literally "RSVP"). RSVP V2 creates Tickets Commerce attendees (`tec_tc_attendee`) and stores the holder name under `_tec_tickets_commerce_full_name`, but `name.php` only read the legacy `_tribe_rsvp_full_name` key. That key is empty on V2 attendees, so `name.php` bailed early and only the "RSVP" label rendered.

This was reproducible **without** Event Tickets Plus, so it is not an IAC/individual-attendee-collection gap — the name is captured, it just wasn't being read from the right place.

The fix reads the Tickets Commerce meta key when the legacy key is empty, with a final fallback to the attendee post title.

## Artifacts
Before:
<img width="1986" height="1902" alt="CleanShot 2026-06-23 at 14 07 41@2x" src="https://github.com/user-attachments/assets/155a06fd-78a1-4c18-b6b7-acc440eecd35" />


After:
<img width="2004" height="1928" alt="CleanShot 2026-06-23 at 14 37 47@2x" src="https://github.com/user-attachments/assets/b41701ee-c64d-4bd9-9831-18c5c32635c6" />


## Testing

1. Activate Event Tickets.
2. Add an RSVP ticket to an event.
3. On the front end, RSVP as "Going" for 2 guests and submit.
4. In the "Your RSVPs" confirmation list, confirm each row now shows the guest name above the "RSVP" ticket label (instead of only "RSVP").

[skip-changelog]
