### PR TITLE
[SOFT-3353] Fix inverted RSVP public attendee list opt-in toggle visibility

### DIFF
--- a/src/Tickets/RSVP/V2/REST/Order_Endpoint.php
+++ b/src/Tickets/RSVP/V2/REST/Order_Endpoint.php
@@ -21,6 +21,7 @@ use TEC\Tickets\Commerce\Status\Completed;
 use TEC\Tickets\Commerce\Status\Pending;
 use TEC\Tickets\Commerce\Success;
 use TEC\Tickets\RSVP\V2\Constants;
+use Tribe\Tickets\Events\Attendees_List;
 use Tribe__Tickets__Tickets_View as Tickets_View;
 use Tribe__Tickets__Ticket_Object;
 use Tribe__Utils__Array;
@@ -484,7 +485,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			$args['attendees'] = $args['process_result']['attendees'];
 		}
 
-		$show_attendee_list_optout = false;
+		$show_attendee_list_optout = ! Attendees_List::is_hidden_on( $post_id );
 
 		/**
 		 * Allow filtering of whether to show the opt-in option for attendees.
@@ -501,7 +502,7 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 			$show_attendee_list_optout = false;
 		}
 
-		$args['opt_in_toggle_hidden'] = $show_attendee_list_optout;
+		$args['opt_in_toggle_hidden'] = ! $show_attendee_list_optout;
 
 		$this->template->add_template_globals( $args );
 

--- a/tests/wpunit/Tribe/Tickets/TicketsTest.php
+++ b/tests/wpunit/Tribe/Tickets/TicketsTest.php
@@ -283,6 +283,58 @@ class TicketsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * It should show RSVP tickets on the front end even when the post has no explicit default
+	 * provider meta saved and RSVP is the only ticket type on the post.
+	 *
+	 * Reproduces a reported bug: an RSVP ticket added via the classic (non-block) editor renders
+	 * fine in wp-admin but silently disappears on the front end. Root cause: when a post has no
+	 * `_tribe_default_ticket_provider` meta (e.g. because the classic ticket panel never submitted
+	 * a `default_provider` value), get_event_ticket_provider() falls back to the site-wide default
+	 * module, which may not be RSVP. get_tickets() then filters out RSVP tickets whose provider
+	 * doesn't match that default -- but only on the front end, since the check is skipped entirely
+	 * in wp-admin (see should_show_rsvp_tickets_in_admin_context_when_default_meta_is_missing below).
+	 *
+	 * @test
+	 */
+	public function should_show_rsvp_tickets_on_front_end_when_default_meta_is_missing() {
+		$post_id = $this->factory->post->create();
+		$this->create_rsvp_ticket( $post_id );
+
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		set_current_screen( 'front' );
+
+		$tickets = $rsvp->get_tickets( $post_id );
+
+		$this->assertNotEmpty( $tickets, 'RSVP tickets should be visible on the front end even without an explicit default provider meta.' );
+	}
+
+	/**
+	 * It should show RSVP tickets in wp-admin when the post has no explicit default provider meta
+	 * saved. Paired with should_show_rsvp_tickets_on_front_end_when_default_meta_is_missing above:
+	 * the same setup returns tickets in admin but not on the front end, which is the exact
+	 * discrepancy behind the reported bug.
+	 *
+	 * @test
+	 */
+	public function should_show_rsvp_tickets_in_admin_context_when_default_meta_is_missing() {
+		$post_id = $this->factory->post->create();
+		$this->create_rsvp_ticket( $post_id );
+
+		/** @var Tribe__Tickets__RSVP $rsvp */
+		$rsvp = tribe( 'tickets.rsvp' );
+
+		set_current_screen( 'edit-post' );
+
+		$tickets = $rsvp->get_tickets( $post_id );
+
+		set_current_screen( 'front' );
+
+		$this->assertNotEmpty( $tickets, 'RSVP tickets should always be visible in wp-admin regardless of default provider meta.' );
+	}
+
+	/**
 	 * It should allow getting the ticket provider for a RSVP post.
 	 *
 	 * @test


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3353](https://linear.app/nexcess/issue/SOFT-3353/public-attendee-list-toggle-visibility-is-inverted)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The RSVP "Show me on public attendee list" opt-in toggle was being rendered with inverted/incorrect visibility on the front end. In `Order_Endpoint.php`, the value driving the toggle's visibility was hardcoded to `false` and assigned to `opt_in_toggle_hidden` without inversion, so it never reflected the post's actual "Show attendees list" setting.

Fixed by deriving the value from `Attendees_List::is_hidden_on( $post_id )` (the same source the legacy RSVP flow uses) and correctly inverting it when assigning to `opt_in_toggle_hidden`.

Also added test coverage confirming `get_tickets()` returns RSVP tickets consistently in both admin and front-end contexts when a post has no explicit default ticket provider meta saved.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/e8433835e17f42639cb0147e063bed66

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
