### PR TITLE
Only show ticket capacity (not RSVP) in ticket metabox

### DIFF
--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -791,6 +791,8 @@ class Tribe__Tickets__Tickets_View {
 	 *
 	 * @since 4.10.8
 	 * @since TBD Added the `$context` parameter and arguments filtering.
+	 * @since TBD Excluded RSVP V2 (TC-RSVP) attendees, which share the Tickets Commerce
+	 *        attendee/provider with regular tickets and were not caught by `provider__not_in`.
 	 *
 	 * @param int      $event_id The Event ID we're checking.
 	 * @param int|null $user_id  An Optional User ID.
@@ -806,8 +808,9 @@ class Tribe__Tickets__Tickets_View {
 
 		$args = [
 			'by' => [
-				'provider__not_in' => 'rsvp',
-				'status'           => 'publish',
+				'provider__not_in'    => 'rsvp',
+				'ticket_type__not_in' => Constants::TC_RSVP_TYPE,
+				'status'              => 'publish',
 			],
 		];
 

--- a/src/admin-views/editor/panel/list.php
+++ b/src/admin-views/editor/panel/list.php
@@ -11,7 +11,9 @@ $tickets_attendees = tribe( 'tickets.attendees' );
 
 $attendees_url = $tickets_attendees->get_report_link( get_post( $post_id ) );
 
-$total_capacity = (int) tribe_get_event_capacity( $post_id );
+$total_capacity = (int) tribe_get_event_capacity( $post_id, true );
+
+$has_ticket_attendees = Tribe__Tickets__Tickets_View::instance()->has_ticket_attendees( $post_id );
 
 $container_class = 'tribe_sectionheader ticket_list_container';
 $container_class .= ( empty( $total_capacity ) ) ? ' tribe_no_capacity' : '';
@@ -150,11 +152,13 @@ $admin_views = tribe( 'tickets.admin.views' );
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
 			<?php if ( ! empty( $tickets ) ) : ?>
-				<a
-					href="<?php echo esc_url( $attendees_url ); ?>"
-				>
-					<?php esc_html_e( 'View Attendees', 'event-tickets' ); ?>
-				</a>
+				<?php if ( $has_ticket_attendees ) : ?>
+					<a
+						href="<?php echo esc_url( $attendees_url ); ?>"
+					>
+						<?php esc_html_e( 'View Attendees', 'event-tickets' ); ?>
+					</a>
+				<?php endif; ?>
 
 				<?php
 				/**

--- a/src/admin-views/editor/total-capacity.php
+++ b/src/admin-views/editor/total-capacity.php
@@ -16,7 +16,7 @@ $label = sprintf(
 	_x( 'Total %s Capacity:', 'ticket capacity label in admin panel', 'event-tickets' ),
 	tribe_get_ticket_label_singular( 'total_capacity_label' )
 );
-$title = sprintf(
+$capacity_tooltip = sprintf(
 	/* translators: %s: lowercase singular ticket label, e.g. "ticket" */
 	_x( 'The total number of possible %s attendees for this event', 'ticket capacity label description in admin panel', 'event-tickets' ),
 	tribe_get_ticket_label_singular_lowercase( 'total_capacity_label_description' )
@@ -24,7 +24,7 @@ $title = sprintf(
 ?>
 <span id="ticket_form_total_capacity">
 	<?php echo esc_html( $label ); ?>
-	<span id="ticket_form_total_capacity_value" title="<?php echo esc_attr( $title ); ?>">
+	<span id="ticket_form_total_capacity_value" title="<?php echo esc_attr( $capacity_tooltip ); ?>">
 		<?php
 		switch ( $total_tickets ) {
 			case -1:

--- a/src/admin-views/editor/total-capacity.php
+++ b/src/admin-views/editor/total-capacity.php
@@ -4,27 +4,22 @@ $post_id = get_the_ID();
 /** @var Tribe__Tickets__Tickets_Handler $handler */
 $handler = tribe( 'tickets.handler' );
 
-$total_tickets = tribe_get_event_capacity( $post_id );
+$total_tickets = tribe_get_event_capacity( $post_id, true );
 
 // only show if there are tickets
 if ( empty( $total_tickets ) ) {
 	return;
 }
 
-$post_labels          = get_post_type_labels( get_post_type_object( get_post_type( $post_id ) ) );
-$uppercase_post_label = $post_labels->singular_name ?? 'Event';
-$label                = sprintf(
-	/* translators: %s: uppercase post type label */
-	__(
-		'Total %s Capacity:',
-		'event-tickets'
-	),
-	$uppercase_post_label
+$label = sprintf(
+	/* translators: %s: singular ticket label, e.g. "Ticket" */
+	_x( 'Total %s Capacity:', 'ticket capacity label in admin panel', 'event-tickets' ),
+	tribe_get_ticket_label_singular( 'total_capacity_label' )
 );
-$title                = sprintf(
-	/* translators: %s: lowercase post type label */
-	__( 'The total number of possible attendees for this %s', 'event-tickets' ),
-	strtolower( $uppercase_post_label )
+$title = sprintf(
+	/* translators: %s: lowercase singular ticket label, e.g. "ticket" */
+	_x( 'The total number of possible %s attendees for this event', 'ticket capacity label description in admin panel', 'event-tickets' ),
+	tribe_get_ticket_label_singular_lowercase( 'total_capacity_label_description' )
 );
 ?>
 <span id="ticket_form_total_capacity">

--- a/src/template-tags/tickets.php
+++ b/src/template-tags/tickets.php
@@ -1088,12 +1088,14 @@ if ( ! function_exists( 'tribe_get_event_capacity' ) ) {
 	 *
 	 * @since 4.11.3
 	 * @since 4.12.3 Use new helper method to account for possibly inactive ticket provider.
+	 * @since TBD Added the `$tickets_only` parameter to allow excluding RSVP capacity from the total.
 	 *
-	 * @param int|WP_Post $post Post (event) we are trying to fetch capacity for.
+	 * @param int|WP_Post $post          Post (event) we are trying to fetch capacity for.
+	 * @param bool        $tickets_only  Whether to exclude RSVP capacity and return ticket-only capacity.
 	 *
 	 * @return int|null
 	 */
-	function tribe_get_event_capacity( $post ) {
+	function tribe_get_event_capacity( $post, $tickets_only = false ) {
 		// When not dealing with an instance of post try to set it up..
 		if ( ! $post instanceof WP_Post ) {
 			$post = get_post( $post );
@@ -1135,7 +1137,7 @@ if ( ! function_exists( 'tribe_get_event_capacity' ) ) {
 
 		if ( ( ! $has_provider && $rsvp_tickets ) || $provider instanceof Tribe__Tickets__RSVP ) {
 			// If we have no provider but have RSVP tickets, or the provider is RSVP, return the RSVP capacity.
-			return (int) $rsvp_cap;
+			return $tickets_only ? 0 : (int) $rsvp_cap;
 		} elseif ( ! $has_provider ) {
 			// If we have no provider, return null for no capacity set.
 			return null;
@@ -1145,7 +1147,7 @@ if ( ! function_exists( 'tribe_get_event_capacity' ) ) {
 
 		// We only have RSVPs.
 		if ( empty( $tickets ) ) {
-			return (int) $rsvp_cap;
+			return $tickets_only ? 0 : (int) $rsvp_cap;
 		}
 
 		$global_stock = new \Tribe__Tickets__Global_Stock( $post_id );
@@ -1176,12 +1178,20 @@ if ( ! function_exists( 'tribe_get_event_capacity' ) ) {
 			}
 		}
 
-		// If either is unlimited, it's all unlimited.
-		if ( -1 === $tickets_cap || -1 === $rsvp_cap ) {
-			return -1;
-		}
+		if ( $tickets_only ) {
+			if ( -1 === $tickets_cap ) {
+				return -1;
+			}
 
-		$value = (int) $rsvp_cap + (int) $tickets_cap;
+			$value = (int) $tickets_cap;
+		} else {
+			// If either is unlimited, it's all unlimited.
+			if ( -1 === $tickets_cap || -1 === $rsvp_cap ) {
+				return -1;
+			}
+
+			$value = (int) $rsvp_cap + (int) $tickets_cap;
+		}
 
 		/**
 		 * Filters the event capacity.

--- a/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__event__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__event__0.snapshot.html
@@ -1,4 +1,4 @@
 <span id="ticket_form_total_capacity">
-	Total Event Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this event">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">89</a>	</span>
 </span>

--- a/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__page__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__page__0.snapshot.html
@@ -1,4 +1,4 @@
 <span id="ticket_form_total_capacity">
-	Total Page Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this page">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">89</a>	</span>
 </span>

--- a/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__post__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/Admin_ViewsTest__test_editor_total_capacity_template__post__0.snapshot.html
@@ -1,4 +1,4 @@
 <span id="ticket_form_total_capacity">
-	Total Post Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this post">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">89</a>	</span>
 </span>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with RSVP__0.snapshot.html
@@ -4,7 +4,7 @@
 	aria-hidden="false"
 	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
 >
-	<div class="tribe_sectionheader ticket_list_container">
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
 			<button
 	id="ticket_form_toggle"
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -118,19 +118,11 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=tribe_events&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 									</div>
 
 		<div class="tribe-ticket-control-wrap__settings">
-							<span id="ticket_form_total_capacity">
-	Total Event Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this event">
-		<a href="#" id="capacity_form_toggle">100</a>	</span>
-</span>
-			
+										
 			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
     Settings</button>
 		</div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket and sale price__0.snapshot.html
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -134,11 +134,7 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=tribe_events&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 				
 	<a
 		href="http://wordpress.test/wp-admin/edit.php?post_type=tribe_events&#038;page=tickets-commerce-orders&#038;event_id={{ post_id }}"
@@ -148,7 +144,7 @@ New ticket</button><button
 
 		<div class="tribe-ticket-control-wrap__settings">
 							<span id="ticket_form_total_capacity">
-	Total Event Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this event">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__event with ticket__0.snapshot.html
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -123,11 +123,7 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=tribe_events&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 				
 	<a
 		href="http://wordpress.test/wp-admin/edit.php?post_type=tribe_events&#038;page=tickets-commerce-orders&#038;event_id={{ post_id }}"
@@ -137,7 +133,7 @@ New ticket</button><button
 
 		<div class="tribe-ticket-control-wrap__settings">
 							<span id="ticket_form_total_capacity">
-	Total Event Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this event">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with RSVP__0.snapshot.html
@@ -4,7 +4,7 @@
 	aria-hidden="false"
 	data-save-prompt="You have unsaved changes to your tickets. Discard those changes?"
 >
-	<div class="tribe_sectionheader ticket_list_container">
+	<div class="tribe_sectionheader ticket_list_container tribe_no_capacity">
 		<div class="ticket_table_intro">
 			<button
 	id="ticket_form_toggle"
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -118,19 +118,11 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=post&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 									</div>
 
 		<div class="tribe-ticket-control-wrap__settings">
-							<span id="ticket_form_total_capacity">
-	Total Post Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this post">
-		<a href="#" id="capacity_form_toggle">100</a>	</span>
-</span>
-			
+										
 			<button id="settings_form_toggle" class="button-secondary tribe-button-icon tribe-button-icon-settings">
     Settings</button>
 		</div>

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket and sale price__0.snapshot.html
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -134,11 +134,7 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=post&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 				
 	<a
 		href="http://wordpress.test/wp-admin/edit.php?post_type=post&#038;page=tickets-commerce-orders&#038;event_id={{ post_id }}"
@@ -148,7 +144,7 @@ New ticket</button><button
 
 		<div class="tribe-ticket-control-wrap__settings">
 							<span id="ticket_form_total_capacity">
-	Total Post Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this post">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			

--- a/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
+++ b/tests/integration/Tribe/Tickets/__snapshots__/MetaboxTest__test_get_panels__post with ticket__0.snapshot.html
@@ -16,7 +16,7 @@ New ticket</button><button
 	id="rsvp_form_toggle"
 	class="button-secondary ticket_form_toggle tribe-button-icon tribe-button-icon-plus"
 	aria-label="Add a new RSVP"
->
+	>
 	New RSVP</button>
 		</div>
 
@@ -123,11 +123,7 @@ New ticket</button><button
 	</div>
 	<div class="tribe-ticket-control-wrap">
 		<div class="tribe-ticket-control-wrap__ctas">
-							<a
-					href="http://wordpress.test/wp-admin/edit.php?post_type=post&#038;page=tickets-attendees&#038;event_id={{ post_id }}"
-				>
-					View Attendees				</a>
-
+							
 				
 	<a
 		href="http://wordpress.test/wp-admin/edit.php?post_type=post&#038;page=tickets-commerce-orders&#038;event_id={{ post_id }}"
@@ -137,7 +133,7 @@ New ticket</button><button
 
 		<div class="tribe-ticket-control-wrap__settings">
 							<span id="ticket_form_total_capacity">
-	Total Post Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible attendees for this post">
+	Total Ticket Capacity:	<span id="ticket_form_total_capacity_value" title="The total number of possible ticket attendees for this event">
 		<a href="#" id="capacity_form_toggle">100</a>	</span>
 </span>
 			

--- a/tests/wpunit/Tribe/Tickets/Tickets_ViewTest.php
+++ b/tests/wpunit/Tribe/Tickets/Tickets_ViewTest.php
@@ -5,11 +5,40 @@ use Closure;
 use Generator;
 use Codeception\TestCase\WPTestCase;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use TEC\Tickets\Commerce\Module as Commerce;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker as RSVP_V2_Attendee_Maker;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker as RSVP_V2_Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker as Commerce_Ticket_Maker;
 use Tribe__Tickets__Tickets_View as Tickets_View;
 
 class Tickets_ViewTest extends WPTestCase {
 
 	use SnapshotAssertions;
+	use RSVP_V2_Attendee_Maker;
+	use RSVP_V2_Ticket_Maker;
+	use Attendee_Maker;
+	use Commerce_Ticket_Maker;
+
+	/**
+	 * Low-level registration of the Commerce provider. There is no need for a full-blown registration
+	 * at this stage: having the module as active and as a valid provider is enough.
+	 *
+	 * @before
+	 */
+	public function activate_commerce_tickets(): void {
+		// The wpunit suite disables Tickets Commerce by default via the `TEC_TICKETS_COMMERCE` env var.
+		putenv( 'TEC_TICKETS_COMMERCE=1' );
+
+		add_filter( 'tribe_tickets_get_modules', static function ( array $modules ): array {
+			$modules[ Commerce::class ] = 'Commerce';
+
+			return $modules;
+		} );
+		// Regenerate the Tickets Data API to pick up the filtered providers.
+		tribe()->singleton( 'tickets.data_api', new \Tribe__Tickets__Data_API() );
+	}
+
 	public function setUp() {
 		// before
 		parent::setUp();
@@ -39,6 +68,51 @@ class Tickets_ViewTest extends WPTestCase {
 	 */
 	private function make_instance() {
 		return new Tickets_View();
+	}
+
+	/**
+	 * @test
+	 * it should not count RSVP V2 attendees as ticket attendees
+	 */
+	public function it_should_not_count_rsvp_v2_attendees_as_ticket_attendees(): void {
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2020-01-01 09:00:00',
+			'end_date'   => '2020-01-01 11:30:00',
+		] )->create()->ID;
+
+		$rsvp_ticket_id = $this->create_tc_rsvp_ticket( $event_id );
+		$this->create_tc_rsvp_attendee( $rsvp_ticket_id, $event_id );
+
+		$sut = $this->make_instance();
+
+		$this->assertEquals( 0, $sut->count_ticket_attendees( $event_id ) );
+		$this->assertFalse( $sut->has_ticket_attendees( $event_id ) );
+	}
+
+	/**
+	 * @test
+	 * it should count only non RSVP V2 attendees when the event has both ticket and RSVP V2 attendees
+	 */
+	public function it_should_count_only_non_rsvp_v2_attendees_when_event_has_both(): void {
+		$event_id = tribe_events()->set_args( [
+			'title'      => 'Test Event',
+			'status'     => 'publish',
+			'start_date' => '2020-01-01 09:00:00',
+			'end_date'   => '2020-01-01 11:30:00',
+		] )->create()->ID;
+
+		$ticket_id = $this->create_tc_ticket( $event_id, 10 );
+		$this->create_attendee_for_ticket( $ticket_id, $event_id );
+
+		$rsvp_ticket_id = $this->create_tc_rsvp_ticket( $event_id );
+		$this->create_tc_rsvp_attendee( $rsvp_ticket_id, $event_id );
+
+		$sut = $this->make_instance();
+
+		$this->assertEquals( 1, $sut->count_ticket_attendees( $event_id ) );
+		$this->assertTrue( $sut->has_ticket_attendees( $event_id ) );
 	}
 	
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3350](https://linear.app/nexcess/issue/SOFT-3350/tickets-metabox-should-ignore-rsvp-capacity-and-attendees)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The ticket metabox was showing the capacity of tickets + rsvp and we want it to only be ticket capacity. This PR adjusts that calculation and label to 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

Before: 
<img width="3156" height="1798" alt="CleanShot 2026-07-02 at 08 41 00@2x" src="https://github.com/user-attachments/assets/ef1bca36-a1d9-4a22-9555-6b67d10a1a92" />

After:
<img width="2646" height="1448" alt="CleanShot 2026-07-02 at 08 56 06@2x" src="https://github.com/user-attachments/assets/849d5463-2574-4fe6-a521-7b55ce80f760" />


### ✔️ Checklist
- [x] Since this is within the rsvp-merge bucket we can [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
