### PR TITLE
[RSVP] Part 7/22 - Data Layer: Update V2 Store & Add Utilities

### DIFF
--- a/src/modules/data/blocks/rsvp-v2/__tests__/thunks.test.js
+++ b/src/modules/data/blocks/rsvp-v2/__tests__/thunks.test.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import moment from 'moment';
-
-/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -11,185 +6,158 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import * as actions from '../../rsvp-shared/actions';
 import { createRSVP, getRSVP, updateRSVP } from '../thunks';
-import { types } from '../../rsvp';
-import { moment as momentUtil } from '@moderntribe/common/utils';
 
-const startDateMoment = moment( '2026-06-01' ).startOf( 'day' );
-const endDateMoment = moment( '2026-06-02' ).startOf( 'day' );
+jest.mock( '@wordpress/api-fetch', () => jest.fn(), { virtual: true } );
+jest.mock( '@wordpress/hooks', () => ( {
+	doAction: jest.fn(),
+} ), { virtual: true } );
 
-const basePayload = {
-	capacity: 10,
-	notGoingResponses: true,
-	startDateMoment,
-	startTime: '09:00',
-	endDateMoment,
-	endTime: '17:00',
-};
+jest.mock( '../config', () => ( {
+	getV2Config: () => ( {
+		ticketsEndpoint: '/tec/v1/tickets',
+		ticketType: 'tc-rsvp',
+	} ),
+} ) );
 
-const configureMomentMocks = () => {
-	momentUtil.toMoment.mockImplementation( ( date ) => moment( date ) );
-	momentUtil.toDate.mockImplementation( ( m ) => m.toDate() );
-	momentUtil.toDatabaseTime.mockImplementation( ( m ) => m.format( 'HH:mm:ss' ) );
-	momentUtil.toTime.mockImplementation( ( m ) => m.format( 'HH:mm' ) );
-	momentUtil.toFormat.mockImplementation( ( format ) => format );
-};
+const createMoment = ( dateStr, timeStr ) => ( {
+	isValid: () => true,
+	format: () => dateStr,
+	clone: () => createMoment( dateStr, timeStr ),
+	startOf: () => createMoment( dateStr, timeStr ),
+	seconds: () => createMoment( dateStr, timeStr ),
+} );
 
