### PR TITLE
[SOFT-3334] RSVP block upgrade

### DIFF
--- a/src/modules/blocks/rsvp-v2/action-dashboard/container.js
+++ b/src/modules/blocks/rsvp-v2/action-dashboard/container.js
@@ -51,6 +51,18 @@ const onCancelClick = ( state, dispatch ) => () => {
 };
 
 const onConfirmClick = ( state, dispatch ) => () => {
+	const postId = select( 'core/editor' ).getCurrentPostId();
+
+	// The IAC admin modal (iac-admin.js) writes to the in-memory global store when in
+	// block editor context since the ticket may not yet exist. Read it here to include
+	// the selected IAC value in the REST call, then the thunk clears it after save.
+	let iac = selectors.getRSVPIAC( state );
+	const pendingAttendeeInfo = window.tribe_event_tickets_plus?.rsvp?.pendingAttendeeInfo?.[ postId ];
+
+	if ( pendingAttendeeInfo?.iac ) {
+		iac = pendingAttendeeInfo.iac;
+	}
+
 	const payload = {
 		capacity: selectors.getRSVPTempCapacity( state ),
 		notGoingResponses: selectors.getRSVPTempNotGoingResponses( state ),
@@ -64,6 +76,7 @@ const onConfirmClick = ( state, dispatch ) => () => {
 		endTime: selectors.getRSVPTempEndTime( state ),
 		startTimeInput: selectors.getRSVPTempStartTimeInput( state ),
 		endTimeInput: selectors.getRSVPTempEndTimeInput( state ),
+		iac,
 	};
 
 	if ( ! selectors.getRSVPCreated( state ) ) {
@@ -71,7 +84,7 @@ const onConfirmClick = ( state, dispatch ) => () => {
 		dispatch(
 			thunks.createRSVP( {
 				...payload,
-				postId: select( 'core/editor' ).getCurrentPostId(),
+				postId,
 			} )
 		);
 	} else {
@@ -80,6 +93,7 @@ const onConfirmClick = ( state, dispatch ) => () => {
 			thunks.updateRSVP( {
 				...payload,
 				id: selectors.getRSVPId( state ),
+				postId,
 			} )
 		);
 	}

--- a/src/modules/blocks/rsvp/attendee-registration/container.js
+++ b/src/modules/blocks/rsvp/attendee-registration/container.js
@@ -51,8 +51,20 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 		onIframeLoad: ( iframe ) => {
 			const iframeWindow = iframe.contentWindow;
 
+			// Track whether the form was submitted so handleUnload can mark changes.
+			let wasFormSubmitted = false;
+
+			// Expose a same-origin callback for ET+ to sync IAC radio changes in real time.
+			window.tribe_event_tickets_plus = window.tribe_event_tickets_plus || {};
+			window.tribe_event_tickets_plus.rsvp = window.tribe_event_tickets_plus.rsvp || {};
+			const previousOnIacChange = window.tribe_event_tickets_plus.rsvp.onIacChange;
+			window.tribe_event_tickets_plus.rsvp.onIacChange = ( iacValue ) => {
+				dispatch( actions.setRSVPIAC( iacValue ) );
+			};
+
 			// show overlay
 			const showOverlay = () => {
+				wasFormSubmitted = true;
 				iframe.nextSibling.classList.add( 'tribe-editor__attendee-registration__modal-overlay--show' );
 			};
 
@@ -64,6 +76,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 			const removeListeners = () => {
 				iframeWindow.removeEventListener( 'unload', handleUnload ); // eslint-disable-line no-use-before-define,max-len
 				form.removeEventListener( 'submit', showOverlay );
+				window.tribe_event_tickets_plus.rsvp.onIacChange = previousOnIacChange;
 			};
 
 			// handle unload on iframe unload
@@ -73,7 +86,19 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 
 				// check if there are meta fields
 				const metaFields = iframeWindow.document.querySelector( '#tribe-tickets-attendee-sortables' );
-				const hasFields = Boolean( metaFields.firstElementChild );
+				const hasFields = metaFields ? Boolean( metaFields.firstElementChild ) : false;
+
+				// Sync final IAC value to Redux on close (covers the case where the callback was not invoked).
+				const iacInput = iframeWindow.document.querySelector( 'input[name="ticket_iac"]:checked' );
+				if ( iacInput ) {
+					dispatch( actions.setRSVPIAC( iacInput.value ) );
+				}
+
+				// If the form was submitted (not just dismissed), mark RSVP as having changes
+				// so the "Update RSVP" button becomes enabled and the REST save includes the new IAC.
+				if ( wasFormSubmitted ) {
+					dispatch( actions.setRSVPHasChanges( true ) );
+				}
 
 				// dispatch actions
 				dispatch( actions.setRSVPHasAttendeeInfoFields( hasFields ) );

--- a/src/modules/data/blocks/rsvp-v2/thunks.js
+++ b/src/modules/data/blocks/rsvp-v2/thunks.js
@@ -88,6 +88,10 @@ export const createRSVP = ( payload ) => async ( dispatch ) => {
 			data.capacity = parseInt( capacity, 10 );
 		}
 
+		if ( payload.iac ) {
+			data.iac = payload.iac;
+		}
+
 		// POST /tec/v1/tickets
 		const response = await apiFetch( {
 			path: config.ticketsEndpoint,
@@ -97,8 +101,12 @@ export const createRSVP = ( payload ) => async ( dispatch ) => {
 		} );
 
 		if ( response && response.id ) {
+			if ( postId && window.tribe_event_tickets_plus?.rsvp?.pendingAttendeeInfo ) {
+				delete window.tribe_event_tickets_plus.rsvp.pendingAttendeeInfo[ postId ];
+			}
 			dispatch( actions.createRSVP() );
 			dispatch( actions.setRSVPId( response.id ) );
+			dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
 			dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
 			dispatch( actions.setRSVPHasChanges( false ) );
 		}
@@ -160,6 +168,10 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
 			data.capacity = parseInt( capacity, 10 );
 		}
 
+		if ( payload.iac ) {
+			data.iac = payload.iac;
+		}
+
 		// PUT /tec/v1/tickets/{id}
 		await apiFetch( {
 			path: `${ config.ticketsEndpoint }/${ id }`,
@@ -168,6 +180,10 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
 			data,
 		} );
 
+		if ( payload.postId && window.tribe_event_tickets_plus?.rsvp?.pendingAttendeeInfo ) {
+			delete window.tribe_event_tickets_plus.rsvp.pendingAttendeeInfo[ payload.postId ];
+		}
+		dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
 		dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
 		dispatch( actions.setRSVPHasChanges( false ) );
 
@@ -269,6 +285,7 @@ export const getRSVP = ( postId ) => async ( dispatch ) => {
 			dispatch( actions.setRSVPGoingCount( parseInt( rsvp.going_count || rsvp.sold || 0, 10 ) ) );
 			dispatch( actions.setRSVPNotGoingCount( parseInt( rsvp.not_going_count || 0, 10 ) ) );
 			dispatch( actions.setRSVPHasAttendeeInfoFields( rsvp.has_attendee_info_fields || false ) );
+			dispatch( actions.setRSVPIAC( rsvp.iac || 'none' ) );
 
 			dispatch(
 				actions.setRSVPDetails( {


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3334](https://linear.app/nexcess/issue/SOFT-3334/update-iacarf-modal-and-support-iac-block-editor)

### 🗒️ Description

Companion PR to [event-tickets-plus #2076](https://github.com/the-events-calendar/event-tickets-plus/pull/2076). That PR adds RSVP V2 IAC options to the block editor attendee registration iframe; this PR updates the Event Tickets side so both plugins share the same integration contract.

Addresses PR review feedback on #2076:

Replace localStorage with an in-memory global store — ET+ now writes pending IAC/meta to `window.tribe_event_tickets_plus.rsvp.pendingAttendeeInfo[ postId ]` instead of localStorage. This PR reads that value in the RSVP action dashboard before create/update, and clears it in the RSVP V2 thunks after a successful save.
Replace `postMessage` with a same-origin global callback — ET+ `attendee-registration-iac.js` now calls `window.parent.tribe_event_tickets_plus.rsvp.onIacChange` when IAC radios change inside the iframe. This PR registers that callback when the ARF modal iframe loads, and restores the previous handler on close.

Shared integration contract
Both plugins use `window.tribe_event_tickets_plus.rsvp:`

🎥 Artifacts
https://www.loom.com/share/e1b2566ae5a0443f831b2fcbd24b0956

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
