### PR TITLE
[RSVP] Part 2/22 - PHP Views & Test Fixtures

### DIFF
--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -179,7 +179,7 @@ jobs:
       # Run tests
       # ------------------------------------------------------------------------------
       - name: Run suite tests
-        run: ${SLIC_BIN} run ${{ matrix.suite }} --ext DotReporter
+        run: ${SLIC_BIN} run ${{ matrix.suite }} --ext DotReporter --debug
       # ------------------------------------------------------------------------------
       # Upload artifacts (On failure)
       # ------------------------------------------------------------------------------

--- a/.github/workflows/tests-php-ct1.yml
+++ b/.github/workflows/tests-php-ct1.yml
@@ -179,7 +179,7 @@ jobs:
       # Run tests
       # ------------------------------------------------------------------------------
       - name: Run suite tests
-        run: ${SLIC_BIN} run ${{ matrix.suite }} --ext DotReporter --debug
+        run: ${SLIC_BIN} run ${{ matrix.suite }} --ext DotReporter
       # ------------------------------------------------------------------------------
       # Upload artifacts (On failure)
       # ------------------------------------------------------------------------------

--- a/src/views/v2/commerce/rsvp/actions/rsvp.php
+++ b/src/views/v2/commerce/rsvp/actions/rsvp.php
@@ -22,5 +22,4 @@ defined( 'ABSPATH' ) || die();
 	<?php $this->template( 'v2/commerce/rsvp/actions/rsvp/going', [ 'rsvp' => $rsvp ] ); ?>
 
 	<?php $this->template( 'v2/commerce/rsvp/actions/rsvp/not-going', [ 'rsvp' => $rsvp ] ); ?>
-
 </div>

--- a/src/views/v2/rsvp/actions/rsvp.php
+++ b/src/views/v2/rsvp/actions/rsvp.php
@@ -18,12 +18,7 @@
 
 ?>
 <div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		<?php esc_html_e( 'RSVP Here', 'event-tickets' ); ?>
-	</span>
-
 	<?php $this->template( 'v2/rsvp/actions/rsvp/going', [ 'rsvp' => $rsvp ] ); ?>
 
 	<?php $this->template( 'v2/rsvp/actions/rsvp/not-going', [ 'rsvp' => $rsvp ] ); ?>
-
 </div>

--- a/tests/_support/Partials/V2TestCase.php
+++ b/tests/_support/Partials/V2TestCase.php
@@ -7,6 +7,7 @@ use tad\WP\Snapshots\WPHtmlOutputDriver;
 use Spatie\Snapshots\MatchesSnapshots;
 use Tribe\Events\Test\Factories\Event;
 use Tribe\Test\PHPUnit\Traits\With_Post_Remapping;
