### PR TITLE
fix: prevent infinite WP-Cron loop in Glance_Items attendee count [SMTNC-1631]

### DIFF
--- a/changelog/fix-smtnc-1631-exclude-not-going
+++ b/changelog/fix-smtnc-1631-exclude-not-going
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Excluded RSVP "not going" attendees from the Dashboard "At a Glance" attendee count so the number reflects actual attendance.

--- a/changelog/performance-smtnc-1631-attendee-count-query
+++ b/changelog/performance-smtnc-1631-attendee-count-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: performance
+
+Replaced full attendee object hydration in `Glance_Items::update_attendee_count()` with a single SQL COUNT query, preventing PHP timeouts and infinite WP-Cron re-queuing on high-volume sites.

--- a/changelog/tweak-smtnc-1631-glance-item-filter
+++ b/changelog/tweak-smtnc-1631-glance-item-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Added the `tec_tickets_glance_item_attendee_count_enabled` filter to allow disabling the attendee count glance item entirely.

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -102,13 +102,14 @@ class Glance_Items {
 	 * @since 5.6.0
 	 * @since TBD Replace full object hydration with a single COUNT query via the Repository.
 	 * @since TBD Always persist the transient (even when count is zero) to prevent infinite cron rescheduling.
+	 * @since TBD Exclude RSVP "not going" attendees via the `rsvp_status__or_none` Repository filter.
 	 */
 	public function update_attendee_count() {
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
-		$total = tribe_attendees()->per_page( 1 )->found();
+		$total = tribe_attendees()->where( 'rsvp_status__or_none', 'yes' )->per_page( 1 )->found();
 
 		set_transient( static::$attendee_count_key, (int) $total, DAY_IN_SECONDS );
 	}

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -37,7 +37,7 @@ class Glance_Items {
 	 *
 	 * @return bool Whether the glance item attendee count is enabled. Default true.
 	 */
-	protected function is_enabled(): bool {
+	private function is_enabled(): bool {
 		/**
 		 * Filters whether the attendee count glance item is enabled.
 		 *

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -102,9 +102,9 @@ class Glance_Items {
 		 * @since TBD
 		 *
 		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
-	 	 * @param array $items The array of items to be displayed. Default empty array.
-
-	 	 * @return bool $enabled Whether the glance item attendee count is enabled.
+		 * @param array $items The array of items to be displayed. Default empty array.
+		 *
+		 * @return bool $enabled Whether the glance item attendee count is enabled.
 		 */
 		if ( ! apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true ) ) {
 			return;

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -28,6 +28,29 @@ class Glance_Items {
 	protected static string $attendee_count_key = 'tec_tickets_glance_item_attendees_count';
 
 	/**
+	 * Check if the attendee count glance item is enabled.
+	 *
+	 * Return false to disable the count entirely (no cron scheduled, no display).
+	 * Useful on high-volume sites where even the transient-backed display is unwanted.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the glance item attendee count is enabled. Default true.
+	 */
+	protected function is_enabled(): bool {
+		/**
+		 * Filters whether the attendee count glance item is enabled.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
+		 *
+		 * @return bool
+		 */
+		return apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true );
+	}
+
+	/**
 	 * Method to register glance items related hooks.
 	 *
 	 * @since 5.5.10
@@ -47,19 +70,7 @@ class Glance_Items {
 	 * @return array $items The maybe modified array of items to be displayed.
 	 */
 	public function custom_glance_items_attendees( $items = [] ): array {
-		/**
-		 * Filters whether the attendee count glance item is enabled.
-		 *
-		 * Return false to disable the count entirely (no cron scheduled, no display).
-		 * Useful on high-volume sites where even the transient-backed display is unwanted.
-		 *
-		 * @since TBD
-		 *
-		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
-		 *
-		 * @return bool
-		 */
-		if ( ! apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true ) ) {
+		if ( ! $this->is_enabled() ) {
 			return (array) $items;
 		}
 
@@ -93,20 +104,7 @@ class Glance_Items {
 	 * @since TBD Always persist the transient (even when count is zero) to prevent infinite cron rescheduling.
 	 */
 	public function update_attendee_count() {
-		/**
-		 * Filters whether the attendee count glance item is enabled.
-		 *
-		 * Return false to disable the count entirely (no cron scheduled, no display).
-		 * Useful on high-volume sites where even the transient-backed display is unwanted.
-		 *
-		 * @since TBD
-		 *
-		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
-		 * @param array $items The array of items to be displayed. Default empty array.
-		 *
-		 * @return bool $enabled Whether the glance item attendee count is enabled.
-		 */
-		if ( ! apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true ) ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -110,17 +110,8 @@ class Glance_Items {
 			return;
 		}
 
-		/*
-		 * The Repository issues a single SQL_CALC_FOUND_ROWS query with LIMIT 1, returning
-		 * the total count from MySQL's FOUND_ROWS() without transferring the full result set.
-		 */
 		$total = tribe_attendees()->per_page( 1 )->found();
 
-		/*
-		 * Always set the transient, including when $total is 0.
-		 * Skipping the set when the count is zero leaves the transient permanently unset,
-		 * causing the cron to reschedule itself on every dashboard page load.
-		 */
 		set_transient( static::$attendee_count_key, (int) $total, DAY_IN_SECONDS );
 	}
 }

--- a/src/Tickets/Admin/Glance_Items.php
+++ b/src/Tickets/Admin/Glance_Items.php
@@ -1,8 +1,13 @@
 <?php
+/**
+ * Glance Items for the WordPress Dashboard.
+ *
+ * @since 5.5.10
+ *
+ * @package TEC\Tickets\Admin
+ */
 
 namespace TEC\Tickets\Admin;
-
-use Tribe__Tickets__Tickets;
 
 /**
  * Class Glance_Items
@@ -36,11 +41,28 @@ class Glance_Items {
 	 * Custom glance item for Attendees count.
 	 *
 	 * @since 5.6.0 Make use of transients and cron jobs to avoid performance issues.
+	 * @since TBD Add filter to allow disabling the glance item attendee count.
 	 *
 	 * @param array $items The array of items to be displayed.
 	 * @return array $items The maybe modified array of items to be displayed.
 	 */
 	public function custom_glance_items_attendees( $items = [] ): array {
+		/**
+		 * Filters whether the attendee count glance item is enabled.
+		 *
+		 * Return false to disable the count entirely (no cron scheduled, no display).
+		 * Useful on high-volume sites where even the transient-backed display is unwanted.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
+		 *
+		 * @return bool
+		 */
+		if ( ! apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true ) ) {
+			return (array) $items;
+		}
+
 		$total = get_transient( static::$attendee_count_key );
 
 		if ( false === $total ) {
@@ -67,15 +89,38 @@ class Glance_Items {
 	 * Update the attendee count.
 	 *
 	 * @since 5.6.0
+	 * @since TBD Replace full object hydration with a single COUNT query via the Repository.
+	 * @since TBD Always persist the transient (even when count is zero) to prevent infinite cron rescheduling.
 	 */
 	public function update_attendee_count() {
-		$results = Tribe__Tickets__Tickets::get_attendees_by_args( [] );
-		$total   = count( $results['attendees'] );
+		/**
+		 * Filters whether the attendee count glance item is enabled.
+		 *
+		 * Return false to disable the count entirely (no cron scheduled, no display).
+		 * Useful on high-volume sites where even the transient-backed display is unwanted.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $enabled Whether the glance item attendee count is enabled. Default true.
+	 	 * @param array $items The array of items to be displayed. Default empty array.
 
-		if ( empty( $total ) ) {
+	 	 * @return bool $enabled Whether the glance item attendee count is enabled.
+		 */
+		if ( ! apply_filters( 'tec_tickets_glance_item_attendee_count_enabled', true ) ) {
 			return;
 		}
 
-		set_transient( static::$attendee_count_key, $total, DAY_IN_SECONDS );
+		/*
+		 * The Repository issues a single SQL_CALC_FOUND_ROWS query with LIMIT 1, returning
+		 * the total count from MySQL's FOUND_ROWS() without transferring the full result set.
+		 */
+		$total = tribe_attendees()->per_page( 1 )->found();
+
+		/*
+		 * Always set the transient, including when $total is 0.
+		 * Skipping the set when the count is zero leaves the transient permanently unset,
+		 * causing the cron to reschedule itself on every dashboard page load.
+		 */
+		set_transient( static::$attendee_count_key, (int) $total, DAY_IN_SECONDS );
 	}
 }

--- a/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
@@ -2,14 +2,13 @@
 
 namespace TEC\Tickets\Admin;
 
-use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 
 /**
  * Integration tests for the Glance_Items attendee-count fix (Panel > Dashboard > "At a Glance" widget).
  *
- * Covers three scenarios introduced by the SMTNC-1631:
+ * Covers scenarios introduced by the SMTNC-1631:
  *
  * 1. update_attendee_count() sets the transient to the real attendee count
  *    when attendees exist.
@@ -20,6 +19,11 @@ use Tribe\Tickets\Test\Commerce\Attendee_Maker;
  *    false prevents both the transient from being set in
  *    update_attendee_count() and the cron from being scheduled in
  *    custom_glance_items_attendees().
+ * 4. update_attendee_count() aggregates attendees across multiple events.
+ * 5. RSVP "not going" attendees are included in the count (the Repository does
+ *    not filter on the going/not-going meta key).
+ * 6. Attendees of hard-deleted events are still counted, because deleting an
+ *    event does not cascade-delete its attendee posts.
  *
  * @covers \TEC\Tickets\Admin\Glance_Items
  *
@@ -29,7 +33,6 @@ use Tribe\Tickets\Test\Commerce\Attendee_Maker;
  */
 class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 
-	use With_Uopz;
 	use RSVP_Ticket_Maker;
 	use Attendee_Maker;
 
@@ -55,10 +58,6 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 
 		delete_transient( self::TRANSIENT_KEY );
 		wp_clear_scheduled_hook( self::CRON_HOOK );
-
-		add_filter( 'tribe_tickets_post_types', static function () {
-			return [ 'post' ];
-		} );
 	}
 
 	/**
@@ -67,6 +66,10 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function update_attendee_count_sets_transient_to_real_count_when_attendees_exist(): void {
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+
 		$post_id   = static::factory()->post->create();
 		$ticket_id = $this->create_rsvp_ticket( $post_id );
 		$this->create_many_attendees_for_ticket( 3, $ticket_id, $post_id );
@@ -105,6 +108,10 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function update_attendee_count_does_not_set_transient_when_filter_disabled(): void {
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+
 		$post_id   = static::factory()->post->create();
 		$ticket_id = $this->create_rsvp_ticket( $post_id );
 		$this->create_many_attendees_for_ticket( 2, $ticket_id, $post_id );
@@ -135,5 +142,98 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 			$next_scheduled,
 			'The cron event should NOT be scheduled when the filter disables the glance item.'
 		);
+	}
+
+	/**
+	 * update_attendee_count() aggregates attendees across multiple events.
+	 *
+	 * Verifies that the Repository COUNT query is not scoped to a single event —
+	 * attendees from all events are included in the dashboard total.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_counts_attendees_across_multiple_events(): void {
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+
+		// Three independent events, each with a different number of attendees.
+		$post_a    = static::factory()->post->create();
+		$ticket_a  = $this->create_rsvp_ticket( $post_a );
+		$this->create_many_attendees_for_ticket( 2, $ticket_a, $post_a );
+
+		$post_b    = static::factory()->post->create();
+		$ticket_b  = $this->create_rsvp_ticket( $post_b );
+		$this->create_many_attendees_for_ticket( 3, $ticket_b, $post_b );
+
+		$post_c    = static::factory()->post->create();
+		$ticket_c  = $this->create_rsvp_ticket( $post_c );
+		$this->create_many_attendees_for_ticket( 1, $ticket_c, $post_c );
+
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertNotFalse( $stored, 'Transient should be set when attendees exist across multiple events.' );
+		$this->assertSame( 6, (int) $stored, 'Count should be the sum of attendees across all events (2 + 3 + 1 = 6).' );
+	}
+
+	/**
+	 * update_attendee_count() includes RSVP "not going" attendees in the total.
+	 *
+	 * The merged tribe_attendees() Repository queries by attendee post type with
+	 * post_status = 'publish' and does not filter on the RSVP going/not-going
+	 * meta key. "Not going" attendees are thus included in the dashboard count.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_includes_rsvp_not_going_attendees(): void {
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_rsvp_ticket( $post_id );
+
+		// One "going" and one "not going" attendee.
+		$this->create_attendee_for_ticket( $ticket_id, $post_id, [ 'rsvp_status' => 'yes' ] );
+		$this->create_attendee_for_ticket( $ticket_id, $post_id, [ 'rsvp_status' => 'no' ] );
+
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertNotFalse( $stored, 'Transient should be set when attendees exist.' );
+		$this->assertSame( 2, (int) $stored, 'Both "going" and "not going" RSVP attendees should be included in the count.' );
+	}
+
+	/**
+	 * update_attendee_count() still counts attendees whose event has been deleted.
+	 *
+	 * Deleting an event post does not cascade-delete its attendee posts.
+	 * The attendee records remain published in the database and are included
+	 * in the global count, because tribe_attendees() does not filter by whether
+	 * the parent event still exists.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_includes_attendees_of_deleted_events(): void {
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_rsvp_ticket( $post_id );
+		$this->create_many_attendees_for_ticket( 2, $ticket_id, $post_id );
+
+		// Hard-delete the parent event; attendee posts are NOT cascade-deleted.
+		wp_delete_post( $post_id, true );
+
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertNotFalse( $stored, 'Transient should be set even when the parent event is deleted.' );
+		$this->assertSame( 2, (int) $stored, 'Attendees of deleted events should still appear in the total count.' );
 	}
 }

--- a/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
@@ -62,16 +62,6 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * Clean up after each test.
-	 */
-	public function tearDown(): void {
-		// your tear down methods here
-
-		// then
-		parent::tearDown();
-	}
-
-	/**
 	 * update_attendee_count() stores the correct attendee total in the transient.
 	 *
 	 * @test

--- a/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
@@ -20,8 +20,8 @@ use Tribe\Tickets\Test\Commerce\Attendee_Maker;
  *    update_attendee_count() and the cron from being scheduled in
  *    custom_glance_items_attendees().
  * 4. update_attendee_count() aggregates attendees across multiple events.
- * 5. RSVP "not going" attendees are included in the count (the Repository does
- *    not filter on the going/not-going meta key).
+ * 5. RSVP "not going" attendees are excluded from the count (the query uses
+ *    `rsvp_status__or_none` = 'yes' to skip opt-outs).
  * 6. Attendees of hard-deleted events are still counted, because deleting an
  *    event does not cascade-delete its attendee posts.
  *
@@ -179,15 +179,17 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * update_attendee_count() includes RSVP "not going" attendees in the total.
+	 * update_attendee_count() excludes RSVP "not going" attendees from the total.
 	 *
-	 * The merged tribe_attendees() Repository queries by attendee post type with
-	 * post_status = 'publish' and does not filter on the RSVP going/not-going
-	 * meta key. "Not going" attendees are thus included in the dashboard count.
+	 * The query uses the `rsvp_status__or_none` Repository filter set to 'yes',
+	 * which includes attendees where the RSVP status meta equals 'yes' or does
+	 * not exist (non-RSVP providers like WooCommerce/Tickets Commerce). RSVP
+	 * attendees with status 'no' ("not going") are excluded because they represent
+	 * opt-outs, not actual attendance.
 	 *
 	 * @test
 	 */
-	public function update_attendee_count_includes_rsvp_not_going_attendees(): void {
+	public function update_attendee_count_excludes_rsvp_not_going_attendees(): void {
 		add_filter( 'tribe_tickets_post_types', static function () {
 			return [ 'post' ];
 		} );
@@ -204,7 +206,7 @@ class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
 		$stored = get_transient( self::TRANSIENT_KEY );
 
 		$this->assertNotFalse( $stored, 'Transient should be set when attendees exist.' );
-		$this->assertSame( 2, (int) $stored, 'Both "going" and "not going" RSVP attendees should be included in the count.' );
+		$this->assertSame( 1, (int) $stored, '"Not going" RSVP attendees should be excluded from the count.' );
 	}
 
 	/**

--- a/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Glance_ItemsTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace TEC\Tickets\Admin;
+
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+
+/**
+ * Integration tests for the Glance_Items attendee-count fix (Panel > Dashboard > "At a Glance" widget).
+ *
+ * Covers three scenarios introduced by the SMTNC-1631:
+ *
+ * 1. update_attendee_count() sets the transient to the real attendee count
+ *    when attendees exist.
+ * 2. update_attendee_count() sets the transient to integer 0 (not false)
+ *    when there are no attendees — the old code left the transient unset,
+ *    causing WP-Cron to reschedule itself on every dashboard page load.
+ * 3. The `tec_tickets_glance_item_attendee_count_enabled` filter returning
+ *    false prevents both the transient from being set in
+ *    update_attendee_count() and the cron from being scheduled in
+ *    custom_glance_items_attendees().
+ *
+ * @covers \TEC\Tickets\Admin\Glance_Items
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Admin
+ */
+class Glance_ItemsTest extends \Codeception\TestCase\WPTestCase {
+
+	use With_Uopz;
+	use RSVP_Ticket_Maker;
+	use Attendee_Maker;
+
+	/**
+	 * The transient key used by Glance_Items to cache the attendee count.
+	 *
+	 * @var string
+	 */
+	private const TRANSIENT_KEY = 'tec_tickets_glance_item_attendees_count';
+
+	/**
+	 * The WP-Cron action that triggers an attendee-count refresh.
+	 *
+	 * @var string
+	 */
+	private const CRON_HOOK = 'tec_tickets_update_glance_item_attendee_counts';
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_transient( self::TRANSIENT_KEY );
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+
+		add_filter( 'tribe_tickets_post_types', static function () {
+			return [ 'post' ];
+		} );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		// your tear down methods here
+
+		// then
+		parent::tearDown();
+	}
+
+	/**
+	 * update_attendee_count() stores the correct attendee total in the transient.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_sets_transient_to_real_count_when_attendees_exist(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_rsvp_ticket( $post_id );
+		$this->create_many_attendees_for_ticket( 3, $ticket_id, $post_id );
+
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertNotFalse( $stored, 'Transient should be set after update_attendee_count().' );
+		$this->assertSame( 3, (int) $stored, 'Transient value should equal the number of created attendees.' );
+	}
+
+	/**
+	 * update_attendee_count() stores integer 0 in the transient even when
+	 * there are no attendees, preventing the infinite cron-rescheduling loop.
+	 *
+	 * Before the fix, the method returned early without calling set_transient()
+	 * when the count was zero. get_transient() then returned false, which caused
+	 * custom_glance_items_attendees() to reschedule the cron on every page load.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_sets_transient_to_zero_when_no_attendees_exist(): void {
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertNotFalse( $stored, 'Transient should be set even when the attendee count is zero.' );
+		$this->assertSame( 0, (int) $stored, 'Transient value should be integer 0 when no attendees exist.' );
+	}
+
+	/**
+	 * When tec_tickets_glance_item_attendee_count_enabled returns false,
+	 * update_attendee_count() must not write the transient.
+	 *
+	 * @test
+	 */
+	public function update_attendee_count_does_not_set_transient_when_filter_disabled(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_rsvp_ticket( $post_id );
+		$this->create_many_attendees_for_ticket( 2, $ticket_id, $post_id );
+
+		add_filter( 'tec_tickets_glance_item_attendee_count_enabled', '__return_false' );
+
+		tribe( Glance_Items::class )->update_attendee_count();
+
+		$stored = get_transient( self::TRANSIENT_KEY );
+
+		$this->assertFalse( $stored, 'Transient should NOT be set when the filter disables the glance item.' );
+	}
+
+	/**
+	 * When tec_tickets_glance_item_attendee_count_enabled returns false,
+	 * custom_glance_items_attendees() must not schedule the cron event.
+	 *
+	 * @test
+	 */
+	public function custom_glance_items_attendees_does_not_schedule_cron_when_filter_disabled(): void {
+		add_filter( 'tec_tickets_glance_item_attendee_count_enabled', '__return_false' );
+
+		tribe( Glance_Items::class )->custom_glance_items_attendees( [] );
+
+		$next_scheduled = wp_next_scheduled( self::CRON_HOOK );
+
+		$this->assertFalse(
+			$next_scheduled,
+			'The cron event should NOT be scheduled when the filter disables the glance item.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1631](https://linear.app/nexcess/issue/SMTNC-1631/tec-tickets-update-glance-item-attendee-counts-causes-infinite-wp-cron)

### PR related

https://github.com/the-events-calendar/event-tickets-plus/pull/2079

### 🗒️ Description

_Speedup: ~2,500×_

**Bug:** `tec_tickets_update_glance_item_attendee_counts` WP-Cron event reschedules itself on every dashboard page load on high-volume sites, causing PHP timeouts and server instability.

**Root cause (two bugs):**

1. **Performance:** `update_attendee_count()` called `get_attendees_by_args([])` which hydrated every attendee as a full PHP object — 94 MB / 17 s for 12,983 attendees. PHP `max_execution_time` was hit before `set_transient()` could be called.
2. **Zero-count loop:** The old `if (empty($total)) return;` guard skipped `set_transient()` when the count was zero, leaving the transient permanently unset on fresh installs — same infinite cron loop.

**Fixes:**

- Replaced `get_attendees_by_args([])` with `tribe_attendees()->per_page(1)->found()` — issues a single `SQL_CALC_FOUND_ROWS LIMIT 1` query; MySQL counts server-side, PHP receives one integer. Benchmark: 0.008 s / 0 MB extra memory.
- Always call `set_transient()` with `(int) $total`, even when zero.
- Added `tec_tickets_glance_item_attendee_count_enabled` filter so high-volume sites can disable the glance item entirely.

### 🎥 🗒️ Benchmark / Artifacts
**Benchmark (12,983 attendees, local):**

<img width="602" height="645" alt="image" src="https://github.com/user-attachments/assets/b1f60b7e-24df-430c-8dd3-e45fd3455c95" />

<img width="724" height="237" alt="image" src="https://github.com/user-attachments/assets/837bca31-b096-4fef-854c-3a47da78acc8" />

<img width="763" height="244" alt="image" src="https://github.com/user-attachments/assets/4860fdce-5a9a-4c1a-8d0e-672199dd62de" />

benchmarks can run via `wp smtnc-1631 benchmark` QA helper plugin (included in QA instructions on Linear ticket).

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.