### PR TITLE
fix: treat disabled Tickets Commerce as an inactive provider [SMTNC-345]

### DIFF
--- a/changelog/fix-smtnc-345-tc-disabled-attendees-fatal
+++ b/changelog/fix-smtnc-345-tc-disabled-attendees-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fix a fatal error on the Attendees screen when Tickets Commerce is disabled but Tickets Commerce records remain, by treating a disabled Tickets Commerce module as an inactive ticket provider [SMTNC-345]

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1757,6 +1757,7 @@ if ( ! function_exists( 'tribe_tickets_is_provider_active' ) ) {
 	 * Example: if provider is for a WooCommerce Ticket but ETP is disabled, returns False.
 	 *
 	 * @since 4.12.3
+	 * @since TBD A disabled Tickets Commerce module is treated as inactive even after construction.
 	 *
 	 * @param Tribe__Tickets__Tickets|string $provider Examples: 'Tribe__Tickets_Plus__Commerce__WooCommerce__Main',
 	 *                                                 'woo', 'rsvp', etc.
@@ -1777,6 +1778,12 @@ if ( ! function_exists( 'tribe_tickets_is_provider_active' ) ) {
 		$status = tribe( 'tickets.status' );
 
 		$provider = $status->get_provider_class_from_slug( $provider );
+
+		// @since TBD A disabled Tickets Commerce module is never an active provider, even if something
+		// constructed it (e.g. ETP's Orders Tabbed View) and it self-registered into the modules list.
+		if ( \TEC\Tickets\Commerce\Module::class === $provider && ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
 
 		return (
 			class_exists( $provider )

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1781,8 +1781,7 @@ if ( ! function_exists( 'tribe_tickets_is_provider_active' ) ) {
 
 		$provider = $status->get_provider_class_from_slug( $provider );
 
-		// @since TBD A disabled Tickets Commerce module is never an active provider, even if something
-		// constructed it (e.g. ETP's Orders Tabbed View) and it self-registered into the modules list.
+		// A constructed Commerce module self-registers into the modules list, so guard on TC being enabled.
 		if ( \TEC\Tickets\Commerce\Module::class === $provider && ! tec_tickets_commerce_is_enabled() ) {
 			return false;
 		}

--- a/tests/_support/Testcases/QR_TestCase.php
+++ b/tests/_support/Testcases/QR_TestCase.php
@@ -20,8 +20,17 @@ class QR_TestCase extends WPTestCase {
 	 */
 	protected $implementation_backups = [];
 
+	/**
+	 * @var string|false TEC_TICKETS_COMMERCE as the suite left it before this test.
+	 */
+	private $original_tc_env;
+
 	function setUp() {
 		parent::setUp();
+
+		// Attendees here are Tickets Commerce records, so provider resolution requires TC enabled.
+		$this->original_tc_env = getenv( 'TEC_TICKETS_COMMERCE' );
+		putenv( 'TEC_TICKETS_COMMERCE=1' );
 
 		$this->factory()->attendee = new QR();
 
@@ -44,6 +53,13 @@ class QR_TestCase extends WPTestCase {
 		foreach ( $this->implementation_backups as $alias => $value ) {
 			tribe_singleton( $alias, $value );
 		}
+
+		if ( false === $this->original_tc_env ) {
+			putenv( 'TEC_TICKETS_COMMERCE' );
+		} else {
+			putenv( 'TEC_TICKETS_COMMERCE=' . $this->original_tc_env );
+		}
+
 		parent::tearDown();
 	}
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Provider_Active_TC_Disabled_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Provider_Active_TC_Disabled_Test.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+
+/**
+ * SMTNC-345: a disabled Tickets Commerce module must resolve as an INACTIVE provider even after
+ * something constructs it (e.g. ETP's Orders Tabbed View), so the Attendees inventory path cannot
+ * reach the unloaded tec_tc_* helpers and fatal.
+ *
+ * @group commerce
+ */
+class Provider_Active_TC_Disabled_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Attendee_Maker;
+
+	/** @var string|false TEC_TICKETS_COMMERCE as the suite left it before this test. */
+	private $original_tc_env;
+
+	public function _setUp() {
+		parent::_setUp();
+		// A defined constant overrides the env var and would defeat disable_tc().
+		$this->assertFalse( defined( 'TEC_TICKETS_COMMERCE' ), 'TEC_TICKETS_COMMERCE must not be defined.' );
+		$this->original_tc_env = getenv( 'TEC_TICKETS_COMMERCE' );
+	}
+
+	public function _tearDown() {
+		if ( false === $this->original_tc_env ) {
+			putenv( 'TEC_TICKETS_COMMERCE' );
+		} else {
+			putenv( 'TEC_TICKETS_COMMERCE=' . $this->original_tc_env );
+		}
+		parent::_tearDown();
+	}
+
+	/**
+	 * tec_tickets_commerce_is_enabled() reads the env var before the filter, so only putenv flips it
+	 * in this suite -- a __return_false filter is ignored.
+	 */
+	private function disable_tc(): void {
+		putenv( 'TEC_TICKETS_COMMERCE=0' );
+	}
+
+	/**
+	 * Event + stock-managed TC ticket + attendee (TC on), then force-construct the Module so it
+	 * self-registers into Tribe__Tickets__Tickets::$active_modules -- exactly the state ETP creates
+	 * via Reports\Tabbed_View::register_tabs() ( tribe( Module::class ) ) on the Attendees screen.
+	 *
+	 * @return array{event_id:int, ticket_id:int}
+	 */
+	private function make_active_tc_ticket(): array {
+		$event_id  = static::factory()->post->create( [ 'post_type' => 'post' ] );
+		$ticket_id = $this->with_capacity( 25 )->create_tc_ticket( $event_id, 20 );
+		$this->create_attendee_for_ticket( $ticket_id, $event_id );
+
+		tribe( Module::class );
+
+		return compact( 'event_id', 'ticket_id' );
+	}
+
+	/**
+	 * The fix: a constructed-but-disabled Commerce module is not an active provider.
+	 * Fails on HEAD (is_provider_active returns true once the Module is in the modules list).
+	 *
+	 * @test
+	 */
+	public function it_reports_commerce_inactive_when_tc_disabled() {
+		$this->make_active_tc_ticket();
+
+		$this->disable_tc();
+
+		$this->assertFalse(
+			tribe_tickets_is_provider_active( Module::class ),
+			'A disabled Tickets Commerce module must not be an active provider, even once constructed.'
+		);
+	}
+
+	/**
+	 * The guard must not over-reach: with TC enabled the Module resolves active as before.
+	 *
+	 * @test
+	 */
+	public function it_reports_commerce_active_when_tc_enabled() {
+		$this->make_active_tc_ticket();
+
+		$this->assertTrue(
+			tribe_tickets_is_provider_active( Module::class ),
+			'Tickets Commerce must resolve as active when enabled.'
+		);
+	}
+
+	/**
+	 * The crash path: Ticket_Object::inventory() resolves the provider; with the fix it now comes back
+	 * inactive, so inventory() takes its empty-provider fallback instead of fetching attendees -- no fatal.
+	 *
+	 * @test
+	 */
+	public function it_does_not_fatal_on_inventory_when_tc_disabled() {
+		[ 'event_id' => $event_id, 'ticket_id' => $ticket_id ] = $this->make_active_tc_ticket();
+		$ticket = tribe( Module::class )->get_ticket( $event_id, $ticket_id );
+		$this->assertInstanceOf( \Tribe__Tickets__Ticket_Object::class, $ticket );
+
+		$this->disable_tc();
+
+		$threw     = false;
+		$inventory = null;
+		try {
+			$inventory = $ticket->inventory();
+		} catch ( \Throwable $e ) {
+			$threw = true;
+		}
+
+		$this->assertFalse( $threw, 'Inventory must not throw when Tickets Commerce is disabled.' );
+		$this->assertIsInt( $inventory, 'Inventory falls back to a numeric value when the provider is inactive.' );
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Provider_Active_TC_Disabled_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Provider_Active_TC_Disabled_Test.php
@@ -7,9 +7,9 @@ use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
 
 /**
- * SMTNC-345: a disabled Tickets Commerce module must resolve as an INACTIVE provider even after
- * something constructs it (e.g. ETP's Orders Tabbed View), so the Attendees inventory path cannot
- * reach the unloaded tec_tc_* helpers and fatal.
+ * A disabled Tickets Commerce module must resolve as an inactive provider even after something
+ * constructs it (e.g. ETP's Orders Tabbed View), so the Attendees inventory path cannot reach the
+ * unloaded tec_tc_* helpers and fatal.
  *
  * @group commerce
  */
@@ -45,9 +45,8 @@ class Provider_Active_TC_Disabled_Test extends WPTestCase {
 	}
 
 	/**
-	 * Event + stock-managed TC ticket + attendee (TC on), then force-construct the Module so it
-	 * self-registers into Tribe__Tickets__Tickets::$active_modules -- exactly the state ETP creates
-	 * via Reports\Tabbed_View::register_tabs() ( tribe( Module::class ) ) on the Attendees screen.
+	 * Force-constructs the Module so it self-registers into the modules list, mirroring the state
+	 * ETP's Orders Tabbed View creates on the Attendees screen.
 	 *
 	 * @return array{event_id:int, ticket_id:int}
 	 */
@@ -62,8 +61,7 @@ class Provider_Active_TC_Disabled_Test extends WPTestCase {
 	}
 
 	/**
-	 * The fix: a constructed-but-disabled Commerce module is not an active provider.
-	 * Fails on HEAD (is_provider_active returns true once the Module is in the modules list).
+	 * A constructed-but-disabled Commerce module is not an active provider.
 	 *
 	 * @test
 	 */
@@ -79,7 +77,7 @@ class Provider_Active_TC_Disabled_Test extends WPTestCase {
 	}
 
 	/**
-	 * The guard must not over-reach: with TC enabled the Module resolves active as before.
+	 * With TC enabled the Module still resolves as an active provider.
 	 *
 	 * @test
 	 */
@@ -93,8 +91,8 @@ class Provider_Active_TC_Disabled_Test extends WPTestCase {
 	}
 
 	/**
-	 * The crash path: Ticket_Object::inventory() resolves the provider; with the fix it now comes back
-	 * inactive, so inventory() takes its empty-provider fallback instead of fetching attendees -- no fatal.
+	 * Ticket_Object::inventory() resolves the provider; an inactive one must take the empty-provider
+	 * fallback rather than reaching the unloaded tec_tc_* helpers and fataling.
 	 *
 	 * @test
 	 */


### PR DESCRIPTION
With Event Tickets Plus active, the Attendees screen's Orders Tabbed View constructs the Commerce Module while Tickets Commerce is disabled, which self-registers it as an active provider. The inventory path then resolves it and calls the unloaded `tec_tc_get_attendee()`, producing a fatal. Guard `tribe_tickets_is_provider_active()` so a disabled Commerce module is never treated as active -- mirroring the existing `tribe_tickets_get_ticket_provider()` guard -- and replace the leaf-guard test with one covering provider resolution.

### 🎫 Ticket

[SMTNC-345](https://linear.app/nexcess/issue/SMTNC-345/fatal-error-call-to-undefined-function-tec-tc-get-attendee-in)


### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
