### PR TITLE
[RSVP] Part 11/22 - Shared Block: Templates & Styles

### DIFF
--- a/src/modules/blocks/rsvp-shared/container-header/style.pcss
+++ b/src/modules/blocks/rsvp-shared/container-header/style.pcss
@@ -1,0 +1,163 @@
+.tribe-editor__container-panel__header {
+
+	.tribe-editor__rsvp & {
+		align-items: center;
+		display: flex;
+	}
+}
+
+.tribe-editor__rsvp--selected {
+
+	&.tribe-editor__rsvp--add-edit-open {
+
+		.tribe-editor__rsvp-container .tribe-editor__container-panel__content {
+			display: block;
+		}
+	}
+
+	.tribe-editor__rsvp-container .tribe-editor__container-panel__content {
+		border: 1px solid var(--tec-color-border-secondary);
+		display: none;
+
+		.tribe-editor__container-panel__content {
+			border-top: none;
+		}
+	}
+}
+
+.tribe-editor__rsvp-container-header__header-details {
+	flex: auto;
+}
+
+.tribe-editor__rsvp .tribe-editor__rsvp-container {
+
+	.tribe-editor__rsvp-container-header__title {
+		color: #141827;
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: 0.16px;
+		line-height: 25px;
+		margin: 0;
+		padding-top: 3px;
+	}
+}
+
+.tribe-editor__rsvp-container-header__title-input-wrapper {
+	align-items: baseline;
+	display: flex;
+
+	svg {
+		fill: #8d949b;
+		flex: none;
+		margin: 6px 0 0 10px;
+	}
+}
+
+.tribe-editor__rsvp {
+
+	.tribe-editor__rsvp-container-header__title-input {
+		background-color: transparent;
+		border: none;
+		color: #000;
+		font-family: "Helvetica Neue", Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+		font-size: 21px;
+		font-weight: 700;
+		letter-spacing: 0.16px;
+		line-height: 25px;
+		margin: 3px 0 0;
+		padding: 0;
+		resize: none;
+		width: calc(95% - 26px);
+
+		&:hover,
+		&:focus {
+			background-color: #fff;
+		}
+	}
+
+	#edit-rsvp {
+		margin-top: auto;
+	}
+}
+
+.tribe-editor__rsvp-container-header__description {
+	color: #545d66;
+	display: block;
+	font-size: 12px;
+	letter-spacing: 0.04px;
+	line-height: 18px;
+	padding-top: 7px;
+}
+
+.tribe-editor__rsvp {
+
+	.tribe-editor__rsvp-container-header__description-input {
+		background-color: transparent;
+		border: none;
+		color: #5d5d5d;
+		display: flex;
+		font-family: "Helvetica Neue", Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+		font-size: 12px;
+		letter-spacing: 0.04px;
+		line-height: 18px;
+		margin: 0;
+		max-height: 108px;
+		padding: 0;
+		width: 95%;
+
+		&:hover,
+		&:focus {
+			background-color: transparent;
+			box-shadow: none;
+		}
+
+		& > * {
+			flex: none;
+		}
+	}
+}
+
+.tribe-editor__numeric-label.tribe-editor__rsvp-container-header__capacity-label {
+	color: var(--tec-color-text-secondary);
+	display: flex;
+	font-size: var(--tec-font-size-1);
+	line-height: var(--tec-line-height-2);
+	padding-top: var(--tec-spacer-4);
+}
+
+.tribe-editor__numeric-label--count {
+
+	.tribe-editor__rsvp-container-header__capacity-label & {
+		font-size: var(--tec-font-size-1);
+		font-weight: var(--tec-font-weight-bold);
+		line-height: var(--tec-line-height-2);
+	}
+}
+
+.tribe-editor__numeric-label--after {
+
+	.tribe-editor__rsvp-container-header__capacity-label & {
+		flex: none;
+		font-size: 12px;
+		letter-spacing: 0.04px;
+		margin-left: 2px;
+		white-space: pre;
+	}
+}
+
+.tribe-editor__rsvp-container-header__capacity-label-fallback {
+	color: #545d66;
+	display: block;
+	font-size: 12px;
+	letter-spacing: 0.04px;
+	line-height: 18px;
+	padding-top: 15px;
+}
+
+.tribe-editor__inactive-block--rsvp.tribe-editor__rsvp-container-header {
+	padding: var(--tec-spacer-9) 0;
+
+	.tribe-editor__rsvp-details-wrapper {
+		padding: 0;
+	}
+}