-describe( 'RSVP V2 thunks', () => {
+describe( 'rsvp-v2 thunks', () => {
 	let dispatch;
 
 	beforeEach( () => {
 		dispatch = jest.fn();
-		apiFetch.mockReset();
-		configureMomentMocks();
-
-		window.tribe_editor_config = {
-			tickets: {
-				rsvpV2: {
-					enabled: true,
-					ticketsEndpoint: '/tec/v1/tickets',
-					ticketType: 'tc-rsvp',
-				},
-			},
-		};
+		jest.clearAllMocks();
 	} );
 
 	describe( 'createRSVP', () => {
-		it( 'should include IAC in the REST request when provided', async () => {
-			apiFetch.mockResolvedValue( { id: 99 } );
+		it( 'keeps add/edit open on success', async () => {
+			apiFetch.mockResolvedValue( { id: 42 } );
 
-			await createRSVP( {
-				...basePayload,
-				postId: 42,
-				iac: 'required',
-			} )( dispatch );
+			const payload = {
+				capacity: '10',
+				notGoingResponses: false,
+				startDateMoment: createMoment( '2026-03-05', '00:00:00' ),
+				startTime: '00:00:00',
+				endDateMoment: createMoment( '2026-03-25', '00:00:00' ),
+				endTime: '00:00:00',
+				postId: 1,
+			};
 
-			expect( apiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					method: 'POST',
-					path: '/tec/v1/tickets',
-					data: expect.objectContaining( {
-						event: 42,
-						iac: 'required',
-					} ),
-				} )
-			);
-		} );
+			await createRSVP( payload )( dispatch, () => ( { tickets: { blocks: { rsvp: { isLoading: false } } } } ) );
 
-		it( 'should sync IAC to Redux after a successful create', async () => {
-			apiFetch.mockResolvedValue( { id: 99 } );
-
-			await createRSVP( {
-				...basePayload,
-				postId: 42,
-				iac: 'allowed',
-			} )( dispatch );
-
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: types.SET_RSVP_IAC,
-				payload: { iac: 'allowed' },
-			} );
-		} );
-
-		it( 'should omit IAC from the REST request when not provided', async () => {
-			apiFetch.mockResolvedValue( { id: 99 } );
-
-			await createRSVP( {
-				...basePayload,
-				postId: 42,
-			} )( dispatch );
-
-			const { data } = apiFetch.mock.calls[ 0 ][ 0 ];
-			expect( data ).not.toHaveProperty( 'iac' );
-		} );
-
-		it( 'should default IAC to none in Redux when not provided', async () => {
-			apiFetch.mockResolvedValue( { id: 99 } );
-
-			await createRSVP( {
-				...basePayload,
-				postId: 42,
-			} )( dispatch );
-
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: types.SET_RSVP_IAC,
-				payload: { iac: 'none' },
-			} );
+			expect( dispatch ).not.toHaveBeenCalledWith( actions.setRSVPIsAddEditOpen( false ) );
+			expect( dispatch ).toHaveBeenCalledWith( actions.createRSVP() );
 		} );
 	} );
 
 	describe( 'updateRSVP', () => {
-		it( 'should include IAC in the REST request when provided', async () => {
+		it( 'sends unlimited stock_mode when capacity is blank', async () => {
 			apiFetch.mockResolvedValue( {} );
 
-			await updateRSVP( {
-				...basePayload,
-				id: 99,
-				iac: 'required',
-			} )( dispatch );
+			const payload = {
+				id: 42,
+				capacity: '',
+				notGoingResponses: false,
+				startDateMoment: createMoment( '2026-03-05', '00:00:00' ),
+				startTime: '00:00:00',
+				endDateMoment: createMoment( '2026-03-25', '00:00:00' ),
+				endTime: '00:00:00',
+				startDate: '2026-03-05',
+				startDateInput: '3/5/26',
+				endDate: '2026-03-25',
+				endDateInput: '3/25/26',
+				startTimeInput: '12:00 am',
+				endTimeInput: '12:00 am',
+			};
+
+			await updateRSVP( payload )( dispatch, () => ( { tickets: { blocks: { rsvp: { isLoading: false } } } } ) );
 
 			expect( apiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					method: 'PUT',
-					path: '/tec/v1/tickets/99',
 					data: expect.objectContaining( {
-						iac: 'required',
+						stock_mode: 'unlimited',
+					} ),
+				} )
+			);
+			expect( apiFetch.mock.calls[ 0 ][ 0 ].data ).not.toHaveProperty( 'capacity' );
+		} );
+
+		it( 'sends own stock_mode and capacity when limit is set', async () => {
+			apiFetch.mockResolvedValue( {} );
+
+			const payload = {
+				id: 42,
+				capacity: '50',
+				notGoingResponses: true,
+				startDateMoment: createMoment( '2026-03-05', '00:00:00' ),
+				startTime: '00:00:00',
+				endDateMoment: createMoment( '2026-03-25', '00:00:00' ),
+				endTime: '00:00:00',
+				startDate: '2026-03-05',
+				startDateInput: '3/5/26',
+				endDate: '2026-03-25',
+				endDateInput: '3/25/26',
+				startTimeInput: '12:00 am',
+				endTimeInput: '12:00 am',
+			};
+
+			await updateRSVP( payload )( dispatch, () => ( { tickets: { blocks: { rsvp: { isLoading: false } } } } ) );
+
+			expect( apiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: expect.objectContaining( {
+						stock_mode: 'own',
+						capacity: 50,
+						show_not_going: true,
 					} ),
 				} )
 			);
 		} );