+use Tribe\Tickets\Test\Traits\With_Snapshot_Post_Id_Replacement;
 use Tribe__Tickets__Editor__Template;
 
 /**
@@ -20,6 +21,7 @@ abstract class V2TestCase extends WPTestCase {
 	}
 
 	use With_Post_Remapping;
+	use With_Snapshot_Post_Id_Replacement;
 
 	/**
 	 * The path relative to the V2 views path.
@@ -35,6 +37,9 @@ abstract class V2TestCase extends WPTestCase {
 		parent::setUp();
 
 		$this->factory()->event = new Event();
+
+		// Prevent loader icon classes from leaking between partial tests.
+		tribe( 'tickets.editor.template' )->set( 'classes', [], false );
 	}
 
 	/**

--- a/tests/_support/Testcases/REST/V1/BaseTicketEditorCest.php
+++ b/tests/_support/Testcases/REST/V1/BaseTicketEditorCest.php
@@ -376,6 +376,8 @@ class BaseTicketEditorCest extends BaseRestCest {
 			],
 			'requires_attendee_information' => false,
 			'attendee_information_fields'   => [],
+			'has_attendee_info_fields'      => false,
+			'field_labels'                  => [],
 			'supports_attendee_information' => false,
 			'attendees'                     => [],
 			'checkin'                       => [
@@ -394,7 +396,7 @@ class BaseTicketEditorCest extends BaseRestCest {
 		$is_plus_test = $this->is_plus;
 
 		if ( ! $is_plus_test ) {
-			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'] );
+			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'], $expected_json['has_attendee_info_fields'], $expected_json['field_labels'] );
 		}
 
 		$response = json_decode( $I->grabResponse(), true );
@@ -505,6 +507,8 @@ class BaseTicketEditorCest extends BaseRestCest {
 			],
 			'requires_attendee_information' => false,
 			'attendee_information_fields'   => [],
+			'has_attendee_info_fields'      => false,
+			'field_labels'                  => [],
 			'supports_attendee_information' => false,
 			'attendees'                     => [],
 			'checkin'                       => [
@@ -533,7 +537,7 @@ class BaseTicketEditorCest extends BaseRestCest {
 		$is_plus_test = $this->is_plus;
 
 		if ( ! $is_plus_test ) {
-			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'] );
+			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'], $expected_json['has_attendee_info_fields'], $expected_json['field_labels'] );
 		}
 
 		$create_response = json_decode( $I->grabResponse(), true );
@@ -688,6 +692,8 @@ class BaseTicketEditorCest extends BaseRestCest {
 			],
 			'requires_attendee_information' => false,
 			'attendee_information_fields'   => [],
+			'has_attendee_info_fields'      => false,
+			'field_labels'                  => [],
 			'supports_attendee_information' => false,
 			'attendees'                     => [],
 			'checkin'                       => [
@@ -707,7 +713,7 @@ class BaseTicketEditorCest extends BaseRestCest {
 		$is_plus_test = $this->is_plus;
 
 		if ( ! $is_plus_test ) {
-			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'] );
+			unset( $expected_json['requires_attendee_information'], $expected_json['attendee_information_fields'], $expected_json['has_attendee_info_fields'], $expected_json['field_labels'] );
 		}
 
 		$response = json_decode( $I->grabResponse(), true );

--- a/tests/_support/Testcases/RSVPBlock_TestCase.php
+++ b/tests/_support/Testcases/RSVPBlock_TestCase.php
@@ -4,10 +4,13 @@ namespace Tribe\Tickets\Test\Testcases;
 
 use tad\WP\Snapshots\WPHtmlOutputDriver;
 use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
+use Tribe\Tickets\Test\Testcases\TicketsBlock_TestCase;
+use Tribe\Tickets\Test\Traits\With_Snapshot_Post_Id_Replacement;
 
 class RSVPBlock_TestCase extends TicketsBlock_TestCase {
 
 	use RSVP_Ticket_Maker;
+	use With_Snapshot_Post_Id_Replacement;
 
 	/**
 	 * Get list of providers for test.
@@ -82,16 +85,12 @@ class RSVPBlock_TestCase extends TicketsBlock_TestCase {
 		$html = preg_replace( '/<svg.*<\/svg>/Ums', '', $html );
 
 		// Handle variations that tolerances won't handle.
-		$html = str_replace(
+		$html = $this->replace_snapshot_post_ids(
+			$html,
 			[
-				$post_id,
-				$ticket_id,
-			],
-			[
-				'[EVENT_ID]',
-				'[TICKET_ID]',
-			],
-			$html
+				$post_id   => '[EVENT_ID]',
+				$ticket_id => '[TICKET_ID]',
+			]
 		);
 
 		$this->assertNotEmpty( $html, 'RSVP block is not rendering' );
@@ -136,16 +135,12 @@ class RSVPBlock_TestCase extends TicketsBlock_TestCase {
 		// Remove pesky SVG.
 		$html = preg_replace( '/<svg.*<\/svg>/Ums', '', $html );
 		// Handle variations that tolerances won't handle.
-		$html = str_replace(
+		$html = $this->replace_snapshot_post_ids(
+			$html,
 			[
-				$post_id,
-				$ticket_id,
-			],
-			[
-				'[EVENT_ID]',
-				'[TICKET_ID]',
-			],
-			$html
+				$post_id   => '[EVENT_ID]',
+				$ticket_id => '[TICKET_ID]',
+			]
 		);
 
 		$this->assertNotEmpty( $html, 'RSVP block is not rendering' );

--- a/tests/_support/Traits/With_Snapshot_Post_Id_Replacement.php
+++ b/tests/_support/Traits/With_Snapshot_Post_Id_Replacement.php
@@ -10,8 +10,16 @@ trait With_Snapshot_Post_Id_Replacement {
 	/**
 	 * Replace dynamic post/ticket IDs with snapshot placeholders.
 	 *
-	 * Uses contextual replacements and word boundaries to avoid corrupting
-	 * unrelated substrings (e.g. `a11y`, `event12`).
+	 * Every replacement is anchored to a static prefix/suffix taken from the
+	 * actual markup (e.g. `data-rsvp-id="`, `tribe_tickets[`,
+	 * `quantity_`) so a small, common ID (e.g. `1` or `2`) cannot match
+	 * unrelated numbers elsewhere in the snapshot (quantities, array
+	 * indices, counters, etc).
+	 *
+	 * There is intentionally no generic catch-all replacement. If a new
+	 * template introduces the ID in a context not listed here, the
+	 * snapshot assertion will fail — add the new exact pattern rather than
+	 * widening one of the existing ones.
 	 *
 	 * @param string                   $html
 	 * @param array<int|string,string> $placeholders Map of ID => placeholder token.
@@ -23,25 +31,25 @@ trait With_Snapshot_Post_Id_Replacement {
 			$id = (string) $id;
 
 			$contextual = [
-				'event[' . $id . ']'              => 'event[' . $placeholder . ']',
-				'event' . $id                     => 'event' . $placeholder,
-				'data-post-id="' . $id . '"'     => 'data-post-id="' . $placeholder . '"',
-				'data-ticket-id="' . $id . '"'   => 'data-ticket-id="' . $placeholder . '"',
-				'data-rsvp-id="' . $id . '"'      => 'data-rsvp-id="' . $placeholder . '"',
-				'data-product-id="' . $id . '"'  => 'data-product-id="' . $placeholder . '"',
-				'[' . $id . ']'                  => '[' . $placeholder . ']',
-				'-' . $id                        => '-' . $placeholder,
-				'_' . $id . '_'                  => '_' . $placeholder . '_',
-				'for ' . $id                     => 'for ' . $placeholder,
-				'post-' . $id                    => 'post-' . $placeholder,
-				'quantity_' . $id                => 'quantity_' . $placeholder,
+				'event[' . $id . ']'               => 'event[' . $placeholder . ']',
+				'event' . $id                       => 'event' . $placeholder,
+				'data-post-id="' . $id . '"'        => 'data-post-id="' . $placeholder . '"',
+				'data-ticket-id="' . $id . '"'      => 'data-ticket-id="' . $placeholder . '"',
+				'data-rsvp-id="' . $id . '"'        => 'data-rsvp-id="' . $placeholder . '"',
+				'data-product-id="' . $id . '"'     => 'data-product-id="' . $placeholder . '"',
+				'tribe_tickets[' . $id . ']'        => 'tribe_tickets[' . $placeholder . ']',
+				'[ticket_id]" value="' . $id . '"'  => '[ticket_id]" value="' . $placeholder . '"',
+				'_' . $id . '_'                     => '_' . $placeholder . '_',
+				'for ' . $id                        => 'for ' . $placeholder,
+				'post-' . $id                       => 'post-' . $placeholder,
+				'quantity_' . $id                   => 'quantity_' . $placeholder,
 			];
 
 			$html = str_replace( array_keys( $contextual ), array_values( $contextual ), $html );
 
 			$html = preg_replace(
-				'/\b' . preg_quote( $id, '/' ) . '\b/',
-				$placeholder,
+				'/-' . preg_quote( $id, '/' ) . '(?!\d)/',
+				'-' . $placeholder,
 				$html
 			);
 		}

--- a/tests/_support/Traits/With_Snapshot_Post_Id_Replacement.php
+++ b/tests/_support/Traits/With_Snapshot_Post_Id_Replacement.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tribe\Tickets\Test\Traits;
+
+/**
+ * Replace dynamic post/ticket IDs with snapshot placeholders.
+ */
+trait With_Snapshot_Post_Id_Replacement {
+
+	/**
+	 * Replace dynamic post/ticket IDs with snapshot placeholders.
+	 *
+	 * Uses contextual replacements and word boundaries to avoid corrupting
+	 * unrelated substrings (e.g. `a11y`, `event12`).
+	 *
+	 * @param string                   $html
+	 * @param array<int|string,string> $placeholders Map of ID => placeholder token.
+	 *
+	 * @return string
+	 */
+	protected function replace_snapshot_post_ids( string $html, array $placeholders ): string {
+		foreach ( $placeholders as $id => $placeholder ) {
+			$id = (string) $id;
+
+			$contextual = [
+				'event[' . $id . ']'              => 'event[' . $placeholder . ']',
+				'event' . $id                     => 'event' . $placeholder,
+				'data-post-id="' . $id . '"'     => 'data-post-id="' . $placeholder . '"',
+				'data-ticket-id="' . $id . '"'   => 'data-ticket-id="' . $placeholder . '"',
+				'data-rsvp-id="' . $id . '"'      => 'data-rsvp-id="' . $placeholder . '"',
+				'data-product-id="' . $id . '"'  => 'data-product-id="' . $placeholder . '"',
+				'[' . $id . ']'                  => '[' . $placeholder . ']',
+				'-' . $id                        => '-' . $placeholder,
+				'_' . $id . '_'                  => '_' . $placeholder . '_',
+				'for ' . $id                     => 'for ' . $placeholder,
+				'post-' . $id                    => 'post-' . $placeholder,
+				'quantity_' . $id                => 'quantity_' . $placeholder,
+			];
+
+			$html = str_replace( array_keys( $contextual ), array_values( $contextual ), $html );
+
+			$html = preg_replace(
+				'/\b' . preg_quote( $id, '/' ) . '\b/',
+				$placeholder,
+				$html
+			);
+		}
+
+		return $html;
+	}
+}

