### PR TITLE
[RSVP] Part 18/22 - V2 RSVP Window, Remove & Sidebar

### DIFF
--- a/src/modules/blocks/rsvp-v2/remove-rsvp/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/__tests__/template.test.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import RSVPRemoveRsvp from '../template';
+
+describe( 'RSVPRemoveRsvp', () => {
+	it( 'should render Remove RSVP button', () => {
+		const component = renderer.create(
+			<RSVPRemoveRsvp isDisabled={ false } isLoading={ false } onRemove={ jest.fn() } />
+		);
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+} );

--- a/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/container.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { dispatch as wpDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import { withStore } from '@moderntribe/common/hoc';
+import { actions, selectors, thunks } from '../../../data/blocks/rsvp-v2';
+import RSVPRemoveRsvp from './template';
+
+const mapStateToProps = ( state ) => ( {
+	created: selectors.getRSVPCreated( state ),
+	isDisabled: selectors.getRSVPSettingsOpen( state ),
+	isLoading: selectors.getRSVPIsLoading( state ),
+	rsvpId: selectors.getRSVPId( state ),
+} );
+
+const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
+	const { dispatch } = dispatchProps;
+
+	return {
+		...ownProps,
+		isDisabled: stateProps.isDisabled,
+		isLoading: stateProps.isLoading,
+		onRemove: async () => {
+			if (
+				! window.confirm(
+					// eslint-disable-line no-alert
+					__( 'Are you sure you want to disable RSVP? This cannot be undone.', 'event-tickets' )
+				)
+			) {
+				return;
+			}
+
+			if ( stateProps.created && stateProps.rsvpId ) {
+				await dispatch( thunks.deleteRSVP( stateProps.rsvpId ) );
+			}
+
+			dispatch( actions.deleteRSVP() );
+			wpDispatch( 'core/block-editor' ).removeBlocks( [ ownProps.clientId ] );
+		},
+	};
+};
+
+const ConnectedRemoveRsvp = compose( withStore(), connect( mapStateToProps, null, mergeProps ) )( RSVPRemoveRsvp );
+
+const RSVPRemoveRsvpContainer = ( { clientId, isSelected, created } ) => {
+	if ( ! created || ! isSelected ) {
+		return null;
+	}
+
+	return <ConnectedRemoveRsvp clientId={ clientId } />;
+};
+
+export default RSVPRemoveRsvpContainer;

--- a/src/modules/blocks/rsvp-v2/remove-rsvp/style.pcss
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/style.pcss
@@ -1,0 +1,9 @@
+.tribe-editor__rsvp-remove {
+	margin-top: var( --tec-spacer-5 );
+}
+
+.tribe-editor__rsvp-remove button {
+	color: var( --tec-color-accent-primary );
+	font-size: 15px;
+	color: var( --tec-color-icon-error );
+}

--- a/src/modules/blocks/rsvp-v2/remove-rsvp/style.pcss
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/style.pcss
@@ -3,7 +3,6 @@
 }
 
 .tribe-editor__rsvp-remove button {
-	color: var( --tec-color-accent-primary );
 	font-size: 15px;
 	color: var( --tec-color-icon-error );
 }

--- a/src/modules/blocks/rsvp-v2/remove-rsvp/template.js
+++ b/src/modules/blocks/rsvp-v2/remove-rsvp/template.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '@moderntribe/common/elements';
+import './style.pcss';
+
+const RSVPRemoveRsvp = ( { isDisabled, isLoading, onRemove } ) => (
+	<div className="tribe-editor__rsvp-remove">
+		<Button disabled={ isDisabled || isLoading } onClick={ onRemove } type="button">
+			{ __( 'Remove RSVP', 'event-tickets' ) }
+		</Button>
+	</div>
+);
+
+RSVPRemoveRsvp.propTypes = {
+	isDisabled: PropTypes.bool.isRequired,
+	isLoading: PropTypes.bool.isRequired,
+	onRemove: PropTypes.func.isRequired,
+};
+
+export default RSVPRemoveRsvp;

--- a/src/modules/blocks/rsvp-v2/rsvp-window/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-v2/rsvp-window/__tests__/template.test.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import RSVPRsvpWindow from '../template';
+
+describe( 'RSVPRsvpWindow', () => {
+	const defaultProps = {
+		dateRange: '3/5/26 - 3/25/26',
+		onEditWindow: jest.fn(),
+		showEditAffordances: false,
+	};
+
+	it( 'should render RSVP Window section', () => {
+		const component = renderer.create( <RSVPRsvpWindow { ...defaultProps } /> );
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	it( 'should return null when dateRange is empty', () => {
+		const component = renderer.create( <RSVPRsvpWindow { ...defaultProps } dateRange="" /> );
+		expect( component.toJSON() ).toBeNull();
+	} );
+
+	it( 'should show edit icon when edit affordances are enabled', () => {
+		const component = renderer.create(
+			<RSVPRsvpWindow { ...defaultProps } showEditAffordances={ true } />
+		);
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).toContain( 'edit' );
+	} );
+} );

--- a/src/modules/blocks/rsvp-v2/rsvp-window/container.js
+++ b/src/modules/blocks/rsvp-v2/rsvp-window/container.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import RSVPRsvpWindow from './template';
+import { selectors } from '../../../data/blocks/rsvp-v2';
+import { withStore } from '@moderntribe/common/hoc';
+import { formatRsvpWindow } from '../utils/format-rsvp-window';
+import { showEditAffordances as getShowEditAffordances } from '../utils/block-state';
+
+const mapStateToProps = ( state, ownProps ) => {
+	const startDateMoment = selectors.getRSVPStartDateMoment( state );
+	const endDateMoment = selectors.getRSVPEndDateMoment( state );
+
+	return {
+		dateRange: formatRsvpWindow( startDateMoment, endDateMoment ),
+		showEditAffordances: getShowEditAffordances( {
+			created: selectors.getRSVPCreated( state ),
+			isSelected: ownProps.isSelected,
+		} ),
+	};
+};
+
+export default compose( withStore(), connect( mapStateToProps ) )( RSVPRsvpWindow );

--- a/src/modules/blocks/rsvp-v2/rsvp-window/style.pcss
+++ b/src/modules/blocks/rsvp-v2/rsvp-window/style.pcss
@@ -1,0 +1,12 @@
+.tribe-editor__rsvp-window {
+	margin-top: var(--tec-spacer-4);
+}
+
+.tribe-editor__rsvp-window__title {
+	color: var(--tec-color-text-primary);
+	font-weight: var(--tec-font-weight-bold);
+}
+
+.tribe-editor__rsvp-window__dates {
+	margin-top: var(--tec-spacer-1);
+}

--- a/src/modules/blocks/rsvp-v2/rsvp-window/template.js
+++ b/src/modules/blocks/rsvp-v2/rsvp-window/template.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { Dashicon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.pcss';
+
+const RSVPRsvpWindow = ( { anchorRef, dateRange, isWindowOpen, onEditWindow, showEditAffordances } ) => {
+	if ( ! dateRange ) {
+		return null;
+	}
+
+	const title = __( 'RSVP Window', 'event-tickets' );
+
+	return (
+		<div className="tribe-editor__rsvp-window">
+			{ showEditAffordances ? (
+				<button
+					ref={ anchorRef }
+					className="tribe-editor__rsvp-inline-edit-button tribe-editor__rsvp-window__title-edit"
+					disabled={ isWindowOpen }
+					onClick={ onEditWindow }
+					type="button"
+				>
+					<span className="tribe-editor__rsvp-window__title tribe-common-h6 tribe-common-h--alt">
+						{ title }
+					</span>
+					<Dashicon className="tribe-editor__rsvp-inline-edit-button__icon" icon="edit" />
+				</button>
+			) : (
+				<span className="tribe-editor__rsvp-window__title tribe-common-h6 tribe-common-h--alt">{ title }</span>
+			) }
+			<div className="tribe-editor__rsvp-window__dates tribe-common-b2">{ dateRange }</div>
+		</div>
+	);
+};
+
+RSVPRsvpWindow.propTypes = {
+	anchorRef: PropTypes.shape( { current: PropTypes.instanceOf( Element ) } ),
+	dateRange: PropTypes.string,
+	isWindowOpen: PropTypes.bool,
+	onEditWindow: PropTypes.func,
+	showEditAffordances: PropTypes.bool,
+};
+
+export default RSVPRsvpWindow;

--- a/src/modules/blocks/rsvp-v2/sidebar-controls/container.js
+++ b/src/modules/blocks/rsvp-v2/sidebar-controls/container.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+/**
+ * Internal dependencies
+ */
+import RSVPSidebarControls from './template';
+import { withStore } from '@moderntribe/common/hoc';
+import { actions, selectors, thunks } from '../../../data/blocks/rsvp-v2';
+
+const mapStateToProps = ( state ) => ( {
+	isLoading: selectors.getRSVPIsLoading( state ),
+	notGoingResponses: selectors.getRSVPNotGoingResponses( state ),
+	state,
+} );
+
+const mapDispatchToProps = ( dispatch ) => ( {
+	dispatch,
+} );
+
+const mergeProps = ( stateProps, dispatchProps ) => {
+	const { state, isLoading, ...restStateProps } = stateProps;
+	const { dispatch } = dispatchProps;
+
+	return {
+		...restStateProps,
+		isLoading,
+		onToggleNotGoing: ( checked ) => {
+			if ( isLoading || selectors.getRSVPNotGoingResponses( state ) === checked ) {
+				return;
+			}
+
+			dispatch( actions.setRSVPNotGoingResponses( checked ) );
+			dispatch( actions.setRSVPTempNotGoingResponses( checked ) );
+			dispatch( thunks.persistRSVP( { notGoingResponses: checked } ) );
+		},
+	};
+};
+
+export default compose(
+	withStore(),
+	connect( mapStateToProps, mapDispatchToProps, mergeProps )
+)( RSVPSidebarControls );

--- a/src/modules/blocks/rsvp-v2/sidebar-controls/template.js
+++ b/src/modules/blocks/rsvp-v2/sidebar-controls/template.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+const RSVPSidebarControls = ( { isLoading, notGoingResponses, onToggleNotGoing } ) => (
+	<InspectorControls>
+		<PanelBody title={ __( 'RSVP Settings', 'event-tickets' ) }>
+			<ToggleControl
+				label={ __( 'Enable "Can\'t go" responses', 'event-tickets' ) }
+				checked={ !! notGoingResponses }
+				disabled={ isLoading }
+				onChange={ onToggleNotGoing }
+				__nextHasNoMarginBottom={ true }
+			/>
+		</PanelBody>
+	</InspectorControls>
+);
+
+RSVPSidebarControls.propTypes = {
+	isLoading: PropTypes.bool,
+	notGoingResponses: PropTypes.bool,
+	onToggleNotGoing: PropTypes.func.isRequired,
+};
+
+export default RSVPSidebarControls;


### PR DESCRIPTION
## Part 18/22

Add V2 rsvp-window, remove-rsvp, and sidebar-controls components.

> Previous: [split/soft-3335-17-blocks-v2-comps-b](https://github.com/the-events-calendar/event-tickets/pull/4298) · Next: [split/soft-3335-19-blocks-v2-comps-d](https://github.com/the-events-calendar/event-tickets/pull/4300)
