### PR TITLE
Fix: Fatal Error in attendes tab & orders tab duplication

### DIFF
--- a/changelog/fix-order-summary-provider-guard
+++ b/changelog/fix-order-summary-provider-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved a fatal error on the Orders admin page when viewing orders for an event without an active ticket provider. The Orders page now gracefully handles missing provider context instead of crashing.

--- a/changelog/fix-smtnc-302-tc-disabled-attendee-fatal
+++ b/changelog/fix-smtnc-302-tc-disabled-attendee-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved a fatal error on the Attendees admin page when having both TC and Woo tickets bought on the same event.

--- a/changelog/fix-woo-orders-tab-instance-check
+++ b/changelog/fix-woo-orders-tab-instance-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the legacy Orders tabbed view could render duplicate "Orders" tabs when both Tickets Commerce and WooCommerce (Event Tickets Plus) were active.

--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -347,6 +347,10 @@ class Module extends \Tribe__Tickets__Tickets {
 	 * @return array|mixed
 	 */
 	public function get_attendees_by_id( $post_id, $post_type = null ) {
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return [];
+		}
+
 		if ( ! $post_type ) {
 			$post_type = get_post_type( $post_id );
 		}
@@ -497,6 +501,10 @@ class Module extends \Tribe__Tickets__Tickets {
 	 * {@inheritdoc}
 	 */
 	public function get_attendee( $attendee, $post_id = 0 ) {
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return false;
+		}
+
 		return tec_tc_get_attendee( $attendee, ARRAY_A );
 	}
 

--- a/src/Tickets/Commerce/Provider.php
+++ b/src/Tickets/Commerce/Provider.php
@@ -57,6 +57,7 @@ class Provider extends Service_Provider {
 		$this->container->singleton( Reports\Attendance_Totals::class );
 		$this->container->singleton( Reports\Attendees::class );
 		$this->container->singleton( Reports\Orders::class );
+		$this->container->singleton( Reports\Tabbed_View::class );
 		$this->container->singleton( Admin_Tables\Orders::class );
 		$this->container->singleton( Admin_Tables\Attendees::class );
 

--- a/src/Tickets/Commerce/Reports/Data/Order_Summary.php
+++ b/src/Tickets/Commerce/Reports/Data/Order_Summary.php
@@ -449,7 +449,12 @@ class Order_Summary {
 		}
 
 		$provider = Tribe__Tickets__Tickets::get_event_ticket_provider_object( $this->post_id );
-		$tickets  = $provider->get_tickets( $this->post_id );
+
+		if ( ! $provider ) {
+			return [];
+		}
+
+		$tickets = $provider->get_tickets( $this->post_id );
 
 		foreach ( $tickets as $ticket ) {
 			$this->tickets[ $ticket->ID ] = $ticket;

--- a/src/Tickets/Commerce/Reports/Orders.php
+++ b/src/Tickets/Commerce/Reports/Orders.php
@@ -197,7 +197,7 @@ class Orders extends Report_Abstract {
 		add_action( 'admin_menu', [ $this, 'register_orders_page' ], 5 );
 
 		// Register the tabbed view.
-		$tc_tabbed_view = new Tabbed_View();
+		$tc_tabbed_view = tribe( Tabbed_View::class );
 		$tc_tabbed_view->set_active( self::$tab_slug );
 		$tc_tabbed_view->register();
 	}

--- a/src/Tickets/Commerce/Reports/Tabbed_View.php
+++ b/src/Tickets/Commerce/Reports/Tabbed_View.php
@@ -115,6 +115,10 @@ class Tabbed_View {
 			return;
 		}
 
+		if ( $this->woo_orders_tab_is_registered( $tabbed_view ) ) {
+			return;
+		}
+
 		add_filter( 'tribe_tickets_attendees_show_title', '__return_false' );
 
 		$orders_report     = new Orders_Tab( $tabbed_view );

--- a/src/Tickets/Commerce/Reports/Tabbed_View.php
+++ b/src/Tickets/Commerce/Reports/Tabbed_View.php
@@ -43,7 +43,34 @@ class Tabbed_View {
 		add_action( 'tec_tickets_commerce_reports_tabbed_view_before_register_tab', [ $this, 'register_tabs' ], 10, 2 );
 
 		// Legacy compatibility with Attendees page which is not part of Tickets Commerce.
-		add_action( 'tribe_tickets_orders_tabbed_view_register_tab_right', [ $this, 'register_tabs' ], 10, 2 );
+		// Runs at priority 20 so any other provider (WooCommerce, EDD, ...) registering at the default
+		// priority has already registered its Orders tab and we can defer to it.
+		add_action( 'tribe_tickets_orders_tabbed_view_register_tab_right', [ $this, 'register_tabs_on_attendees_page' ], 20, 2 );
+	}
+
+	/**
+	 * Registers the Tickets Commerce Orders tab on the legacy Attendees page's tabbed view.
+	 *
+	 * Skips registration when Tickets Commerce is disabled or when another provider has already
+	 * registered an Orders tab on the same tabbed view — so we don't render two "Orders" tabs.
+	 *
+	 * @since TBD
+	 *
+	 * @param Tribe__Tabbed_View $tabbed_view The tabbed view that is rendering.
+	 * @param WP_Post            $post        The post orders should be shown for.
+	 *
+	 * @return void
+	 */
+	public function register_tabs_on_attendees_page( Tribe__Tabbed_View $tabbed_view, WP_Post $post ): void {
+		if ( ! tec_tickets_commerce_is_enabled() ) {
+			return;
+		}
+
+		if ( $this->woo_orders_tab_is_registered( $tabbed_view ) ) {
+			return;
+		}
+
+		$this->register_tabs( $tabbed_view, $post );
 	}
 
 	/**
@@ -94,6 +121,25 @@ class Tabbed_View {
 		$orders_report_url = Orders::get_tickets_report_link( $post );
 		$orders_report->set_url( $orders_report_url );
 		$tabbed_view->register( $orders_report );
+	}
+
+	/**
+	 * Whether the given tabbed view already has an Orders tab registered by another provider.
+	 *
+	 * @since TBD
+	 *
+	 * @param Tribe__Tabbed_View $tabbed_view The tabbed view being rendered.
+	 *
+	 * @return bool
+	 */
+	protected function woo_orders_tab_is_registered( Tribe__Tabbed_View $tabbed_view ): bool {
+		foreach ( $tabbed_view->get_tabs() as $tab ) {
+			if ( $tab instanceof \Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/Tickets/Commerce/Reports/Tabbed_View.php
+++ b/src/Tickets/Commerce/Reports/Tabbed_View.php
@@ -41,18 +41,18 @@ class Tabbed_View {
 	public function register(): void {
 		add_filter( 'tec_tickets_commerce_reports_tabbed_view_tab_map', [ $this, 'include_order_tab' ] );
 		add_action( 'tec_tickets_commerce_reports_tabbed_view_before_register_tab', [ $this, 'register_tabs' ], 10, 2 );
-
-		// Legacy compatibility with Attendees page which is not part of Tickets Commerce.
-		// Runs at priority 20 so any other provider (WooCommerce, EDD, ...) registering at the default
-		// priority has already registered its Orders tab and we can defer to it.
-		add_action( 'tribe_tickets_orders_tabbed_view_register_tab_right', [ $this, 'register_tabs_on_attendees_page' ], 20, 2 );
+ 
+		/**
+		 * Runs at priority 20 so any other provider (WooCommerce, EDD, ...) registering at the default
+		 * priority has already registered its Orders tab and we can defer to it.
+		*/
+		add_action( 'tribe_tickets_orders_tabbed_view_register_tab_right', [ $this, 'register_tabs' ], 20, 2 );
 	}
 
 	/**
-	 * Registers the Tickets Commerce Orders tab on the legacy Attendees page's tabbed view.
-	 *
-	 * Skips registration when Tickets Commerce is disabled or when another provider has already
-	 * registered an Orders tab on the same tabbed view — so we don't render two "Orders" tabs.
+	 * Registers the Tickets Commerce Orders tab on the Attendees page's tabbed view.
+	 * 
+	 * Skips registration when Tickets Commerce is disabled or when ETP has already registered an Orders tab.
 	 *
 	 * @since TBD
 	 *

--- a/src/Tickets/Seating/Orders/Seats_Report.php
+++ b/src/Tickets/Seating/Orders/Seats_Report.php
@@ -64,7 +64,7 @@ class Seats_Report extends Report_Abstract {
 	 */
 	public function register_tab() {
 		// Register the tabbed view.
-		$tc_tabbed_view = new Tabbed_View();
+		$tc_tabbed_view = tribe( Tabbed_View::class );
 		$tc_tabbed_view->set_active( self::$tab_slug );
 		$tc_tabbed_view->register();
 	}
@@ -107,7 +107,7 @@ class Seats_Report extends Report_Abstract {
 	 * @since 5.16.0
 	 */
 	public function render_page() {
-		$tc_tabbed_view = new Tabbed_View();
+		$tc_tabbed_view = tribe( Tabbed_View::class );
 		$tc_tabbed_view->set_active( self::$tab_slug );
 		$tc_tabbed_view->render();
 

--- a/tests/_support/Stubs/Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab_Stub.php
+++ b/tests/_support/Stubs/Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab_Stub.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Minimal Event Tickets Plus WooCommerce Orders tab stub used to exercise the
+ * `Tabbed_View::woo_orders_tab_is_registered()` `instanceof` branch in tests
+ * without loading Event Tickets Plus.
+ *
+ * @package TEC\Tickets\Tests\Support\Stubs
+ */
+
+if ( ! class_exists( 'Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab', false ) ) {
+	/**
+	 * Minimal WooCommerce Orders tab stub.
+	 */
+	class Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab extends Tribe__Tabbed_View__Tab {
+		/**
+		 * @var string
+		 */
+		protected $slug = 'tribe-tickets-plus-woocommerce-orders-report';
+
+		/**
+		 * @return string
+		 */
+		public function get_slug() {
+			return $this->slug;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function get_label() {
+			return 'Orders';
+		}
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Module_Guards_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Module_Guards_Test.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+
+/**
+ * Guards `TEC\Tickets\Commerce\Module::get_attendee()` and
+ * `Module::get_attendees_by_id()` against being called while Tickets Commerce
+ * is disabled — the free function `tec_tc_get_attendee()` isn't loaded in
+ * that state and would otherwise raise a fatal.
+ */
+class Module_Guards_Test extends WPTestCase {
+
+	use With_Uopz;
+
+	private function module(): Module {
+		return tribe( Module::class );
+	}
+
+	public function test_get_attendee_returns_false_when_tc_is_disabled(): void {
+		$this->set_fn_return( 'tec_tickets_commerce_is_enabled', false );
+
+		$this->assertFalse( $this->module()->get_attendee( 12345 ) );
+	}
+
+	public function test_get_attendees_by_id_returns_empty_array_when_tc_is_disabled(): void {
+		$this->set_fn_return( 'tec_tickets_commerce_is_enabled', false );
+
+		$event_id = static::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$this->assertSame( [], $this->module()->get_attendees_by_id( $event_id ) );
+	}
+
+	public function test_get_attendee_does_not_fatal_for_unknown_attendee_when_tc_disabled(): void {
+		// Regression guard: the customer-reported fatal occurs because `tec_tc_get_attendee` is
+		// not loaded when TC is disabled. If the guard is ever removed, this test will surface
+		// an `Error` instead of returning a value.
+		$this->set_fn_return( 'tec_tickets_commerce_is_enabled', false );
+
+		$result = $this->module()->get_attendee( PHP_INT_MAX );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_get_attendees_by_id_does_not_fatal_when_tc_disabled_for_event(): void {
+		// Reproduces the customer stack: `Ticket_Object::inventory()` calls
+		// `Module::get_attendees_by_id( $event_id )` for a global-stock ticket. If the guard
+		// is removed the default switch branch reaches `get_attendee`, which fatals.
+		$this->set_fn_return( 'tec_tickets_commerce_is_enabled', false );
+
+		$event_id = static::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$this->assertSame( [], $this->module()->get_attendees_by_id( $event_id ) );
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Reports/Data/Order_Summary_Guard_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Reports/Data/Order_Summary_Guard_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Reports\Data;
+
+use Codeception\TestCase\WPTestCase;
+
+/**
+ * Regression: `Order_Summary::get_tickets()` used to fatal on an event that
+ * had no active ticket provider because it called `$provider->get_tickets()`
+ * on a `false` value returned by `Tribe__Tickets__Tickets::get_event_ticket_provider_object()`.
+ */
+class Order_Summary_Guard_Test extends WPTestCase {
+
+	public function test_get_tickets_returns_empty_array_when_provider_is_missing(): void {
+		$post_id = static::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		// A brand-new post has no ticket provider meta, so
+		// `Tribe__Tickets__Tickets::get_event_ticket_provider_object()` returns false.
+		$summary = new Order_Summary( $post_id );
+
+		$this->assertSame( [], $summary->get_tickets() );
+	}
+
+	public function test_build_data_does_not_fatal_when_provider_is_missing(): void {
+		// `Order_Summary` calls `build_data()` via `init()`. Prior to the fix, this would
+		// walk into `get_tickets()` and dereference a `false` provider — fatal.
+		$post_id = static::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$summary = new Order_Summary( $post_id );
+		$summary->init();
+
+		$this->assertSame( [], $summary->get_tickets() );
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Reports/Tabbed_View_Dedup_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Reports/Tabbed_View_Dedup_Test.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Reports;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe__Tabbed_View;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe\Tickets\Test\Traits\With_Tickets_Commerce;
+
+/**
+ * Regression: on the legacy Attendees admin page, both Tickets Commerce and
+ * Event Tickets Plus (WooCommerce) used to register an "Orders" tab on the
+ * same tabbed view, rendering "Orders | Orders" side by side.
+ *
+ * `Tabbed_View::register_tabs()` should now defer to ETP's WooCommerce Orders tab when it is already registered.
+ */
+class Tabbed_View_Dedup_Test extends WPTestCase {
+
+	use With_Tickets_Commerce;
+	use Ticket_Maker;
+	use With_Uopz;
+
+	/**
+	 * Event Tickets Plus is intentionally not loaded by the commerce_integration suite so ET can
+	 * be exercised standalone. Load a minimal stub of ETP's WooCommerce Orders tab class with
+	 * the exact FQN the production code checks against, so the `instanceof` branch can be tested.
+	 *
+	 * In production, when ETP is absent PHP evaluates `$tab instanceof \Missing\Class` as `false`
+	 * without fataling, so `Tabbed_View::woo_orders_tab_is_registered()` is safe either way.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		require_once dirname( __DIR__, 5 ) . '/_support/Stubs/Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab_Stub.php';
+	}
+
+	/**
+	 * Builds a tabbed view with a real Tickets Commerce ticket on a post so
+	 * `Module::post_has_tickets()` is truthy for the target event.
+	 */
+	private function tabbed_view_for_event(): array {
+		$event_id  = static::factory()->post->create( [ 'post_type' => 'post' ] );
+		$this->create_tc_ticket( $event_id, 10 );
+
+		$_REQUEST['event_id'] = $event_id;
+		$_REQUEST['post_id']  = $event_id;
+
+		$tabbed_view = new Tribe__Tabbed_View();
+
+		return [ $tabbed_view, get_post( $event_id ) ];
+	}
+
+	public function test_registers_tc_orders_tab_when_no_woo_tab_present(): void {
+		[ $tabbed_view, $post ] = $this->tabbed_view_for_event();
+
+		( new Tabbed_View() )->register_tabs( $tabbed_view, $post );
+
+		$slugs = array_map( static fn( $t ) => $t->get_slug(), $tabbed_view->get_tabs() );
+
+		$this->assertContains( Orders::$tab_slug, $slugs );
+	}
+
+	public function test_skips_tc_orders_tab_when_woo_tab_already_registered(): void {
+		[ $tabbed_view, $post ] = $this->tabbed_view_for_event();
+
+		$woo_tab = new \Tribe__Tickets_Plus__Commerce__WooCommerce__Tabbed_View__Orders_Report_Tab( $tabbed_view );
+		$woo_tab->set_url( '#' );
+		$tabbed_view->register( $woo_tab );
+
+		( new Tabbed_View() )->register_tabs( $tabbed_view, $post );
+
+		$slugs = array_map( static fn( $t ) => $t->get_slug(), $tabbed_view->get_tabs() );
+
+		$this->assertNotContains( Orders::$tab_slug, $slugs, 'Tickets Commerce Orders tab should be skipped when the WooCommerce Orders tab is already registered.' );
+	}
+
+	public function test_legacy_hook_is_bound_at_priority_20(): void {
+		// The dedup relies on TC registering after ETP on the legacy hook. Locking the
+		// priority in a test guards against accidental reordering.
+		$priority = has_action(
+			'tribe_tickets_orders_tabbed_view_register_tab_right',
+			[ tribe( Tabbed_View::class ), 'register_tabs' ]
+		);
+
+		$this->assertSame( 20, $priority );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-302](https://linear.app/nexcess/issue/SMTNC-302/fatal-error-and-orders-tab-duplication-when-switching-from-tickets)

### 🗒️ Description

<img width="1996" height="598" alt="image" src="https://github.com/user-attachments/assets/8d88f77d-fea5-4777-a451-ed3d744639ff" />

<img width="2001" height="822" alt="image" src="https://github.com/user-attachments/assets/fd14fe08-9492-453b-8b87-51d5dd87ff4b" />

Fixes two issues seen when a site has both Tickets Commerce and Event Tickets Plus (WooCommerce) tickets on the same event:

- **Fatal error on the Attendees admin page.** `TEC\Tickets\Commerce\Module::get_attendee()` unconditionally called `tec_tc_get_attendee()`, which is only loaded when Tickets Commerce is enabled. If TC is disabled but the event still references `TEC\Tickets\Commerce\Module` as its default provider (or is reached via `Ticket_Object::inventory()` for a global-stock ticket), the free function is undefined and the page fatals. Added `tec_tickets_commerce_is_enabled()` guards on both `Module::get_attendee()` and `Module::get_attendees_by_id()` so they safely no-op when TC is off.
- **Duplicate "Orders" tab on the Attendees admin page.** Both Tickets Commerce and ETP-WooCommerce hook `tribe_tickets_orders_tabbed_view_register_tab_right` and each register an Orders tab with the same label but a different slug — rendering "Orders | Orders" side by side. TC now hooks the legacy compat action at priority 20 (was 10) and skips registering its Orders tab if ETP's WooCommerce Orders tab is already present.
- **Companion fix in `Order_Summary::get_tickets()`.** Guarded against a null provider so the Orders admin page no longer fatals when the event has no active ticket provider.

### 🎥 Artifacts

https://www.loom.com/share/a14596a8a3c5491cb82fc7d3fb28f2f4

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
