### PR TITLE
[RSVP] Part 1/22 - PHP V2 Core Classes

### DIFF
--- a/src/Tickets/RSVP/V2/Assets.php
+++ b/src/Tickets/RSVP/V2/Assets.php
@@ -117,6 +117,17 @@ class Assets {
 			[ 'tribe-common-skeleton-style', 'tribe-common-responsive' ]
 		);
 
+		tec_asset(
+			$plugin,
+			Block_Editor::EDITOR_MIRROR_STYLE,
+			'rsvp/editor-mirror.css',
+			[ 'tec-tickets-commerce-rsvp-style' ],
+			'enqueue_block_editor_assets',
+			[
+				'conditionals' => [ $this, 'should_enqueue_block_editor_styles' ],
+			]
+		);
+
 		$stylesheet = Tribe__Templates::locate_stylesheet( 'tribe-events/tickets/rsvp.css' );
 
 		if ( $stylesheet ) {
@@ -141,5 +152,34 @@ class Assets {
 		}
 
 		return tribe_tickets_post_type_enabled( $post->post_type );
+	}
+
+	/**
+	 * Whether to enqueue block editor RSVP canvas styles.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_enqueue_block_editor_styles(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( $screen instanceof \WP_Screen && $screen->base === 'post' ) {
+			return tribe_tickets_post_type_enabled( $screen->post_type );
+		}
+
+		$post = get_post();
+
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+
+		$ticketable_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+
+		return in_array( $post->post_type, $ticketable_post_types, true );
 	}
 }

--- a/src/Tickets/RSVP/V2/Block_Editor.php
+++ b/src/Tickets/RSVP/V2/Block_Editor.php
@@ -9,6 +9,9 @@
 
 namespace TEC\Tickets\RSVP\V2;
 
+use TEC\Tickets\REST\TEC\V1\Endpoints\Ticket as Ticket_Endpoint;
+use WP_Post;
+
 /**
  * Class Block_Editor
  *
@@ -19,6 +22,27 @@ namespace TEC\Tickets\RSVP\V2;
  * @package TEC\Tickets\RSVP\V2
  */
 class Block_Editor {
+	/**
+	 * Style handle for RSVP V2 editor canvas overrides (mirror affordances).
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const EDITOR_MIRROR_STYLE = 'tec-tickets-rsvp-v2-block-editor-mirror-style';
+
+	/**
+	 * Register `register_block_type_args` filter so the canvas iframe (WP 6.3+)
+	 * also receives the shared frontend RSVP styles via the block's `editorStyle`.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_filter( 'register_block_type_args', [ $this, 'add_rsvp_block_editor_style_args' ], 10, 2 );
+	}
+
 	/**
 	 * Add V2 RSVP configuration to the block editor config.
 	 *
@@ -35,17 +59,72 @@ class Block_Editor {
 			'enabled'         => true,
 			'ticketsEndpoint' => '/tec/v1/tickets',
 			'ticketType'      => Constants::TC_RSVP_TYPE,
+			'initialTicket'   => $this->get_initial_rsvp_ticket(),
 		];
 
 		return $config;
 	}
 
 	/**
-	 * Use the pre-render block filter as an action to ensure that Tickets' block assets
-	 * are enqueued.
+	 * Returns the RSVP ticket for the current post in REST-shaped format.
 	 *
-	 * The Tickets' block assets need to be enqueued before the block renders to ensure the
-	 * scripts queued with it will not be dequeued by the block rendering process.
+	 * Preloaded into the block editor so the RSVP block can render without
+	 * waiting for an async fetch on first paint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string,mixed>|null Formatted ticket entity or null when none exists.
+	 */
+	private function get_initial_rsvp_ticket(): ?array {
+		$post_id = get_the_ID();
+
+		if ( ! $post_id ) {
+			return null;
+		}
+
+		$ticket = tribe( Ticket::class )->get_for_event( (int) $post_id );
+
+		if ( ! $ticket ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'tec_tc_get_ticket' ) ) {
+			return null;
+		}
+
+		$ticket_post = tec_tc_get_ticket( (int) $ticket->ID );
+
+		if ( ! $ticket_post instanceof WP_Post ) {
+			return null;
+		}
+
+		/** @var Ticket_Endpoint $endpoint */
+		$endpoint = tribe( Ticket_Endpoint::class );
+
+		$initial_ticket = $endpoint->get_formatted_entity( $ticket_post );
+
+		/**
+		 * Filters the initial RSVP ticket data preloaded into the block editor.
+		 *
+		 * Allows ET+ and other add-ons to inject additional fields (e.g.,
+		 * has_attendee_info_fields, field_labels) into the server-preloaded
+		 * ticket data so the RSVP block renders correctly on first paint.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string,mixed> $initial_ticket The formatted ticket entity.
+		 * @param int                 $post_id        The current post ID.
+		 * @param int                 $ticket_id      The ticket post ID.
+		 */
+		return apply_filters( 'tec_tickets_rsvp_v2_initial_ticket', $initial_ticket, $post_id, (int) $ticket_post->ID );
+	}
+
+	/**
+	 * Use the pre-render block filter as an action to ensure that Tickets' block assets
+	 * are enqueued for server-side rendering contexts (REST API, etc.).
+	 *
+	 * Note: this does NOT fire in the block editor admin (blocks render client-side there).
+	 * Editor assets are handled by `enqueue_rsvp_block_editor_styles` instead.
 	 *
 	 * @since TBD
 	 *
@@ -60,5 +139,92 @@ class Block_Editor {
 		}
 
 		return $pre_render;
+	}
+
+	/**
+	 * Attach frontend RSVP styles to the tribe/rsvp block type so WordPress
+	 * automatically loads them inside the editor canvas iframe (WP 6.3+).
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $args       Block registration arguments.
+	 * @param string              $block_type The block name.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function add_rsvp_block_editor_style_args( array $args, string $block_type ): array {
+		if ( 'tribe/rsvp' !== $block_type ) {
+			return $args;
+		}
+
+		$canvas_styles = [
+			'tribe-common-skeleton-style',
+			'tribe-common-responsive',
+			'tribe-common-full-style',
+			'tec-tickets-commerce-rsvp-style',
+			self::EDITOR_MIRROR_STYLE,
+		];
+
+		$existing = isset( $args['editorStyle'] ) ? (array) $args['editorStyle'] : [];
+
+		$args['editorStyle'] = array_values( array_unique( array_merge( $existing, $canvas_styles ) ) );
+
+		return $args;
+	}
+
+	/**
+	 * Whether RSVP editor canvas styles should be enqueued.
+	 *
+	 * Called during `enqueue_block_editor_assets` and `enqueue_block_assets`.
+	 * Uses `get_current_screen()` so it works even when `get_post()` is not yet set.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function should_enqueue_block_editor_styles(): bool {
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( $screen instanceof \WP_Screen && $screen->base === 'post' ) {
+			return tribe_tickets_post_type_enabled( $screen->post_type );
+		}
+
+		// Fallback: if screen is not set yet (e.g. during REST block rendering), check the post.
+		$post = get_post();
+
+		if ( ! $post instanceof \WP_Post ) {
+			return false;
+		}
+
+		$ticketable_post_types = (array) tribe_get_option( 'ticket-enabled-post-types', [] );
+
+		return in_array( $post->post_type, $ticketable_post_types, true );
+	}
+
+	/**
+	 * Enqueue RSVP frontend styles in the block editor.
+	 *
+	 * Hooked to both `enqueue_block_editor_assets` (editor chrome + non-iframe WP < 6.3)
+	 * and `enqueue_block_assets` (editor canvas iframe WP 6.3+).
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function enqueue_rsvp_block_editor_styles(): void {
+		if ( ! $this->should_enqueue_block_editor_styles() ) {
+			return;
+		}
+
+		tribe_asset_enqueue( 'tribe-common-skeleton-style' );
+		tribe_asset_enqueue( 'tribe-common-responsive' );
+		tribe_asset_enqueue( 'tribe-common-full-style' );
+		tribe_asset_enqueue( 'tribe-tickets-gutenberg-block-rsvp-style' );
+		tribe_asset_enqueue( 'tec-tickets-commerce-rsvp-style' );
+		tribe_asset_enqueue( self::EDITOR_MIRROR_STYLE );
 	}
 }

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -42,6 +42,8 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( Metabox::class );
 		$this->container->singleton( Classic_Editor::class );
 		$this->container->singleton( Block_Editor::class );
+		$block_editor = $this->container->get( Block_Editor::class );
+		$block_editor->register();
 		$this->container->singleton( Frontend::class );
 		$this->container->singleton( Repository_Filters::class );
 		$this->container->singleton( REST\Order_Endpoint::class );
@@ -104,6 +106,17 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Block_Editor::class, 'enqueue_tickets_block_assets' ),
 			10,
 			2
+		);
+		// Load in editor chrome (WP < 6.3 non-iframe) AND canvas iframe (WP 6.3+).
+		add_action(
+			'enqueue_block_editor_assets',
+			$this->container->callback( Block_Editor::class, 'enqueue_rsvp_block_editor_styles' ),
+			20
+		);
+		add_action(
+			'enqueue_block_assets',
+			$this->container->callback( Block_Editor::class, 'enqueue_rsvp_block_editor_styles' ),
+			20
 		);
 
 		// Frontend.
@@ -256,6 +269,21 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'pre_render_block',
 			$this->container->callback( Block_Editor::class, 'enqueue_tickets_block_assets' )
+		);
+		remove_filter(
+			'register_block_type_args',
+			$this->container->callback( Block_Editor::class, 'add_rsvp_block_editor_style_args' ),
+			10
+		);
+		remove_action(
+			'enqueue_block_editor_assets',
+			$this->container->callback( Block_Editor::class, 'enqueue_rsvp_block_editor_styles' ),
+			20
+		);
+		remove_action(
+			'enqueue_block_assets',
+			$this->container->callback( Block_Editor::class, 'enqueue_rsvp_block_editor_styles' ),
+			20
 		);
 		remove_action( 'wp_enqueue_scripts', $this->container->callback( Frontend::class, 'enqueue_rsvp_assets' ) );
 		remove_filter(

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -9,13 +9,14 @@
 
 namespace TEC\Tickets\RSVP\V2;
 
+use TEC\Tickets\Commerce\Attendee;
 use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Ticket;
+use TEC\Tickets\RSVP\V2\Ticket as RSVP_V2_Ticket;
 use Tribe__Tickets__Editor__Template as Tickets_Editor_Template;
 use Tribe__Tickets__RSVP as RSVP_V1_Tickets_Handler;
-use Tribe__Tickets__Tickets as Tickets_Handler;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
-use TEC\Tickets\Commerce\Attendee;
-use TEC\Tickets\Commerce\Ticket;
+use Tribe__Tickets__Tickets as Tickets_Handler;
 use WP_Post;
 
 /**
@@ -71,18 +72,21 @@ class Frontend {
 		WP_Post $post,
 		bool $should_echo
 	): string {
-		$active_rsvps = $args['active_rsvps'] ?? [];
-
-		// Find the first TC-RSVP ticket in the active RSVPs.
+		// Check $args['active_rsvps'] first (may be populated by third-party extensions).
 		$rsvp = null;
-		foreach ( $active_rsvps as $ticket ) {
+		foreach ( $args['active_rsvps'] ?? [] as $ticket ) {
 			if ( $ticket->type() === Constants::TC_RSVP_TYPE ) {
-				$rsvp = $ticket;
-				break;
+				if ( $rsvp === null || $ticket->ID > $rsvp->ID ) {
+					$rsvp = $ticket;
+				}
 			}
 		}
 
-		// Only process if we have a TC-RSVP ticket.
+		// $args['active_rsvps'] is built from V1 RSVP tickets only; query TC-RSVP tickets directly.
+		if ( $rsvp === null ) {
+			$rsvp = tribe( RSVP_V2_Ticket::class )->get_for_event( $post->ID );
+		}
+
 		if ( $rsvp === null ) {
 			return $content;
 		}

--- a/src/Tickets/RSVP/V2/Metabox.php
+++ b/src/Tickets/RSVP/V2/Metabox.php
@@ -15,6 +15,7 @@ use TEC\Tickets\Event;
 use Tribe__Tickets__Admin__Views as Admin_Views;
 use TEC\Tickets\RSVP\V2\Constants;
 use TEC\Tickets\Commerce\Ticket;
+use TEC\Tickets\RSVP\V2\Ticket as RSVP_V2_Ticket;
 use Tribe__Tickets__Main;
 use Tribe__Date_Utils;
 use WP_Post;
@@ -303,14 +304,6 @@ class Metabox {
 	 * @return Tribe__Tickets__Ticket_Object|null Matching ticket object or null if not found.
 	 */
 	private function get_tc_rsvp_ticket( int $post_id ): ?Tribe__Tickets__Ticket_Object {
-		$ticket_id = tribe( 'tickets.ticket-repository.rsvp' )
-			->where( 'event', $post_id )
-			->first_id();
-
-		if ( ! $ticket_id ) {
-			return null;
-		}
-
-		return tribe( 'tickets.rsvp' )->get_ticket( $post_id, $ticket_id );
+		return tribe( RSVP_V2_Ticket::class )->get_for_event( $post_id );
 	}
 }