--- a/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
+++ b/tests/integration/TEC/Tickets/Ticket_Actions_Test.php
@@ -633,6 +633,6 @@ class Ticket_Actions_Test extends Controller_Test_Case {
 		$ticket_actions = $this->make_controller();
 		$ticket_actions->update_event_cost( $ticket_id, $post_id );
 
-		$this->assertEquals( $expected, get_post_meta( $post_id, '_EventCost' ) );
+		$this->assertEqualsCanonicalizing( $expected, get_post_meta( $post_id, '_EventCost' ) );
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Block_Editor_Test.php
@@ -50,6 +50,49 @@ class Block_Editor_Test extends WPTestCase {
 		);
 	}
 
+	public function test_rsvp_v2_config_should_include_initial_ticket_key(): void {
+		$config = apply_filters( 'tribe_editor_config', [] );
+
+		$this->assertArrayHasKey(
+			'initialTicket',
+			$config['tickets']['rsvpV2'],
+			'RSVP V2 config should include initialTicket key'
+		);
+	}
+
+	public function test_rsvp_v2_config_initial_ticket_is_null_without_post(): void {
+		$config = apply_filters( 'tribe_editor_config', [] );
+
+		$this->assertNull(
+			$config['tickets']['rsvpV2']['initialTicket'],
+			'initialTicket should be null when no post context exists'
+		);
+	}
+
+	public function test_rsvp_v2_config_initial_ticket_matches_event_rsvp(): void {
+		wp_set_current_user( 1 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_title'  => 'RSVP Event',
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			]
+		);
+
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		global $post;
+		$post = get_post( $post_id );
+
+		$config = apply_filters( 'tribe_editor_config', [] );
+
+		$this->assertIsArray( $config['tickets']['rsvpV2']['initialTicket'] );
+		$this->assertSame( $ticket_id, $config['tickets']['rsvpV2']['initialTicket']['id'] );
+
+		wp_set_current_user( 0 );
+	}
+
 	public function test_should_preserve_existing_config_when_adding_rsvp_v2(): void {
 		$existing_config = [
 			'someKey'   => 'someValue',

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 0__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 0__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 1__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 1__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 2__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block with data set 2__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 0__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 0__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 1__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 1__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 2__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 2__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 3__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 3__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 4__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 4__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 5__1.php
+++ b/tests/wpunit/Tribe/Tickets/Commerce/RSVP/__snapshots__/RSVPBlockV2Test__test_should_render_ticket_block_after_update with data set 5__1.php
@@ -48,9 +48,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -60,8 +57,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 
@@ -118,9 +114,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -130,8 +123,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/__snapshots__/RsvpTest__test_should_render_going_and_not_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/__snapshots__/RsvpTest__test_should_render_going_and_not_going__1.php
@@ -1,7 +1,4 @@
 <?php return '<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -17,6 +14,5 @@
 			>
 		Can&#039;t go	</button>
 </div>
-
 </div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/__snapshots__/RsvpTest__test_should_render_going_only__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/Actions/__snapshots__/RsvpTest__test_should_render_going_only__1.php
@@ -1,7 +1,4 @@
 <?php return '<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -11,6 +8,5 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 ';

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/__snapshots__/ActionsTest__test_should_render_rsvp_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/__snapshots__/ActionsTest__test_should_render_rsvp_going__1.php
@@ -3,9 +3,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -15,8 +12,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/__snapshots__/ActionsTest__test_should_render_rsvp_going_and_not_going__1.php
+++ b/tests/wpunit/Tribe/Tickets/Partials/V2/RSVP/__snapshots__/ActionsTest__test_should_render_rsvp_going_and_not_going__1.php
@@ -3,9 +3,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -21,7 +18,6 @@
 			>
 		Can&#039;t go	</button>
 </div>
-
 </div>
 
 			</div>

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -2,18 +2,18 @@
 
 namespace Tribe\Tickets;
 
+use Closure;
+use Generator;
 use Prophecy\Argument;
 use Spatie\Snapshots\MatchesSnapshots;
 use tad\WP\Snapshots\WPHtmlOutputDriver;
 use Tribe\Events\Test\Factories\Event;
+use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
 use Tribe__Tickets__RSVP as RSVP;
 use Tribe__Tickets__Tickets_Handler as Handler;
 use Tribe__Tickets__Tickets_View as Tickets_View;
-use Generator;
-use Closure;
-use Tribe\Tests\Traits\With_Uopz;
 
 class RSVPTest extends \Codeception\TestCase\WPTestCase {
 
@@ -770,17 +770,19 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 			'data-opt-in-nonce',
 		] );
 
-		// Handle ticket ID variations that tolerances won't handle
+		// Handle ID variations that tolerances won't handle
 		$html = str_replace(
 			[
 				'[' . $ticket_id . ']',
 				'"' . $ticket_id . '"',
 				'--' . $ticket_id . '',
+				'[' . $post_id . ']',
 			],
 			[
 				'[TICKET_ID]',
 				'"TICKET_ID"',
 				'--TICKET_ID',
+				'[EVENT_ID]',
 			],
 			$html
 		);

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -11,6 +11,7 @@ use Tribe\Events\Test\Factories\Event;
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
+use Tribe\Tickets\Test\Traits\With_Snapshot_Post_Id_Replacement;
 use Tribe__Tickets__RSVP as RSVP;
 use Tribe__Tickets__Tickets_Handler as Handler;
 use Tribe__Tickets__Tickets_View as Tickets_View;
@@ -21,6 +22,7 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 	use Attendee_Maker;
 	use RSVP_Ticket_Maker;
 	use With_Uopz;
+	use With_Snapshot_Post_Id_Replacement;
 
 	/**
 	 * @var Tickets_View
@@ -755,14 +757,6 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 
 		$driver = new WPHtmlOutputDriver( home_url(), TRIBE_TESTS_HOME_URL );
 
-		$driver->setTolerableDifferences( [ $post_id, $ticket_id ] );
-		$driver->setTolerableDifferencesPrefixes( [
-			'quantity_',
-			'tribe-tickets-rsvp-name-',
-			'tribe-tickets-rsvp-email-',
-			'tribe-tickets__rsvp-ar-quantity-number--',
-		] );
-
 		$driver->setTimeDependentAttributes( [
 			'data-rsvp-id',
 			'data-product-id',
@@ -770,23 +764,13 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 			'data-opt-in-nonce',
 		] );
 
-		// Handle ID variations that tolerances won't handle.
-		$html = str_replace(
+		// Handle variations that tolerances won't handle.
+		$html = $this->replace_snapshot_post_ids(
+			$html,
 			[
-				'[' . $ticket_id . ']',
-				'"' . $ticket_id . '"',
-				'--' . $ticket_id . '',
-				'[' . $post_id . ']',
-				(string) $post_id,
-			],
-			[
-				'[TICKET_ID]',
-				'"TICKET_ID"',
-				'--TICKET_ID',
-				'[EVENT_ID]',
-				'[EVENT_ID]',
-			],
-			$html
+				$post_id   => '[EVENT_ID]',
+				$ticket_id => '[TICKET_ID]',
+			]
 		);
 
 		$this->assertMatchesSnapshot( $html, $driver );

--- a/tests/wpunit/Tribe/Tickets/RSVPTest.php
+++ b/tests/wpunit/Tribe/Tickets/RSVPTest.php
@@ -770,18 +770,20 @@ class RSVPTest extends \Codeception\TestCase\WPTestCase {
 			'data-opt-in-nonce',
 		] );
 
-		// Handle ID variations that tolerances won't handle
+		// Handle ID variations that tolerances won't handle.
 		$html = str_replace(
 			[
 				'[' . $ticket_id . ']',
 				'"' . $ticket_id . '"',
 				'--' . $ticket_id . '',
 				'[' . $post_id . ']',
+				(string) $post_id,
 			],
 			[
 				'[TICKET_ID]',
 				'"TICKET_ID"',
 				'--TICKET_ID',
+				'[EVENT_ID]',
 				'[EVENT_ID]',
 			],
 			$html

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
@@ -88,8 +88,8 @@
 		data-guest-number="1"
 		role="tab"
 		aria-selected="true"
-		aria-controls="tribe-tickets-rsvp-13704-guest-1-tab"
-		id="tribe-tickets-rsvp-13704-guest-1"
+		aria-controls="tribe-tickets-rsvp-14097-guest-1-tab"
+		id="tribe-tickets-rsvp-14097-guest-1"
 			>
 		<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-ar-guest-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 11 14"><defs/><path fill="#141827" stroke="#141827" stroke-width="1.1" d="M8.24995 3.575c0 1.32005-1.18823 2.475-2.75 2.475s-2.75-1.15495-2.75-2.475v-.55c0-1.32005 1.18823-2.475 2.75-2.475s2.75 1.15495 2.75 2.475v.55zM.55 11.5868c0-2.12633 1.7237-3.85003 3.85-3.85003h2.2c2.1263 0 3.85 1.7237 3.85 3.85003v1.7435H.55v-1.7435z"/></svg>		<span class="tribe-tickets__rsvp-ar-guest-list-item-title tribe-common-a11y-visual-hide">
 			Main Guest		</span>
@@ -97,7 +97,7 @@
 </li>
 	<script
 	class="tribe-tickets__rsvp-ar-guest-list-item-template"
-	id="tmpl-tribe-tickets__rsvp-ar-guest-list-item-template-13704"
+	id="tmpl-tribe-tickets__rsvp-ar-guest-list-item-template-14097"
 	type="text/template"
 >
 	<li class="tribe-tickets__rsvp-ar-guest-list-item">
@@ -107,8 +107,8 @@
 			data-guest-number="{{data.attendee_id + 1}}"
 			role="tab"
 			aria-selected="false"
-			aria-controls="tribe-tickets-rsvp-13704-guest-{{data.attendee_id + 1}}-tab"
-			id="tribe-tickets-rsvp-13704-guest-{{data.attendee_id + 1}}"
+			aria-controls="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}-tab"
+			id="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}"
 					>
 			<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-ar-guest-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 11 14"><defs/><path fill="#141827" stroke="#141827" stroke-width="1.1" d="M8.24995 3.575c0 1.32005-1.18823 2.475-2.75 2.475s-2.75-1.15495-2.75-2.475v-.55c0-1.32005 1.18823-2.475 2.75-2.475s2.75 1.15495 2.75 2.475v.55zM.55 11.5868c0-2.12633 1.7237-3.85003 3.85-3.85003h2.2c2.1263 0 3.85 1.7237 3.85 3.85003v1.7435H.55v-1.7435z"/></svg>			<span class="tribe-tickets__rsvp-ar-guest-list-item-title tribe-common-a11y-visual-hide">
 								Guest {{data.attendee_id + 1}}			</span>
@@ -135,8 +135,8 @@
 	data-guest-number="1"
 	tabindex="0"
 	role="tabpanel"
-	id="tribe-tickets-rsvp-13704-guest-1-tab"
-	aria-labelledby="tribe-tickets-rsvp-13704-guest-1"
+	id="tribe-tickets-rsvp-14097-guest-1-tab"
+	aria-labelledby="tribe-tickets-rsvp-14097-guest-1"
 >
 	<header>
 	<h3 class="tribe-tickets__rsvp-ar-form-title tribe-common-h5">
@@ -154,7 +154,7 @@
 	<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-13704"
+		for="tribe-tickets-rsvp-name-14097"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -163,7 +163,7 @@
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
 		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-13704"
+		id="tribe-tickets-rsvp-name-14097"
 		value=""
 		required
 		placeholder="Your Name"
@@ -173,7 +173,7 @@
 	<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-13704"
+		for="tribe-tickets-rsvp-email-14097"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -182,7 +182,7 @@
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
 		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-13704"
+		id="tribe-tickets-rsvp-email-14097"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -216,7 +216,7 @@
 
 	<script
 	class="tribe-tickets__rsvp-ar-form-guest-template"
-	id="tmpl-tribe-tickets__rsvp-ar-form-guest-template-13704"
+	id="tmpl-tribe-tickets__rsvp-ar-form-guest-template-14097"
 	type="text/template"
 >
 	<div
@@ -224,8 +224,8 @@
 		data-guest-number="{{data.attendee_id + 1}}"
 		tabindex="0"
 		role="tabpanel"
-		id="tribe-tickets-rsvp-13704-guest-{{data.attendee_id + 1}}-tab"
-		aria-labelledby="tribe-tickets-rsvp-13704-guest-{{data.attendee_id + 1}}"
+		id="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}-tab"
+		aria-labelledby="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}"
 		hidden
 	>
 

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set ari__1.php
@@ -27,7 +27,7 @@
 	<form
 	class="tribe-tickets__rsvp-ar tribe-common-g-row tribe-common-g-row--gutters"
 	name="tribe-tickets-rsvp-form-ari"
-	data-rsvp-id="TICKET_ID"
+	data-rsvp-id="[TICKET_ID]"
 >
 	<div class="tribe-tickets__rsvp-ar-sidebar-wrapper tribe-common-g-col">
 		<div class="tribe-tickets__rsvp-ar-sidebar">
@@ -49,13 +49,13 @@
 
 		<label
 	class="tribe-common-a11y-visual-hide"
-	for="tribe-tickets__rsvp-ar-quantity-number--TICKET_ID"
+	for="tribe-tickets__rsvp-ar-quantity-number--[TICKET_ID]"
 >
 	Quantity</label>
 <input
 	type="number"
-	id="tribe-tickets__rsvp-ar-quantity-number--TICKET_ID"
-	name="tribe_tickets[TICKET_ID][quantity]"
+	id="tribe-tickets__rsvp-ar-quantity-number--[TICKET_ID]"
+	name="tribe_tickets[[TICKET_ID]][quantity]"
 	class="tribe-common-h4"
 	step="1"
 	min="1"
@@ -88,8 +88,8 @@
 		data-guest-number="1"
 		role="tab"
 		aria-selected="true"
-		aria-controls="tribe-tickets-rsvp-14097-guest-1-tab"
-		id="tribe-tickets-rsvp-14097-guest-1"
+		aria-controls="tribe-tickets-rsvp-[TICKET_ID]-guest-1-tab"
+		id="tribe-tickets-rsvp-[TICKET_ID]-guest-1"
 			>
 		<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-ar-guest-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 11 14"><defs/><path fill="#141827" stroke="#141827" stroke-width="1.1" d="M8.24995 3.575c0 1.32005-1.18823 2.475-2.75 2.475s-2.75-1.15495-2.75-2.475v-.55c0-1.32005 1.18823-2.475 2.75-2.475s2.75 1.15495 2.75 2.475v.55zM.55 11.5868c0-2.12633 1.7237-3.85003 3.85-3.85003h2.2c2.1263 0 3.85 1.7237 3.85 3.85003v1.7435H.55v-1.7435z"/></svg>		<span class="tribe-tickets__rsvp-ar-guest-list-item-title tribe-common-a11y-visual-hide">
 			Main Guest		</span>
@@ -97,7 +97,7 @@
 </li>
 	<script
 	class="tribe-tickets__rsvp-ar-guest-list-item-template"
-	id="tmpl-tribe-tickets__rsvp-ar-guest-list-item-template-14097"
+	id="tmpl-tribe-tickets__rsvp-ar-guest-list-item-template-[TICKET_ID]"
 	type="text/template"
 >
 	<li class="tribe-tickets__rsvp-ar-guest-list-item">
@@ -107,8 +107,8 @@
 			data-guest-number="{{data.attendee_id + 1}}"
 			role="tab"
 			aria-selected="false"
-			aria-controls="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}-tab"
-			id="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}"
+			aria-controls="tribe-tickets-rsvp-[TICKET_ID]-guest-{{data.attendee_id + 1}}-tab"
+			id="tribe-tickets-rsvp-[TICKET_ID]-guest-{{data.attendee_id + 1}}"
 					>
 			<svg  class="tribe-tickets-svgicon tribe-tickets__rsvp-ar-guest-icon"  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 11 14"><defs/><path fill="#141827" stroke="#141827" stroke-width="1.1" d="M8.24995 3.575c0 1.32005-1.18823 2.475-2.75 2.475s-2.75-1.15495-2.75-2.475v-.55c0-1.32005 1.18823-2.475 2.75-2.475s2.75 1.15495 2.75 2.475v.55zM.55 11.5868c0-2.12633 1.7237-3.85003 3.85-3.85003h2.2c2.1263 0 3.85 1.7237 3.85 3.85003v1.7435H.55v-1.7435z"/></svg>			<span class="tribe-tickets__rsvp-ar-guest-list-item-title tribe-common-a11y-visual-hide">
 								Guest {{data.attendee_id + 1}}			</span>
@@ -125,9 +125,9 @@
 	<div class="tribe-tickets__rsvp-ar-form-wrapper tribe-common-g-col">
 		<div class="tribe-tickets__rsvp-ar-form">
 
-	<input type="hidden" name="tribe_tickets[TICKET_ID][ticket_id]" value="TICKET_ID">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][order_status]" value="yes">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][optout]" value="1">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][ticket_id]" value="[TICKET_ID]">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][order_status]" value="yes">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][optout]" value="1">
 
 	
 <div
@@ -135,8 +135,8 @@
 	data-guest-number="1"
 	tabindex="0"
 	role="tabpanel"
-	id="tribe-tickets-rsvp-14097-guest-1-tab"
-	aria-labelledby="tribe-tickets-rsvp-14097-guest-1"
+	id="tribe-tickets-rsvp-[TICKET_ID]-guest-1-tab"
+	aria-labelledby="tribe-tickets-rsvp-[TICKET_ID]-guest-1"
 >
 	<header>
 	<h3 class="tribe-tickets__rsvp-ar-form-title tribe-common-h5">
@@ -154,7 +154,7 @@
 	<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-14097"
+		for="tribe-tickets-rsvp-name-[TICKET_ID]"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -162,8 +162,8 @@
 	<input
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
-		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-14097"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][full_name]"
+		id="tribe-tickets-rsvp-name-[TICKET_ID]"
 		value=""
 		required
 		placeholder="Your Name"
@@ -173,7 +173,7 @@
 	<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-14097"
+		for="tribe-tickets-rsvp-email-[TICKET_ID]"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -181,8 +181,8 @@
 	<input
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
-		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-14097"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][email]"
+		id="tribe-tickets-rsvp-email-[TICKET_ID]"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -216,7 +216,7 @@
 
 	<script
 	class="tribe-tickets__rsvp-ar-form-guest-template"
-	id="tmpl-tribe-tickets__rsvp-ar-form-guest-template-14097"
+	id="tmpl-tribe-tickets__rsvp-ar-form-guest-template-[TICKET_ID]"
 	type="text/template"
 >
 	<div
@@ -224,8 +224,8 @@
 		data-guest-number="{{data.attendee_id + 1}}"
 		tabindex="0"
 		role="tabpanel"
-		id="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}-tab"
-		aria-labelledby="tribe-tickets-rsvp-14097-guest-{{data.attendee_id + 1}}"
+		id="tribe-tickets-rsvp-[TICKET_ID]-guest-{{data.attendee_id + 1}}-tab"
+		aria-labelledby="tribe-tickets-rsvp-[TICKET_ID]-guest-{{data.attendee_id + 1}}"
 		hidden
 	>
 

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set going__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set going__1.php
@@ -27,11 +27,11 @@
 	
 <form
 	name="tribe-tickets-rsvp-form"
-	data-rsvp-id="TICKET_ID"
+	data-rsvp-id="[TICKET_ID]"
 >
-	<input type="hidden" name="tribe_tickets[TICKET_ID][ticket_id]" value="TICKET_ID">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][order_status]" value="going">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][optout]" value="1">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][ticket_id]" value="[TICKET_ID]">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][order_status]" value="going">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][optout]" value="1">
 
 	<div class="tribe-tickets__rsvp-form-wrapper">
 
@@ -44,7 +44,7 @@
 			<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-14073"
+		for="tribe-tickets-rsvp-name-[TICKET_ID]"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -52,8 +52,8 @@
 	<input
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
-		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-14073"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][full_name]"
+		id="tribe-tickets-rsvp-name-[TICKET_ID]"
 		value=""
 		required
 		placeholder="Your Name"
@@ -62,7 +62,7 @@
 <div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-14073"
+		for="tribe-tickets-rsvp-email-[TICKET_ID]"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -70,8 +70,8 @@
 	<input
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
-		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-14073"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][email]"
+		id="tribe-tickets-rsvp-email-[TICKET_ID]"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -80,15 +80,15 @@
 <div class="tribe-common-b1 tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-common-b2--min-medium tribe-tickets__form-field-label"
-		for="quantity_14073"
+		for="quantity_[TICKET_ID]"
 	>
 		Number of Guests<span class="screen-reader-text">(required)</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
 	</label>
 	<input
 		type="number"
-		name="tribe_tickets[TICKET_ID][quantity]"
-		id="quantity_14073"
+		name="tribe_tickets[[TICKET_ID]][quantity]"
+		id="quantity_[TICKET_ID]"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-input-number tribe-tickets__rsvp-form-field-quantity"
 		value="1"
 		required

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set going__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set going__1.php
@@ -44,7 +44,7 @@
 			<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-13680"
+		for="tribe-tickets-rsvp-name-14073"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -53,7 +53,7 @@
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
 		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-13680"
+		id="tribe-tickets-rsvp-name-14073"
 		value=""
 		required
 		placeholder="Your Name"
@@ -62,7 +62,7 @@
 <div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-13680"
+		for="tribe-tickets-rsvp-email-14073"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -71,7 +71,7 @@
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
 		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-13680"
+		id="tribe-tickets-rsvp-email-14073"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -80,7 +80,7 @@
 <div class="tribe-common-b1 tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-common-b2--min-medium tribe-tickets__form-field-label"
-		for="quantity_13680"
+		for="quantity_14073"
 	>
 		Number of Guests<span class="screen-reader-text">(required)</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -88,7 +88,7 @@
 	<input
 		type="number"
 		name="tribe_tickets[TICKET_ID][quantity]"
-		id="quantity_13680"
+		id="quantity_14073"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-input-number tribe-tickets__rsvp-form-field-quantity"
 		value="1"
 		required

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set initial state__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set initial state__1.php
@@ -30,10 +30,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 13664</h3>
+	Test RSVP ticket for 14057</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 13664</p>
+	<p>Ticket RSVP ticket excerpt for 14057</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">
@@ -57,9 +57,6 @@
 
 		
 			<div class="tribe-tickets__rsvp-actions-rsvp">
-	<span class="tribe-common-h2 tribe-common-h6--min-medium">
-		RSVP Here	</span>
-
 	
 <div class="tribe-tickets__rsvp-actions-rsvp-going">
 	<button
@@ -69,8 +66,7 @@
 		Going	</button>
 </div>
 
-	
-</div>
+	</div>
 
 			</div>
 

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set initial state__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set initial state__1.php
@@ -30,10 +30,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 14057</h3>
+	Test RSVP ticket for [EVENT_ID]</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 14057</p>
+	<p>Ticket RSVP ticket excerpt for [EVENT_ID]</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set not going__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set not going__1.php
@@ -45,7 +45,7 @@
 			<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-13692"
+		for="tribe-tickets-rsvp-name-14085"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -54,7 +54,7 @@
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
 		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-13692"
+		id="tribe-tickets-rsvp-name-14085"
 		value=""
 		required
 		placeholder="Your Name"
@@ -63,7 +63,7 @@
 <div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-13692"
+		for="tribe-tickets-rsvp-email-14085"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -72,7 +72,7 @@
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
 		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-13692"
+		id="tribe-tickets-rsvp-email-14085"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -81,7 +81,7 @@
 <div class="tribe-common-b1 tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-common-b2--min-medium tribe-tickets__form-field-label"
-		for="quantity_13692"
+		for="quantity_14085"
 	>
 		Number of Guests Not Attending<span class="screen-reader-text">(required)</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -89,7 +89,7 @@
 	<input
 		type="number"
 		name="tribe_tickets[TICKET_ID][quantity]"
-		id="quantity_13692"
+		id="quantity_14085"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-input-number tribe-tickets__rsvp-form-field-quantity"
 		value="1"
 		required

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set not going__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set not going__1.php
@@ -27,11 +27,11 @@
 	
 <form
 	name="tribe-tickets-rsvp-form"
-	data-rsvp-id="TICKET_ID"
+	data-rsvp-id="[TICKET_ID]"
 >
-	<input type="hidden" name="tribe_tickets[TICKET_ID][ticket_id]" value="TICKET_ID">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][order_status]" value="not-going">
-	<input type="hidden" name="tribe_tickets[TICKET_ID][attendees][0][optout]" value="1">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][ticket_id]" value="[TICKET_ID]">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][order_status]" value="not-going">
+	<input type="hidden" name="tribe_tickets[[TICKET_ID]][attendees][0][optout]" value="1">
 
 	<div class="tribe-tickets__rsvp-form-wrapper">
 
@@ -45,7 +45,7 @@
 			<div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-name-14085"
+		for="tribe-tickets-rsvp-name-[TICKET_ID]"
 	>
 		Name<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -53,8 +53,8 @@
 	<input
 		type="text"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-name"
-		name="tribe_tickets[TICKET_ID][attendees][0][full_name]"
-		id="tribe-tickets-rsvp-name-14085"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][full_name]"
+		id="tribe-tickets-rsvp-name-[TICKET_ID]"
 		value=""
 		required
 		placeholder="Your Name"
@@ -63,7 +63,7 @@
 <div class="tribe-common-b1 tribe-common-b2--min-medium tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-tickets__form-field-label"
-		for="tribe-tickets-rsvp-email-14085"
+		for="tribe-tickets-rsvp-email-[TICKET_ID]"
 	>
 		Email<span class="screen-reader-text">required</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
@@ -71,8 +71,8 @@
 	<input
 		type="email"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-field-email"
-		name="tribe_tickets[TICKET_ID][attendees][0][email]"
-		id="tribe-tickets-rsvp-email-14085"
+		name="tribe_tickets[[TICKET_ID]][attendees][0][email]"
+		id="tribe-tickets-rsvp-email-[TICKET_ID]"
 		value=""
 		required
 		placeholder="your@email.com"
@@ -81,15 +81,15 @@
 <div class="tribe-common-b1 tribe-tickets__form-field tribe-tickets__form-field--required">
 	<label
 		class="tribe-common-b2--min-medium tribe-tickets__form-field-label"
-		for="quantity_14085"
+		for="quantity_[TICKET_ID]"
 	>
 		Number of Guests Not Attending<span class="screen-reader-text">(required)</span>
 		<span class="tribe-required" aria-hidden="true" role="presentation">*</span>
 	</label>
 	<input
 		type="number"
-		name="tribe_tickets[TICKET_ID][quantity]"
-		id="quantity_14085"
+		name="tribe_tickets[[TICKET_ID]][quantity]"
+		id="quantity_[TICKET_ID]"
 		class="tribe-common-form-control-text__input tribe-tickets__form-field-input tribe-tickets__rsvp-form-input-number tribe-tickets__rsvp-form-field-quantity"
 		value="1"
 		required

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
@@ -41,10 +41,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 13774</h3>
+	Test RSVP ticket for 14167</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 13774</p>
+	<p>Ticket RSVP ticket excerpt for 14167</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set opt-in__1.php
@@ -41,10 +41,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 14167</h3>
+	Test RSVP ticket for [EVENT_ID]</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 14167</p>
+	<p>Ticket RSVP ticket excerpt for [EVENT_ID]</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
@@ -41,10 +41,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 14105</h3>
+	Test RSVP ticket for [EVENT_ID]</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 14105</p>
+	<p>Ticket RSVP ticket excerpt for [EVENT_ID]</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">
@@ -95,7 +95,7 @@
 	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
 	Jane Doe</div>
 	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
-	Test RSVP ticket for 14105</div>
+	Test RSVP ticket for [EVENT_ID]</div>
 </div>
 				</div>
 							<div class="tec-tickets__attendees-list-item">
@@ -103,7 +103,7 @@
 	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
 	Jane Doe</div>
 	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
-	Test RSVP ticket for 14105</div>
+	Test RSVP ticket for [EVENT_ID]</div>
 </div>
 				</div>
 					</div>

--- a/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
+++ b/tests/wpunit/Tribe/Tickets/__snapshots__/RSVPTest__it_should_render_rsvp_step with data set success__1.php
@@ -41,10 +41,10 @@
 		<div class="tribe-tickets__rsvp-details-wrapper tribe-common-g-col">
 	<div class="tribe-tickets__rsvp-details">
 		<h3 class="tribe-tickets__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">
-	Test RSVP ticket for 13712</h3>
+	Test RSVP ticket for 14105</h3>
 
 		<div class="tribe-tickets__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
-	<p>Ticket RSVP ticket excerpt for 13712</p>
+	<p>Ticket RSVP ticket excerpt for 14105</p>
 </div>
 
 		<div class="tribe-tickets__rsvp-attendance">
@@ -95,7 +95,7 @@
 	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
 	Jane Doe</div>
 	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
-	Test RSVP ticket for 13712</div>
+	Test RSVP ticket for 14105</div>
 </div>
 				</div>
 							<div class="tec-tickets__attendees-list-item">
@@ -103,7 +103,7 @@
 	<div class="tec-tickets__attendees-list-item-attendee-details-name tribe-common-b1--bold">
 	Jane Doe</div>
 	<div class="tec-tickets__attendees-list-item-attendee-details-rsvp">
-	Test RSVP ticket for 13712</div>
+	Test RSVP ticket for 14105</div>
 </div>
 				</div>
 					</div>


### PR DESCRIPTION
## Part 2/19

These files handle the **PHP views and test fixtures** for the RSVP V2 block editor:

- `src/views/` — Clean up RSVP action templates for streamlined rendering
- `tests/rsvp_v2_integration/` — Update Block_Editor_Test for new editor structure  
- `tests/_support/` — Update BaseTicketEditorCest with attendee info fields

---

> **Previous:** [split/soft-3335-01-php-core](https://github.com/the-events-calendar/event-tickets/pull/4282)  
> **Next:** [split/soft-3335-03-data-shared-types](https://github.com/the-events-calendar/event-tickets/pull/4284)  