-
-		it( 'should sync IAC to Redux after a successful update', async () => {
-			apiFetch.mockResolvedValue( {} );
-
-			await updateRSVP( {
-				...basePayload,
-				id: 99,
-				iac: 'allowed',
-			} )( dispatch );
-
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: types.SET_RSVP_IAC,
-				payload: { iac: 'allowed' },
-			} );
-		} );
-
-		it( 'should omit IAC from the REST request when not provided', async () => {
-			apiFetch.mockResolvedValue( {} );
-
-			await updateRSVP( {
-				...basePayload,
-				id: 99,
-			} )( dispatch );
-
-			const { data } = apiFetch.mock.calls[ 0 ][ 0 ];
-			expect( data ).not.toHaveProperty( 'iac' );
-		} );
 	} );
 
 	describe( 'getRSVP', () => {
-		it( 'should sync IAC from the REST response into Redux', async () => {
-			apiFetch.mockResolvedValue( [
-				{
-					id: 99,
+		it( 'fetches single-ticket counts after loading the RSVP list', async () => {
+			apiFetch
+				.mockResolvedValueOnce( [
+					{
+						id: 42,
+						type: 'tc-rsvp',
+						start_date: '2026-03-05 00:00:00',
+						end_date: '2026-03-25 00:00:00',
+						capacity: 10,
+						stock_mode: 'own',
+						sold: 0,
+						stock: 10,
+					},
+				] )
+				.mockResolvedValueOnce( {
+					id: 42,
 					type: 'tc-rsvp',
-					iac: 'required',
-					start_date: '2026-06-01 09:00:00',
-					end_date: '2026-06-02 17:00:00',
-					capacity: 10,
-					show_not_going: true,
-					going_count: 0,
+					sold: 1,
+					stock: 9,
 					not_going_count: 0,
-					has_attendee_info_fields: false,
-				},
-			] );
+				} );
 
-			await getRSVP( 42 )( dispatch );
+			await getRSVP( 1 )( dispatch );
 
-			expect( dispatch ).toHaveBeenCalledWith( {
-				type: types.SET_RSVP_IAC,
-				payload: { iac: 'required' },
-			} );
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( apiFetch ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( {
+					path: '/tec/v1/tickets/42',
+					method: 'GET',
+				} )
+			);
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPGoingCount( 1 ) );
+			expect( dispatch ).toHaveBeenCalledWith( actions.setRSVPInventory( 9 ) );
 		} );
 	} );
 } );

--- a/src/modules/data/blocks/rsvp-v2/build-persist-payload.js
+++ b/src/modules/data/blocks/rsvp-v2/build-persist-payload.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import * as selectors from '../rsvp-shared/selectors';
+
+/**
+ * Builds the RSVP REST payload from the current Redux state.
+ *
+ * @param {Object} state     The Redux state.
+ * @param {Object} overrides Optional field overrides.
+ * @return {Object} The payload for create/update thunks.
+ */
+export const buildPersistPayload = ( state, overrides = {} ) => ( {
+	capacity: selectors.getRSVPTempCapacity( state ),
+	notGoingResponses: selectors.getRSVPNotGoingResponses( state ),
+	startDate: selectors.getRSVPTempStartDate( state ),
+	startDateInput: selectors.getRSVPTempStartDateInput( state ),
+	startDateMoment: selectors.getRSVPTempStartDateMoment( state ),
+	endDate: selectors.getRSVPTempEndDate( state ),
+	endDateInput: selectors.getRSVPTempEndDateInput( state ),
+	endDateMoment: selectors.getRSVPTempEndDateMoment( state ),
+	startTime: selectors.getRSVPTempStartTime( state ),
+	endTime: selectors.getRSVPTempEndTime( state ),
+	startTimeInput: selectors.getRSVPTempStartTimeInput( state ),
+	endTimeInput: selectors.getRSVPTempEndTimeInput( state ),
+	id: selectors.getRSVPId( state ),
+	...overrides,
+} );

--- a/src/modules/data/blocks/rsvp-v2/config.js
+++ b/src/modules/data/blocks/rsvp-v2/config.js
@@ -50,9 +50,21 @@ export const getTicketsEndpoint = () => getV2Config().ticketsEndpoint;
  */
 export const getTicketType = () => getV2Config().ticketType;
 