--- a/src/modules/blocks/rsvp-shared/style.pcss
+++ b/src/modules/blocks/rsvp-shared/style.pcss
@@ -1,0 +1,210 @@
+@import './edit-button/style.pcss';
+
+.tribe-editor__rsvp-container {
+	background-color: #fff;
+}
+
+.tribe-editor__rsvp {
+	font-family: "Helvetica Neue", Helvetica, -apple-system, BlinkMacSystemFont, Roboto, Arial, sans-serif;
+	position: relative;
+
+
+	.tribe-editor {
+
+		&__ticket__capacity-label {
+			width: 90px;
+		}
+	}
+
+	.components-spinner {
+		float: none;
+		left: 50%;
+		margin: 0;
+		opacity: 0.8;
+		position: absolute;
+		top: 50%;
+		transform: translate(-50%, -50%);
+	}
+
+	&--selected.tribe-editor__rsvp--add-edit-open {
+		border: none;
+		padding: 0;
+	}
+}
+
+.tribe-editor__inactive-block__icon {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+
+	> svg {
+		flex: none;
+	}
+}
+
+.tribe-editor__rsvp__inactive-block-icon-label {
+	color: var(--tec-color-text-disabled);
+	flex: none;
+	font-size: 16px;
+	font-weight: 700;
+	letter-spacing: 0.05px;
+	line-height: 19px;
+}
+
+.tribe-editor__card.tribe-editor__inactive-block--rsvp {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+
+.tribe-editor__inactive-block--rsvp {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	width: 100%;
+
+	.tribe-editor__rsvp-details-wrapper {
+		align-items: center;
+		display: flex;
+		flex: none;
+		justify-content: center;
+		padding: var(--tec-spacer-6);
+		width: calc(var(--tec-grid-width-1-of-8) *5);
+	}
+
+	.tribe-editor__rsvp-details {
+		width: 100%;
+	}
+
+	.tribe-editor__rsvp-description {
+		color: var(--tec-color-text-secondary);
+		font-size: var(--tec-font-size-1);
+		margin-top: var(--tec-spacer-1);
+	}
+
+	.tribe-editor__rsvp__content-wrapper {
+		padding: var(--tec-spacer-5);
+	}
+
+	.tribe-editor__rsvp-disabled-text {
+		color: var(--tec-color-text-secondary);
+		font-size: var(--tec-font-size-3);
+		margin-top: var(--tec-spacer-1);
+	}
+
+	.tribe-editor__rsvp-actions-wrapper {
+		align-items: center;
+		border-left: 1px dashed var(--tec-color-border-secondary);
+		display: flex;
+		flex: none;
+		justify-content: center;
+		padding: 0 var(--tec-spacer-5) 0 var(--tec-spacer-4);
+		text-align: center;
+
+		@media screen and (min-width: 1024px) {
+			padding: 0 var(--tec-spacer-5) 0 var(--tec-spacer-9);
+		}
+	}
+
+	.tribe-editor__rsvp-actions {
+		border-top: 0;
+		height: 100%;
+		margin-top: 0;
+		padding: 0;
+		width: 100%;
+
+		.tribe-common-c-btn {
+			text-wrap: nowrap;
+			width: 125px;
+		}
+
+		.tribe-editor__rsvp-actions-rsvp {
+			align-items: center;
+			display: flex;
+			height: 100%;
+
+			.tribe-editor__rsvp-actions-rsvp-create {
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+				justify-content: space-between;
+			}
+
+			.tribe-editor__rsvp__action-button {
+				padding: var(--tec-spacer-3) 0 0 0;
+			}
+		}
+	}
+
+	#add-rsvp {
+		margin: auto;
+	}
+}
+
+/* -------------------------------------------------------------------------
+   RSVP disabled / loading muted styles
+   ------------------------------------------------------------------------- */
+
+.tribe-editor__rsvp-container--disabled {
+	.tribe-editor__rsvp-container-header__title,
+	.tribe-editor__rsvp-container-header__description,
+	.tribe-editor__numeric-label.tribe-editor__rsvp-container-header__capacity-label,
+	.tribe-editor__rsvp-container-header__capacity-label-fallback,
+	.tribe-editor__rsvp-container-content__capacity-label,
+	.tribe-editor__rsvp-container-content__not-going-responses .tribe-editor__checkbox__label,
+	.tribe-editor__rsvp__attendee-registration-label-with-modal .tribe-editor__labeled-item__label,
+	.tribe-editor__rsvp__attendee-registration-helper-text,
+	.tribe-editor__rsvp-container__icon-label,
+	.tribe-editor__rsvp-duration__duration-label .tribe-editor__labeled-item__label,
+	.tribe-editor__rsvp__advanced-options-header-text,
+	.tribe-editor__date-time-range-picker__separator {
+		color: var(--tec-color-text-disabled);
+	}
+
+	svg.tribe-editor__rsvp-duration__duration-tooltip-label,
+	svg.tribe-editor__rsvp__advanced-options-header-icon {
+		fill: var(--tec-color-icon-disabled);
+	}
+}
+
+.tribe-editor__rsvp .tribe-editor__rsvp-container .tribe-editor__rsvp-container-content__capacity-input:disabled {
+	color: var(--tec-color-text-disabled);
+}
+
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__title-input:disabled,
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__title-input:disabled:hover,
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__title-input:disabled:focus,
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__description-input:disabled,
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__description-input:disabled:hover,
+.tribe-editor__rsvp .tribe-editor__rsvp-container-header__description-input:disabled:focus {
+	background-color: transparent;
+	color: var(--tec-color-text-disabled);
+}
+
+.tribe-editor__rsvp--loading {
+	.tribe-editor__warning-button-text {
+		color: var(--tec-color-text-disabled);
+	}
+
+	svg.tribe-editor__warning-button-icon {
+		fill: var(--tec-color-icon-disabled);
+	}
+}
+
+.tribe-editor__rsvp__settings-dashboard--loading {
+	.tribe-editor__settings-dashboard__header-left-text {
+		color: var(--tec-color-text-disabled);
+	}
+
+	.tribe-editor__settings-dashboard__header-left > svg,
+	.tribe-editor__settings-dashboard__header-left > svg path {
+		fill: var(--tec-color-icon-disabled);
+	}
+}
+
+.edit-post-visual-editor .editor-block-list__block .tribe-editor__rsvp__settings-dashboard--loading {
+	.tribe-editor__image-upload__title,
+	.tribe-editor__image-upload__content p.tribe-editor__image-upload__description {
+		color: var(--tec-color-text-disabled);
+	}
+}