--- a/src/Tickets/RSVP/V2/Ticket.php
+++ b/src/Tickets/RSVP/V2/Ticket.php
@@ -9,7 +9,9 @@
 
 namespace TEC\Tickets\RSVP\V2;
 
+use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Ticket as Commerce_Ticket;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
 
 /**
  * Class Ticket
@@ -59,5 +61,32 @@ class Ticket {
 	 */
 	public function set_as_rsvp( int $ticket_id ): bool {
 		return (bool) update_post_meta( $ticket_id, Commerce_Ticket::$type_meta_key, Constants::TC_RSVP_TYPE );
+	}
+
+	/**
+	 * Get the TC-RSVP ticket for an event.
+	 *
+	 * When multiple tickets exist for the same event, returns the most recently
+	 * created one so stale tickets left behind after a failed delete do not win.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $post_id The event post ID.
+	 *
+	 * @return Ticket_Object|null Matching ticket object or null when not found.
+	 */
+	public function get_for_event( int $post_id ): ?Ticket_Object {
+		$ticket_id = (int) tribe( 'tickets.ticket-repository.rsvp' )
+			->where( 'event', $post_id )
+			->order_by( 'ID', 'DESC' )
+			->first_id();
+
+		if ( ! $ticket_id ) {
+			return null;
+		}
+
+		$ticket = tribe( Module::class )->get_ticket( $post_id, $ticket_id );
+
+		return $ticket instanceof Ticket_Object ? $ticket : null;
 	}
 }


### PR DESCRIPTION
## Part 1/19

These files handle the **PHP backend core** for the RSVP V2 block editor refactor:

- `Ticket.php` — Initial ticket retrieval methods supporting RSVP V2
- `Block_Editor.php` — Block editor styles, initial ticket data, editor configuration
- `Controller.php` — RSVP V2 controller updates
- `Assets.php` — Conditional block editor style loading
- `Frontend.php` — Switch ticket retrieval to RSVP V2 class
- `Metabox.php` — Updated ticket class references
- `RSVP.php` — Base RSVP class type safety improvements

---

> **Next:** [split/soft-3335-02-php-views-tests](https://github.com/the-events-calendar/event-tickets/pull/4283)
