### PR TITLE
test: phpcs CI — intentional phpcs violation [DO NOT MERGE]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,7 +25,7 @@ jobs:
   phpcs:
     needs: check
     if: needs.check.outputs.run_tests == 'true'
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@main
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -25,7 +25,7 @@ jobs:
   phpcs:
     needs: check
     if: needs.check.outputs.run_tests == 'true'
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-xargs-exit-code
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/test-phpcs-violation.php
+++ b/test-phpcs-violation.php
@@ -1,0 +1,11 @@
+<?php
+// Intentional phpcs violation file - DO NOT MERGE.
+// This file contains deliberate coding standard violations
+// to validate that phpcs CI correctly reports them via reviewdog.
+function intentional_violation(){$x=1+2;$y=$x*3;return $y;}
+class BadClass{
+function bad_method($a,$b){
+$result=$a+$b;
+return $result;
+}
+}

--- a/test-phpcs-violation.php
+++ b/test-phpcs-violation.php
@@ -1,11 +1,18 @@
 <?php
-// Intentional phpcs violation file - DO NOT MERGE.
-// This file contains deliberate coding standard violations
-// to validate that phpcs CI correctly reports them via reviewdog.
-function intentional_violation(){$x=1+2;$y=$x*3;return $y;}
-class BadClass{
-function bad_method($a,$b){
-$result=$a+$b;
-return $result;
-}
+// Intentional phpcs violation — DO NOT MERGE.
+// Violations: missing space after control keywords, old array() syntax, no space after commas.
+function check_items($items,$limit,$strict) {
+  $result = array();
+  if($strict===true){
+    foreach($items as $k=>$v){
+      if(strlen($v)>$limit){
+        $result[] = $v;
+      }elseif(is_null($v)){
+        continue;
+      }
+    }
+  }else{
+    $result = array_filter($items,function($v) use($limit){ return strlen($v)<=$limit; });
+  }
+  return $result;
 }


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — Test PR only.

Validates the fix from [stellarwp/github-actions#22](https://github.com/stellarwp/github-actions/pull/22) before it merges to `main`.

**Scenario:** A PHP file with deliberate coding standard violations is added (`test-phpcs-violation.php`).

Violations introduced:
- No spaces around operators (`$x=1+2`)
- Multiple statements on one line
- Missing space before opening brace on functions and classes
- Missing doc comments

**Expected CI result:** The `phpcs` job should **run** phpcs, produce a valid JSON report with the violations found, and exit with a **non-zero code** (as expected when real violations exist). reviewdog should post **inline comments** on this PR for each violation. The job should not crash with an invalid JSON error or a "file does not exist" error — only the phpcs exit code should propagate.

---
_Temporarily points `.github/workflows/phpcs.yml` to `fix/phpcs-empty-changed-files` to validate the fix before merge._