--- a/src/modules/blocks/rsvp-shared/templates/action-dashboard/style.pcss
+++ b/src/modules/blocks/rsvp-shared/templates/action-dashboard/style.pcss
@@ -1,0 +1,20 @@
+.tribe-editor__rsvp__warning {
+	bottom: -14px;
+	color: #545d66;
+	font-size: var(--tec-font-size-1);
+	line-height: var(--tec-line-height-0);
+	margin: 0 -14px 0;
+	position: relative;
+
+	@media (min-width: 600px) {
+		padding: 0 var(--tec-spacer-3) var(--tec-spacer-3);
+	}
+}
+
+.tribe-editor__rsvp {
+
+	.tribe-editor__action-dashboard {
+		border: 1px solid var(--tec-color-border-secondary);
+		border-top: none;
+	}
+}

--- a/src/modules/blocks/rsvp-shared/templates/action-dashboard/template.js
+++ b/src/modules/blocks/rsvp-shared/templates/action-dashboard/template.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment, PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { ActionDashboard } from '../../../../elements';
+import './style.pcss';
+
+const confirmLabel = ( created ) =>
+	created ? __( 'Update RSVP', 'event-tickets' ) : __( 'Create RSVP', 'event-tickets' );
+
+const cancelLabel = __( 'Cancel', 'event-tickets' );
+
+class RSVPActionDashboard extends PureComponent {
+	static propTypes = {
+		clientId: PropTypes.string.isRequired,
+		created: PropTypes.bool.isRequired,
+		hasRecurrenceRules: PropTypes.bool.isRequired,
+		isCancelDisabled: PropTypes.bool.isRequired,
+		isConfirmDisabled: PropTypes.bool.isRequired,
+		isLoading: PropTypes.bool.isRequired,
+		onCancelClick: PropTypes.func.isRequired,
+		onConfirmClick: PropTypes.func.isRequired,
+		showCancel: PropTypes.bool.isRequired,
+	};
+
+	getActions = () =>
+		applyFilters( 'tec.tickets.blocks.RSVP.ActionDashboardActions', [], {
+			clientId: this.props.clientId,
+			created: this.props.created,
+		} );
+
+	render() {
+		const { created, hasRecurrenceRules, isConfirmDisabled, onCancelClick, onConfirmClick } = this.props;
+
+		/* eslint-disable max-len */
+		return (
+			<Fragment>
+				<ActionDashboard
+					className="tribe-editor__rsvp__action-dashboard tribe-common"
+					actions={ this.getActions() }
+					cancelLabel={ cancelLabel }
+					confirmLabel={ confirmLabel( created ) }
+					isConfirmDisabled={ isConfirmDisabled }
+					onCancelClick={ onCancelClick }
+					onConfirmClick={ onConfirmClick }
+					showCancel={ true }
+				/>
+				{ hasRecurrenceRules && (
+					<div className="tribe-editor__rsvp__warning">
+						{ __(
+							'This is a recurring event. If you add tickets they will only show up on the next upcoming event in the recurrence pattern. The same ticket form will appear across all events in the series. Please configure your events accordingly.',
+							'event-tickets'
+						) }
+					</div>
+				) }
+			</Fragment>
+		);
+		/* eslint-enable max-len */
+	}
+}
+
+export default RSVPActionDashboard;

