### PR TITLE
Fix fatal when deleting an attendee

### DIFF
--- a/src/Tickets/RSVP/RSVP_Disabled.php
+++ b/src/Tickets/RSVP/RSVP_Disabled.php
@@ -38,7 +38,7 @@ class RSVP_Disabled extends Tribe__Tickets__RSVP {
 	 *
 	 * @return array Empty array.
 	 */
-	public function get_tickets( $post_id, string $context = null ) {
+	public function get_tickets( $post_id, ?string $context = null ) {
 		return [];
 	}
 
@@ -341,7 +341,7 @@ class RSVP_Disabled extends Tribe__Tickets__RSVP {
 	 *
 	 * @return array Empty array.
 	 */
-	public function get_tickets_ids( $post = 0, string $context = null ) {
+	public function get_tickets_ids( $post = 0, ?string $context = null ) {
 		return [];
 	}
 }

--- a/src/Tickets/RSVP/V2/REST/Order_Endpoint.php
+++ b/src/Tickets/RSVP/V2/REST/Order_Endpoint.php
@@ -545,7 +545,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 
 		$attendee_email = null;
 		if ( ! empty( $first_attendee['email'] ) ) {
-			$decoded_email = html_entity_decode( $first_attendee['email'] );
+			$decoded_email = html_entity_decode( $first_attendee['email'], ENT_QUOTES );
 
 			if ( $decoded_email === wp_strip_all_tags( $decoded_email ) ) {
 				$attendee_email = htmlentities( sanitize_email( $decoded_email ), ENT_COMPAT );
@@ -556,7 +556,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			null
 			: htmlentities(
 				sanitize_text_field(
-					html_entity_decode( $first_attendee['full_name'] )
+					html_entity_decode( $first_attendee['full_name'], ENT_QUOTES )
 				),
 				ENT_COMPAT
 			);

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -760,6 +760,11 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @param int $post_id The post ID.
 		 */
 		public function clear_ticket_cache_for_post( $post_id ) {
+			// No post context (e.g. deleting an attendee) means there is nothing to clear.
+			if ( empty( $post_id ) ) {
+				return;
+			}
+
 			/** @var Tribe__Cache $cache */
 			$cache = tribe( 'cache' );
 
@@ -854,14 +859,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param string   $orm_provider The provider ORM slug (e.g. `tribe-commerce`, `rsvp`).
-		 * @param int|null $post_id      The post (event) ID the tickets belong to. May be null when the
-		 *                               caller has no post context (e.g. deleting an attendee).
+		 * @param string $orm_provider The provider ORM slug (e.g. `tribe-commerce`, `rsvp`).
+		 * @param int    $post_id      The post (event) ID the tickets belong to.
 		 *
 		 * @return string The cache key.
 		 */
-		public static function get_tickets_cache_key( string $orm_provider, ?int $post_id ): string {
-			return self::class . '::get_tickets-' . $orm_provider . '-' . (int) $post_id;
+		public static function get_tickets_cache_key( string $orm_provider, int $post_id ): string {
+			return self::class . '::get_tickets-' . $orm_provider . '-' . $post_id;
 		}
 
 		/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -854,13 +854,14 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param string $orm_provider The provider ORM slug (e.g. `tribe-commerce`, `rsvp`).
-		 * @param int    $post_id      The post (event) ID the tickets belong to.
+		 * @param string   $orm_provider The provider ORM slug (e.g. `tribe-commerce`, `rsvp`).
+		 * @param int|null $post_id      The post (event) ID the tickets belong to. May be null when the
+		 *                               caller has no post context (e.g. deleting an attendee).
 		 *
 		 * @return string The cache key.
 		 */
-		public static function get_tickets_cache_key( string $orm_provider, int $post_id ): string {
-			return self::class . '::get_tickets-' . $orm_provider . '-' . $post_id;
+		public static function get_tickets_cache_key( string $orm_provider, ?int $post_id ): string {
+			return self::class . '::get_tickets-' . $orm_provider . '-' . (int) $post_id;
 		}
 
 		/**

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -503,4 +503,105 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( 'some-context', $request_context );
 	}
+
+	/**
+	 * Empty post IDs that may reach clear_ticket_cache_for_post() when there is no post context,
+	 * e.g. when deleting an attendee that is no longer attached to an event.
+	 *
+	 * @return array<string,array{0:mixed}>
+	 */
+	public function empty_post_id_provider(): array {
+		return [
+			'null'         => [ null ],
+			'zero int'     => [ 0 ],
+			'zero string'  => [ '0' ],
+			'empty string' => [ '' ],
+			'false'        => [ false ],
+		];
+	}
+
+	/**
+	 * It should not throw when clearing the ticket cache without a post context.
+	 *
+	 * Deleting an attendee can call clear_ticket_cache_for_post() with no post ID. The cache key
+	 * helper is strictly typed to an int, so an empty value must be guarded before it is used.
+	 *
+	 * @test
+	 * @dataProvider empty_post_id_provider
+	 */
+	public function should_not_throw_when_clearing_cache_without_post_context( $post_id ): void {
+		$provider = tribe( 'tickets.rsvp' );
+
+		// Before the guard this would throw a TypeError from get_tickets_cache_key().
+		$provider->clear_ticket_cache_for_post( $post_id );
+
+		$this->assertNull( $provider->clear_ticket_cache_for_post( $post_id ) );
+	}
+
+	/**
+	 * It should not throw when deleting a ticket without a post context.
+	 *
+	 * This mirrors the real-world path that surfaced the bug: deleting an attendee with no
+	 * associated event post should not blow up while clearing caches.
+	 *
+	 * @test
+	 */
+	public function should_not_throw_when_deleting_ticket_without_post_context(): void {
+		$post_id        = $this->factory->post->create();
+		$rsvp_ticket_id = $this->create_rsvp_ticket( $post_id );
+
+		$provider = tribe( 'tickets.rsvp' );
+
+		// Delete with an empty parent post ID, as happens for an orphaned attendee.
+		$provider->delete_ticket( null, $rsvp_ticket_id );
+
+		$this->assertTrue( true, 'delete_ticket() should complete without throwing a TypeError.' );
+	}
+
+	/**
+	 * It should clear the cached tickets for a post.
+	 *
+	 * @test
+	 */
+	public function should_clear_cached_tickets_for_post(): void {
+		$post_id = $this->factory->post->create();
+		$this->create_paypal_ticket_basic( $post_id, 1 );
+
+		/** @var Tribe__Tickets__Tickets $provider */
+		$provider = call_user_func( [ Tickets::get_event_ticket_provider( $post_id ), 'get_instance' ] );
+
+		/** @var \Tribe__Cache $cache */
+		$cache = tribe( 'cache' );
+		$key   = Tickets::get_tickets_cache_key( $provider->orm_provider, $post_id );
+
+		// Populate the request-scoped get_tickets() cache.
+		$provider->get_tickets( $post_id );
+		$this->assertTrue( isset( $cache[ $key ] ), 'get_tickets() should have primed the cache.' );
+
+		$provider->clear_ticket_cache_for_post( $post_id );
+		$this->assertFalse( isset( $cache[ $key ] ), 'clear_ticket_cache_for_post() should remove the cached entry.' );
+	}
+
+	/**
+	 * It should build a stable cache key for a provider and post.
+	 *
+	 * @test
+	 */
+	public function should_build_stable_cache_key_for_provider_and_post(): void {
+		$post_id = $this->factory->post->create();
+
+		$expected = Tickets::class . '::get_tickets-rsvp-' . $post_id;
+
+		$this->assertSame( $expected, Tickets::get_tickets_cache_key( 'rsvp', $post_id ) );
+		// The key is deterministic for the same inputs.
+		$this->assertSame(
+			Tickets::get_tickets_cache_key( 'rsvp', $post_id ),
+			Tickets::get_tickets_cache_key( 'rsvp', $post_id )
+		);
+		// Different providers and posts produce different keys.
+		$this->assertNotSame(
+			Tickets::get_tickets_cache_key( 'rsvp', $post_id ),
+			Tickets::get_tickets_cache_key( 'tribe-commerce', $post_id )
+		);
+	}
 }


### PR DESCRIPTION
## Ticket 
None right now, but I can add one if necessary. 

## Description

Deleting an attendee from the Attendees table fatals with an uncaught `TypeError`.

`Attendees_Table::do_delete()` calls `delete_ticket( null, $attendee_id )` — `null` post ID by design. That `null` flows into `clear_ticket_cache_for_post()` → `get_tickets_cache_key()`, whose strict `int $post_id` hint throws.

I introduced this new fatal behavior when I tried centralizing the cache key. The old inline string concatenation tolerated `null`; the new typed method did not. This PR should adjust the code so that it can tolerate null again. 