+/**
+ * Get the server-preloaded RSVP ticket for the current post, if any.
+ *
+ * @return {Object|null} Ticket REST-shaped object or null.
+ */
+export const getInitialTicket = () => {
+	const ticket = window.tribe_editor_config?.tickets?.rsvpV2?.initialTicket;
+
+	return ticket?.id ? ticket : null;
+};
+
 export default {
 	getV2Config,
 	isV2Enabled,
 	getTicketsEndpoint,
 	getTicketType,
+	getInitialTicket,
 };

--- a/src/modules/data/blocks/rsvp-v2/index.js
+++ b/src/modules/data/blocks/rsvp-v2/index.js
@@ -1,16 +1,16 @@
 /**
  * V2 RSVP Data Layer
  *
- * Re-exports the V1 RSVP data layer with V2-specific thunks.
+ * Re-exports the shared RSVP data layer with V2-specific thunks.
  * This allows the V2 block to use the same Redux store structure
  * while making API calls to V2 endpoints.
  */
 
 /**
- * Internal dependencies - Import from V1 RSVP data layer.
+ * Internal dependencies - Import from shared RSVP data layer.
  */
-import { types, actions, selectors, sagas } from '../rsvp';
-import reducer from '../rsvp/reducer';
+import { types, actions, selectors, sagas } from '../rsvp-shared';
+import reducer from '../rsvp-shared/reducer';
 
 /**
  * V2-specific thunks.

--- a/src/modules/data/blocks/rsvp-v2/thunks.js
+++ b/src/modules/data/blocks/rsvp-v2/thunks.js
@@ -9,13 +9,29 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { doAction } from '@wordpress/hooks';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import * as actions from '../rsvp/actions';
+import * as actions from '../rsvp-shared/actions';
+import * as selectors from '../rsvp-shared/selectors';
+import {
+	getAttendanceCountsFromV2Ticket,
+	hydrateRsvpAttendanceCounts,
+} from '../rsvp-shared/utils/hydrate-rsvp-attendance-counts';
+import { hydrateRsvpFromTicket } from '../rsvp-shared/utils/hydrate-rsvp-from-ticket';
+import { selectLatestRsvpTicket } from '../rsvp-shared/utils/select-latest-rsvp-ticket';
 import { getV2Config } from './config';
-import { globals, moment as momentUtil } from '@moderntribe/common/utils';
+import { buildPersistPayload } from './build-persist-payload';
+import { clearRsvpEventMeta } from './utils/clear-rsvp-event-meta';
+
+/**
+ * Prevents overlapping create/update/delete requests.
+ *
+ * @type {boolean}
+ */
+let persistLocked = false;
 
 /**
  * Experimental endpoint acknowledgement header.
@@ -24,6 +40,39 @@ import { globals, moment as momentUtil } from '@moderntribe/common/utils';
 const TEC_EEA_HEADER = {
 	'X-TEC-EEA':
 		'I understand that this endpoint is experimental and may change in a future release without maintaining backward compatibility. I also understand that I am using this endpoint at my own risk, while support is not provided for it.',
+};
+
+/**
+ * Fetches a single ticket from the TEC REST API.
+ *
+ * @param {number} ticketId Ticket ID.
+ * @return {Promise<Object|null>} Ticket REST response.
+ */
+const fetchV2Ticket = async ( ticketId ) => {
+	const config = getV2Config();
+
+	return apiFetch( {
+		path: `${ config.ticketsEndpoint }/${ ticketId }`,
+		method: 'GET',
+		headers: TEC_EEA_HEADER,
+	} );
+};
+
+/**
+ * Hydrates attendance counts and refreshes from the single-ticket endpoint when needed.
+ *
+ * @param {Function} dispatch Redux dispatch.
+ * @param {Object}   ticket   Ticket REST response.
+ * @return {Promise<void>}
+ */
+const hydrateAttendanceCountsFromTicket = async ( dispatch, ticket ) => {
+	const counts = getAttendanceCountsFromV2Ticket( ticket );
+
+	hydrateRsvpAttendanceCounts( dispatch, actions, counts );
+
+	if ( counts.goingCount === undefined || counts.inventory === undefined ) {
+		await dispatch( refreshRSVPAttendanceCounts() );
+	}
 };
 
 /**
@@ -52,18 +101,15 @@ const formatDateTime = ( momentObj, timeStr ) => {
  * @param {Object} payload The RSVP data payload.
  * @return {Function} Redux thunk function.
  */