--- a/src/modules/blocks/rsvp-shared/templates/capacity/styles.pcss
+++ b/src/modules/blocks/rsvp-shared/templates/capacity/styles.pcss
@@ -1,0 +1,28 @@
+.tribe-editor__ticket__content-row--capacity {
+	margin-bottom: var(--tec-spacer-4);
+	padding-bottom: 0;
+}
+
+.tribe-editor__ticket__capacity-label {
+	flex: none;
+	width: 140px;
+}
+
+.tribe-editor__ticket__capacity-input {
+	width: 100%;
+}
+
+.tribe-editor__rsvp-container-content__capacity {
+	display: flex;
+	flex-direction: column;
+}
+
+.tribe-editor__rsvp-container-content__capacity-label-help {
+	color: var(--tec-color-text-primary-light);
+	font-family: var(--tec-font-family-sans-serif);
+	font-size: var(--tec-font-size-1);
+	font-style: normal;
+	font-weight: var(--tec-font-weight-regular);
+	line-height: var(--tec-line-height-2);
+	margin: var(--tec-spacer-1) 0;
+}

--- a/src/modules/blocks/rsvp-shared/templates/capacity/template.js
+++ b/src/modules/blocks/rsvp-shared/templates/capacity/template.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import uniqid from 'uniqid';
+
+/**
+ * Wordpress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { LabeledItem, NumberInput } from '@moderntribe/common/elements';
+import './styles.pcss';
+
+const RSVPCapacity = ( {
+	helpText = __( 'Leave blank if unlimited', 'event-tickets' ),
+	isDisabled,
+	label = __( 'RSVP Capacity', 'event-tickets' ),
+	onTempCapacityChange,
+	tempCapacity,
+} ) => {
+	const capacityId = uniqid();
+
+	return (
+		<div
+			className={ classNames(
+				'tribe-editor__ticket__capacity',
+				'tribe-editor__ticket__content-row',
+				'tribe-editor__ticket__content-row--capacity'
+			) }
+		>
+			<LabeledItem
+				className="tribe-editor__ticket__capacity-label"
+				forId={ capacityId }
+				isLabel={ true }
+				label={ label }
+			/>
+			<div className="tribe-editor__rsvp-container-content__capacity">
+				<NumberInput
+					className="tribe-editor__rsvp-container-content__capacity-input"
+					disabled={ isDisabled }
+					id={ capacityId }
+					min={ 0 }
+					onChange={ onTempCapacityChange }
+					value={ tempCapacity }
+				/>
+				<span className="tribe-editor__rsvp-container-content__capacity-label-help">
+					{ helpText }
+				</span>
+			</div>
+		</div>
+	);
+};
+
+RSVPCapacity.propTypes = {
+	helpText: PropTypes.string,
+	isDisabled: PropTypes.bool,
+	label: PropTypes.string,
+	onTempCapacityChange: PropTypes.func.isRequired,
+	tempCapacity: PropTypes.string,
+};
+
+export default RSVPCapacity;

--- a/src/modules/blocks/rsvp-shared/templates/duration-picker/style.pcss
+++ b/src/modules/blocks/rsvp-shared/templates/duration-picker/style.pcss
@@ -1,0 +1,20 @@
+.tribe-editor__rsvp-duration__duration-picker {
+	flex: 1;
+	margin-left: -55px;
+
+	.tribe-editor__date-input__container input.tribe-editor__date-input,
+	.tribe-editor__timepicker .components-dropdown.tribe-editor__timepicker__toggle {
+		border-radius: var( --tec-spacer-0 );
+	}
+
+	&--no-margin-left {
+		margin-left: 0;
+	}
+
+	&--sm-label {
+		.tribe-editor__date-time-range-picker__field-label {
+			font-size: 14px;
+		}
+	}
+}
+

--- a/src/modules/blocks/rsvp-shared/templates/duration-picker/template.js
+++ b/src/modules/blocks/rsvp-shared/templates/duration-picker/template.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { DateTimeRangePicker } from '../../../../elements';
+import './style.pcss';
+
+const RSVPDurationPicker = ( props ) => (
+	<DateTimeRangePicker className="tribe-editor__rsvp-duration__duration-picker" { ...props } />
+);
+
+RSVPDurationPicker.propTypes = {
+	fromDate: PropTypes.instanceOf( Date ),
+	fromDateInput: PropTypes.string,
+	fromDateDisabled: PropTypes.bool,
+	fromLabel: PropTypes.string,
+	fromTime: PropTypes.string,
+	fromTimeDisabled: PropTypes.bool,
+	onFromDateChange: PropTypes.func,
+	onFromTimePickerBlur: PropTypes.func,
+	onFromTimePickerChange: PropTypes.func,
+	onFromTimePickerClick: PropTypes.func,
+	onToDateChange: PropTypes.func,
+	onToTimePickerBlur: PropTypes.func,
+	onToTimePickerChange: PropTypes.func,
+	onToTimePickerClick: PropTypes.func,
+	toDate: PropTypes.instanceOf( Date ),
+	toDateInput: PropTypes.string,
+	toDateDisabled: PropTypes.bool,
+	toLabel: PropTypes.string,
+	toTime: PropTypes.string,
+	toTimeDisabled: PropTypes.bool,
+	separatorTimeRange: PropTypes.string,
+};
+
+export default RSVPDurationPicker;

--- a/src/modules/blocks/rsvp-shared/templates/inactive-block/template.js
+++ b/src/modules/blocks/rsvp-shared/templates/inactive-block/template.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Card, SplitContainer } from '../../../../elements';
+
+const RSVPInactiveBlock = ( { created, setAddEditOpen } ) => {
+	const title = created
+		? __( 'RSVP is not currently active', 'event-tickets' )
+		: __( 'Add an RSVP', 'event-tickets' );
+
+	const description = created
+		? __( 'Edit this block to change RSVP settings.', 'event-tickets' )
+		: __( 'Allow users to confirm their attendance.', 'event-tickets' );
+
+	/* eslint-disable max-len */
+	const leftColumn = (
+		<>
+			<h3 className="tribe-editor__rsvp-title tribe-common-h2 tribe-common-h4--min-medium">{ title }</h3>
+
+			<div className="tribe-editor__rsvp-description tribe-common-h6 tribe-common-h--alt tribe-common-b3--min-medium">
+				{ description }
+			</div>
+		</>
+	);
+
+	const rightColumn = (
+		<>
+			<button
+				id="add-rsvp"
+				className="tribe-common-c-btn tribe-common-b1 tribe-common-b2--min-medium"
+				onClick={ setAddEditOpen }
+			>
+				{ __( 'Add RSVP', 'event-tickets' ) }
+			</button>
+		</>
+	);
+	/* eslint-enable max-len */
+
+	return (
+		<Card className="tribe-common tribe-editor__inactive-block--rsvp">
+			<SplitContainer leftColumn={ leftColumn } rightColumn={ rightColumn } />
+		</Card>
+	);
+};
+
+RSVPInactiveBlock.propTypes = {
+	created: PropTypes.bool.isRequired,
+	setAddEditOpen: PropTypes.func.isRequired,
+};
+
+export default RSVPInactiveBlock;

--- a/src/modules/data/blocks/ticket/__tests__/sagas.test.js
+++ b/src/modules/data/blocks/ticket/__tests__/sagas.test.js
@@ -34,6 +34,8 @@ import {
 	time as timeUtil,
 	globals,
 } from '@moderntribe/common/utils';
+const { wpREST } = api;
+const datePickerFormat = globals.tecDateSettings().datepickerFormat;
 import { plugins } from '@moderntribe/common/data';
 import {
 	isTribeEventPostType,


### PR DESCRIPTION
## Part 11/19

These files add **shared RSVP block templates and styles**:

- `templates/action-dashboard/` — Action dashboard template + styles
- `templates/capacity/` — Capacity template + styles
- `templates/duration-picker/` — Duration picker template + styles
- `templates/inactive-block/` — Inactive block template
- `container-header/style.pcss` — Shared header styles
- `style.pcss` — Global shared RSVP styles

---

> **Previous:** [split/soft-3335-10-blocks-shared-a](https://github.com/the-events-calendar/event-tickets/pull/4291)  
> **Next:** [split/soft-3335-12-blocks-rsvp-a](https://github.com/the-events-calendar/event-tickets/pull/4293)
