### PR TITLE
[SMTNC-1409] When duplicate events with WooCommerce Tickets with Shared Capacity, capacity becomes 0

### DIFF
--- a/changelog/smtnc-1409-when-duplicate-events-with-woocommerce-tickets-with-shared
+++ b/changelog/smtnc-1409-when-duplicate-events-with-woocommerce-tickets-with-shared
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where duplicating an event with shared-capacity tickets reset the duplicated tickets capacity to zero.

--- a/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
+++ b/src/Tickets/Integrations/Plugins/Events_Pro/Duplicate_Post.php
@@ -80,6 +80,13 @@ class Duplicate_Post extends Integration_Abstract {
 			return;
 		}
 
+		/*
+		 * The duplicated event is created global-stock-enabled with a capacity but no stock
+		 * level. Seed the level from its capacity before cloning tickets, or saving the first
+		 * shared ticket syncs the empty level to zero and resets every ticket's capacity.
+		 */
+		$this->seed_duplicated_global_stock_level( $new_post_id, $post->ID );
+
 		$duplicated_ticket_ids = [];
 
 		// You technically can have multiple providers if you have RSVP + a ticket provider.
@@ -151,16 +158,6 @@ class Duplicate_Post extends Integration_Abstract {
 				'post_content' => $new_post_content,
 			]
 		);
-
-		if ( ! get_post_meta( $original_post_id, Global_Stock::GLOBAL_STOCK_ENABLED, true ) ) {
-			return;
-		}
-
-		update_post_meta(
-			$new_post_id,
-			Global_Stock::GLOBAL_STOCK_LEVEL,
-			get_post_meta( $original_post_id, tribe( 'tickets.handler' )->key_capacity, true )
-		);
 	}
 
 	/**
@@ -182,6 +179,33 @@ class Duplicate_Post extends Integration_Abstract {
 				Global_Stock::GLOBAL_STOCK_ENABLED,
 				Attendees_List::HIDE_META_KEY,
 			],
+		);
+	}
+
+	/**
+	 * Seed a duplicated event's shared-stock level from its capacity before its tickets clone.
+	 *
+	 * A duplicated event is created global-stock-enabled with a capacity but no stock level;
+	 * cloning the first shared-capacity ticket onto it would otherwise sync the empty level to
+	 * zero and reset every ticket's capacity. A fresh duplicate has no sales, so the level
+	 * equals the full capacity.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $new_post_id      The duplicated event post ID.
+	 * @param int $original_post_id The original event post ID.
+	 *
+	 * @return void
+	 */
+	private function seed_duplicated_global_stock_level( int $new_post_id, int $original_post_id ): void {
+		if ( ! get_post_meta( $original_post_id, Global_Stock::GLOBAL_STOCK_ENABLED, true ) ) {
+			return;
+		}
+
+		update_post_meta(
+			$new_post_id,
+			Global_Stock::GLOBAL_STOCK_LEVEL,
+			get_post_meta( $original_post_id, tribe( 'tickets.handler' )->key_capacity, true )
 		);
 	}
 }

--- a/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
+++ b/tests/ct1_integration/TEC/Tickets/Integrations/Plugins/Events_Pro/Duplicate_PostTest.php
@@ -10,6 +10,7 @@ use TEC\Events_Pro\Custom_Tables\V1\Duplicate\Duplicate;
 use Tribe\Tickets\Events\Attendees_List;
 use Tribe__Tickets__Global_Stock as Global_Stock;
 use WP_Post;
+use Tribe__Tickets__Tickets;
 
 class Duplicate_PostTest extends WPTestCase {
 	use Ticket_Maker;
@@ -84,6 +85,47 @@ class Duplicate_PostTest extends WPTestCase {
 			$this->assertEquals( $v, get_post_meta( $event_id, $k, true ), $k );
 			$val_to_check = $k !== Global_Stock::GLOBAL_STOCK_LEVEL ? $v : $meta[ tribe( 'tickets.handler' )->key_capacity ];
 			$this->assertEquals( $val_to_check, get_post_meta( $duplicated_event->ID, $k, true ), $k );
+		}
+	}
+
+	/**
+	 * @test
+	 * it should duplicate shared-capacity tickets at full capacity
+	 */
+	public function it_should_duplicate_shared_capacity_tickets_at_full_capacity() {
+		$capacity = 100;
+
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Shared Capacity Event',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 12:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		$shared = [ 'tribe-ticket' => [ 'mode' => Global_Stock::GLOBAL_STOCK_MODE, 'capacity' => $capacity, 'event_capacity' => $capacity ] ];
+		$this->create_tc_ticket( $event_id, 10, $shared );
+		$this->create_tc_ticket( $event_id, 10, $shared );
+
+		/*
+		 * Pin the source event into a shared-capacity state, then simulate prior sales so the
+		 * pool sits below capacity — the case where naively copying the level would be wrong.
+		 */
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, true );
+		update_post_meta( $event_id, tribe( 'tickets.handler' )->key_capacity, $capacity );
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_LEVEL, $capacity - 20 );
+
+		$duplicated_event = tribe( Duplicate::class )->duplicate_event( get_post( $event_id ) );
+
+		$this->assertInstanceOf( WP_Post::class, $duplicated_event );
+
+		/* A fresh duplicate has no sales: capacity and pool are both the full capacity. */
+		$this->assertEquals( $capacity, get_post_meta( $duplicated_event->ID, tribe( 'tickets.handler' )->key_capacity, true ), 'event capacity' );
+		$this->assertEquals( $capacity, get_post_meta( $duplicated_event->ID, Global_Stock::GLOBAL_STOCK_LEVEL, true ), 'event stock level' );
+
+		foreach ( Tribe__Tickets__Tickets::get_all_event_tickets( $duplicated_event->ID ) as $ticket ) {
+			$this->assertEquals( $capacity, $ticket->capacity(), 'duplicated ticket capacity' );
 		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1409](https://linear.app/nexcess/issue/SMTNC-1409/when-duplicate-events-with-woocommerce-tickets-with-shared-capacity)

### 🗒️ Description

Resolved an issue where duplicating an event that had shared-capacity (global stock) tickets reset the duplicated tickets' capacity to zero. The duplicated event was created with global stock *enabled* and a copied capacity but no stock *level*; saving the first shared ticket onto it then synced the empty level to `0`, which cascaded to zero out the event capacity and every ticket's capacity.

### 🎥 Artifacts

[https://www.loom.com/share/44999451966c46168a4dc53e289d1fd8](https://www.loom.com/share/44999451966c46168a4dc53e289d1fd8)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