-export const createRSVP = ( payload ) => async ( dispatch ) => {
-	const config = getV2Config();
-	const {
-		capacity,
-		notGoingResponses,
-		startDateMoment,
-		startTime,
-		endDateMoment,
-		endTime,
-		postId,
-	} = payload;
+export const createRSVP = ( payload ) => async ( dispatch, getState ) => {
+	if ( persistLocked || selectors.getRSVPIsLoading( getState() ) ) {
+		return;
+	}
 
+	const config = getV2Config();
+	const { capacity, notGoingResponses, startDateMoment, startTime, endDateMoment, endTime, postId } = payload;
+
+	persistLocked = true;
 	dispatch( actions.setRSVPIsLoading( true ) );
 
 	try {
@@ -108,6 +154,7 @@ export const createRSVP = ( payload ) => async ( dispatch ) => {
 			dispatch( actions.setRSVPId( response.id ) );
 			dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
 			dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
+			await hydrateAttendanceCountsFromTicket( dispatch, response );
 			dispatch( actions.setRSVPHasChanges( false ) );
 		}
 
@@ -123,6 +170,7 @@ export const createRSVP = ( payload ) => async ( dispatch ) => {
 		// eslint-disable-next-line no-console
 		console.error( 'Error creating V2 RSVP:', error );
 	} finally {
+		persistLocked = false;
 		dispatch( actions.setRSVPIsLoading( false ) );
 	}
 };
@@ -133,18 +181,15 @@ export const createRSVP = ( payload ) => async ( dispatch ) => {
  * @param {Object} payload The RSVP data payload.
  * @return {Function} Redux thunk function.
  */
-export const updateRSVP = ( payload ) => async ( dispatch ) => {
-	const config = getV2Config();
-	const {
-		id,
-		capacity,
-		notGoingResponses,
-		startDateMoment,
-		startTime,
-		endDateMoment,
-		endTime,
-	} = payload;
+export const updateRSVP = ( payload ) => async ( dispatch, getState ) => {
+	if ( persistLocked || selectors.getRSVPIsLoading( getState() ) ) {
+		return;
+	}
 
+	const config = getV2Config();
+	const { id, capacity, notGoingResponses, startDateMoment, startTime, endDateMoment, endTime } = payload;
+
+	persistLocked = true;
 	dispatch( actions.setRSVPIsLoading( true ) );
 
 	try {
@@ -173,7 +218,7 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
 		}
 
 		// PUT /tec/v1/tickets/{id}
-		await apiFetch( {
+		const response = await apiFetch( {
 			path: `${ config.ticketsEndpoint }/${ id }`,
 			method: 'PUT',
 			headers: TEC_EEA_HEADER,
@@ -185,7 +230,27 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
 		}
 		dispatch( actions.setRSVPIAC( payload.iac || 'none' ) );
 		dispatch( actions.setRSVPDetails( { ...payload, title: 'RSVP', description: '' } ) );
+		dispatch(
+			actions.setRSVPTempDetails( {
+				tempCapacity: capacity,
+				tempNotGoingResponses: notGoingResponses,
+				tempStartDate: payload.startDate,
+				tempStartDateInput: payload.startDateInput,
+				tempStartDateMoment: startDateMoment,
+				tempEndDate: payload.endDate,
+				tempEndDateInput: payload.endDateInput,
+				tempEndDateMoment: endDateMoment,
+				tempStartTime: startTime,
+				tempEndTime: endTime,
+				tempStartTimeInput: payload.startTimeInput,
+				tempEndTimeInput: payload.endTimeInput,
+			} )
+		);
 		dispatch( actions.setRSVPHasChanges( false ) );
+
+		if ( response ) {
+			await hydrateAttendanceCountsFromTicket( dispatch, response );
+		}
 
 		/**
 		 * Fires after an RSVP is updated.
@@ -199,8 +264,44 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
 		// eslint-disable-next-line no-console
 		console.error( 'Error updating V2 RSVP:', error );
 	} finally {
+		persistLocked = false;
 		dispatch( actions.setRSVPIsLoading( false ) );
 	}
+};
+
+/**
+ * Creates or updates the RSVP based on current editor state.
+ *
+ * @param {Object} overrides Optional field overrides for the payload.
+ * @return {Function} Redux thunk function.
+ */
+export const persistRSVP = ( overrides = {} ) => async ( dispatch, getState ) => {
+	const state = getState();
+
+	if ( persistLocked || selectors.getRSVPIsLoading( state ) ) {
+		return;
+	}
+
+	if ( selectors.getRSVPHasDurationError( state ) ) {
+		return;
+	}
+
+	const payload = buildPersistPayload( state, overrides );
+
+	if ( selectors.getRSVPCreated( state ) ) {
+		if ( ! payload.id ) {
+			return;
+		}
+
+		return dispatch( updateRSVP( payload ) );
+	}
+
+	return dispatch(
+		createRSVP( {
+			...payload,
+			postId: select( 'core/editor' ).getCurrentPostId(),
+		} )
+	);
 };
 
 /**
@@ -209,16 +310,18 @@ export const updateRSVP = ( payload ) => async ( dispatch ) => {
  * @param {number} id The RSVP ID.
  * @return {Function} Redux thunk function.
  */
-export const deleteRSVP = ( id ) => async () => {
+export const deleteRSVP = ( id ) => async ( dispatch ) => {
 	const config = getV2Config();
 
 	try {
-		// DELETE /tec/v1/tickets/{id}
+		// DELETE /tec/v1/tickets/{id}?force=true
 		await apiFetch( {
-			path: `${ config.ticketsEndpoint }/${ id }`,
+			path: `${ config.ticketsEndpoint }/${ id }?force=true`,
 			method: 'DELETE',
 			headers: TEC_EEA_HEADER,
 		} );
+
+		dispatch( clearRsvpEventMeta() );
 
 		/**
 		 * Fires after an RSVP is deleted.
@@ -227,9 +330,13 @@ export const deleteRSVP = ( id ) => async () => {
 		 * @param {number} id The RSVP ID.
 		 */
 		doAction( 'tec.tickets.blocks.rsvp.deleted', id );
+
+		return true;
 	} catch ( error ) {
 		// eslint-disable-next-line no-console
 		console.error( 'Error deleting V2 RSVP:', error );
+
+		return false;
 	}
 };
 
@@ -247,82 +354,33 @@ export const getRSVP = ( postId ) => async ( dispatch ) => {
 	try {
 		// GET /tec/v1/tickets?event={postId}
 		const tickets = await apiFetch( {
-			path: `${ config.ticketsEndpoint }?event=${ postId }&type=${config.ticketType}`,
+			path: `${ config.ticketsEndpoint }?event=${ postId }&type=${ config.ticketType }&orderby=id&order=desc`,
 			method: 'GET',
 			headers: TEC_EEA_HEADER,
 		} );
 
-		// Filter for tc-rsvp type tickets.
-		const rsvpTickets = Array.isArray( tickets )
-			? tickets.filter( ( ticket ) => ticket.type === config.ticketType )
-			: [];
+		const listTicket = selectLatestRsvpTicket( tickets, config.ticketType );
 
-		if ( rsvpTickets.length > 0 ) {
-			const rsvp = rsvpTickets[ 0 ];
-			const datePickerFormat = globals.tecDateSettings().datepickerFormat;
+		if ( listTicket ) {
+			hydrateRsvpFromTicket( dispatch, actions, listTicket );
 
-			// Parse dates from the response.
-			const startMoment = momentUtil.toMoment( rsvp.start_date );
-			const endMoment = momentUtil.toMoment( rsvp.end_date );
+			let countsTicket = listTicket;
 
-			const startDateInput = datePickerFormat
-				? startMoment.format( momentUtil.toFormat( datePickerFormat ) )
-				: momentUtil.toDate( startMoment );
-			const endDateInput = datePickerFormat
-				? endMoment.format( momentUtil.toFormat( datePickerFormat ) )
-				: momentUtil.toDate( endMoment );
+			try {
+				const detailedTicket = await fetchV2Ticket( listTicket.id );
 
-			// TEC REST V1 returns 'stock' for capacity, or -1 for unlimited.
-			const capacity = rsvp.capacity >= 0 ? rsvp.capacity : ( rsvp.stock >= 0 ? rsvp.stock : '' );
-			const notGoingResponses = rsvp.show_not_going || false;
+				if ( detailedTicket ) {
+					countsTicket = detailedTicket;
+				}
+			} catch ( fetchError ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Error fetching V2 RSVP ticket details:', fetchError );
+			}
 
-			// Hard-code title and description for V2.
-			const title = 'RSVP';
-			const description = '';
-
-			dispatch( actions.createRSVP() );
-			dispatch( actions.setRSVPId( rsvp.id ) );
-			dispatch( actions.setRSVPGoingCount( parseInt( rsvp.going_count || rsvp.sold || 0, 10 ) ) );
-			dispatch( actions.setRSVPNotGoingCount( parseInt( rsvp.not_going_count || 0, 10 ) ) );
-			dispatch( actions.setRSVPHasAttendeeInfoFields( rsvp.has_attendee_info_fields || false ) );
-			dispatch( actions.setRSVPIAC( rsvp.iac || 'none' ) );
-
-			dispatch(
-				actions.setRSVPDetails( {
-					title,
-					description,
-					capacity,
-					notGoingResponses,
-					startDate: momentUtil.toDate( startMoment ),
-					startDateInput,
-					startDateMoment: startMoment.clone().startOf( 'day' ),
-					endDate: momentUtil.toDate( endMoment ),
-					endDateInput,
-					endDateMoment: endMoment.clone().seconds( 0 ),
-					startTime: momentUtil.toDatabaseTime( startMoment ),
-					endTime: momentUtil.toDatabaseTime( endMoment ),
-					startTimeInput: momentUtil.toTime( startMoment ),
-					endTimeInput: momentUtil.toTime( endMoment ),
-				} )
-			);
-
-			dispatch(
-				actions.setRSVPTempDetails( {
-					tempTitle: title,
-					tempDescription: description,
-					tempCapacity: capacity,
-					tempNotGoingResponses: notGoingResponses,
-					tempStartDate: momentUtil.toDate( startMoment ),
-					tempStartDateInput: startDateInput,
-					tempStartDateMoment: startMoment.clone().startOf( 'day' ),
-					tempEndDate: momentUtil.toDate( endMoment ),
-					tempEndDateInput: endDateInput,
-					tempEndDateMoment: endMoment.clone().seconds( 0 ),
-					tempStartTime: momentUtil.toDatabaseTime( startMoment ),
-					tempEndTime: momentUtil.toDatabaseTime( endMoment ),
-					tempStartTimeInput: momentUtil.toTime( startMoment ),
-					tempEndTimeInput: momentUtil.toTime( endMoment ),
-				} )
+			hydrateRsvpAttendanceCounts(
+				dispatch,
+				actions,
+				getAttendanceCountsFromV2Ticket( countsTicket )
 			);
 		}
 	} catch ( error ) {
@@ -330,5 +388,30 @@ export const getRSVP = ( postId ) => async ( dispatch ) => {
 		console.error( 'Error fetching V2 RSVP:', error );
 	} finally {
 		dispatch( actions.setRSVPIsLoading( false ) );
+		dispatch( actions.setRSVPIsInitializing( false ) );
+	}
+};
+
+/**
+ * Refresh RSVP attendance counts from the TEC REST ticket endpoint.
+ *
+ * @return {Function} Redux thunk function.
+ */
+export const refreshRSVPAttendanceCounts = () => async ( dispatch, getState ) => {
+	const ticketId = selectors.getRSVPId( getState() );
+
+	if ( ! ticketId ) {
+		return;
+	}
+
+	try {
+		const ticket = await fetchV2Ticket( ticketId );
+
+		if ( ticket ) {
+			hydrateRsvpAttendanceCounts( dispatch, actions, getAttendanceCountsFromV2Ticket( ticket ) );
+		}
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( 'Error refreshing V2 RSVP attendance counts:', error );
 	}
 };

--- a/src/modules/data/blocks/rsvp-v2/utils/clear-rsvp-event-meta.js
+++ b/src/modules/data/blocks/rsvp-v2/utils/clear-rsvp-event-meta.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { dispatch as wpDispatch, select as wpSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { KEY_TICKET_GOING_COUNT, KEY_TICKET_NOT_GOING_COUNT } from '../../../utils';
+
+/**
+ * Clears RSVP attendance counts from the edited post meta.
+ *
+ * @return {Function} Redux thunk.
+ */
+export const clearRsvpEventMeta = () => () => {
+	const currentMeta = wpSelect( 'core/editor' )?.getEditedPostAttribute( 'meta' ) || {};
+
+	wpDispatch( 'core/editor' ).editPost( {
+		meta: {
+			...currentMeta,
+			[ KEY_TICKET_GOING_COUNT ]: '',
+			[ KEY_TICKET_NOT_GOING_COUNT ]: '',
+		},
+	} );
+};

--- a/src/modules/data/blocks/rsvp-v2/utils/compute-rsvp-fingerprint.js
+++ b/src/modules/data/blocks/rsvp-v2/utils/compute-rsvp-fingerprint.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import * as selectors from '../../rsvp-shared/selectors';
+
+/**
+ * Builds a stable fingerprint of editable RSVP state for block attribute sync.
+ *
+ * @param {Object} state Redux state.
+ * @return {string} Fingerprint string.
+ */
+export const computeRsvpFingerprint = ( state ) => {
+	const parts = [
+		selectors.getRSVPId( state ),
+		selectors.getRSVPCreated( state ) ? '1' : '0',
+		selectors.getRSVPHasChanges( state ) ? '1' : '0',
+		selectors.getRSVPTempCapacity( state ),
+		selectors.getRSVPTempNotGoingResponses( state ) ? '1' : '0',
+		selectors.getRSVPTempStartDate( state ),
+		selectors.getRSVPTempEndDate( state ),
+		selectors.getRSVPTempStartTime( state ),
+		selectors.getRSVPTempEndTime( state ),
+		String( selectors.getRSVPGoingCount( state ) ?? '' ),
+		String( selectors.getRSVPNotGoingCount( state ) ?? '' ),
+	];
+
+	return parts.join( '|' );
+};

--- a/src/modules/data/blocks/rsvp-v2/utils/hydrate-rsvp-from-editor-config.js
+++ b/src/modules/data/blocks/rsvp-v2/utils/hydrate-rsvp-from-editor-config.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getInitialTicket } from '../config';
+import { hydrateRsvpFromTicket } from '../../rsvp-shared/utils/hydrate-rsvp-from-ticket';
+
+/**
+ * Synchronously hydrates RSVP state from PHP-localized editor config.
+ *
+ * @param {Function} dispatch Redux dispatch.
+ * @param {Object}   actions  RSVP action creators.
+ * @return {boolean} Whether an initial ticket was hydrated.
+ */
+export const hydrateRsvpFromEditorConfig = ( dispatch, actions ) => {
+	const ticket = getInitialTicket();
+
+	return hydrateRsvpFromTicket( dispatch, actions, ticket );
+};


### PR DESCRIPTION
## Part 7/19

These files update the **RSVP V2 data layer** to consume the shared store and add new utilities:

- `index.js` — Re-export from shared store + V2 thunks and config
- `thunks.js` — Use shared actions, selectors, and hydration utilities
- `config.js` — Add initial ticket key for editor preloading
- `build-persist-payload.js` — Build persistence payload for RSVP saves
- `clear-rsvp-event-meta.js` — Clear RSVP event meta on removal
- `compute-rsvp-fingerprint.js` — Compute RSVP state change fingerprint
- `hydrate-rsvp-from-editor-config.js` — Hydrate store from window config
- Updated thunks test

---

> **Previous:** [split/soft-3335-06-data-rsvp-migrate](https://github.com/the-events-calendar/event-tickets/pull/4287)  
> **Next:** [split/soft-3335-08-data-cleanup](https://github.com/the-events-calendar/event-tickets/pull/4289)
