### PR TITLE
fix: RSVP metabox spacing, alignment, and helper text color (SOFT-3346)

### DIFF
--- a/src/admin-views/editor/panel/fields/limit.php
+++ b/src/admin-views/editor/panel/fields/limit.php
@@ -13,17 +13,19 @@
 defined( 'ABSPATH' ) || die();
 ?>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
-		<?php echo esc_html_x( 'Limit:', 'RSVP limit for an event.', 'event-tickets' ); ?>
-	</label>
-	<input
-		type='text'
-		id='rsvp_limit'
-		name='rsvp_limit'
-		class="ticket_field ticket_form_right"\
-		value="<?php echo esc_attr( $rsvp_limit ); ?>"
-		data-validation-error="<?php echo esc_attr( $rsvp_required_type_error_message ); ?>"
-	/>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
+			<?php echo esc_html_x( 'Limit:', 'RSVP limit for an event.', 'event-tickets' ); ?>
+		</label>
+		<input
+			type='text'
+			id='rsvp_limit'
+			name='rsvp_limit'
+			class="ticket_field ticket_form_right"
+			value="<?php echo esc_attr( $rsvp_limit ); ?>"
+			data-validation-error="<?php echo esc_attr( $rsvp_required_type_error_message ); ?>"
+		/>
+	</div>
 	<p class="description ticket_form_right">
 		<?php echo esc_html_x( 'Leave blank for unlimited', 'price description', 'event-tickets' ); ?>
 	</p>

--- a/src/admin-views/editor/panel/fields/rsvp/dates.php
+++ b/src/admin-views/editor/panel/fields/rsvp/dates.php
@@ -33,65 +33,69 @@ $default_end_time = '00:00:00';
 
 ?>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
-		<?php esc_html_e( 'Open RSVP:', 'event-tickets' ); ?>
-	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-start_date ticket_field"
-			name="rsvp_start_date"
-			id="rsvp_start_date"
-			value="<?php echo esc_attr( $tc_rsvp ? $ticket_start_date : $default_start_date ); ?>"
-			data-validation-type="datepicker"
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+			<?php esc_html_e( 'Open RSVP:', 'event-tickets' ); ?>
+		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-start_date ticket_field"
+				name="rsvp_start_date"
+				id="rsvp_start_date"
+				value="<?php echo esc_attr( $tc_rsvp ? $ticket_start_date : $default_start_date ); ?>"
+				data-validation-type="datepicker"
 
-			data-validation-error="<?php echo esc_attr( wp_json_encode( $start_date_errors ) ); ?>"
-		/>
-		<span class="helper-text hide-if-js"><?php esc_html_e( 'YYYY-MM-DD', 'event-tickets' ); ?></span>
-		<span class="datetime_seperator"> <?php esc_html_e( 'at', 'event-tickets' ); ?> </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-start_time ticket_field"
-			name="rsvp_start_time"
-			id="rsvp_start_time"
-			<?php echo Tribe__View_Helpers::is_24hr_format() ? 'data-format="H:i"' : ''; ?>
-			data-step="<?php echo esc_attr( $timepicker_step ); ?>"
-			data-round="<?php echo esc_attr( $timepicker_round ); ?>"
-			value="<?php echo esc_attr( $tc_rsvp ? $ticket_start_time : $default_start_time ); ?>"
-			aria-label="<?php echo esc_attr( $ticket_start_date_aria_label ); ?>"
-		/>
-		<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
+				data-validation-error="<?php echo esc_attr( wp_json_encode( $start_date_errors ) ); ?>"
+			/>
+			<span class="helper-text hide-if-js"><?php esc_html_e( 'YYYY-MM-DD', 'event-tickets' ); ?></span>
+			<span class="datetime_seperator"> <?php esc_html_e( 'at', 'event-tickets' ); ?> </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-start_time ticket_field"
+				name="rsvp_start_time"
+				id="rsvp_start_time"
+				<?php echo Tribe__View_Helpers::is_24hr_format() ? 'data-format="H:i"' : ''; ?>
+				data-step="<?php echo esc_attr( $timepicker_step ); ?>"
+				data-round="<?php echo esc_attr( $timepicker_round ); ?>"
+				value="<?php echo esc_attr( $tc_rsvp ? $ticket_start_time : $default_start_time ); ?>"
+				aria-label="<?php echo esc_attr( $ticket_start_date_aria_label ); ?>"
+			/>
+			<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
+		</div>
 	</div>
 </div>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
-		<?php esc_html_e( 'Close RSVP:', 'event-tickets' ); ?>
-	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-end_date ticket_field"
-			name="rsvp_end_date"
-			id="rsvp_end_date"
-			value="<?php echo esc_attr( $tc_rsvp ? $ticket_end_date : $default_end_date ); ?>"
-		/>
-		<span class="helper-text hide-if-js"><?php esc_html_e( 'YYYY-MM-DD', 'event-tickets' ); ?></span>
-		<span class="datetime_seperator"> <?php esc_html_e( 'at', 'event-tickets' ); ?> </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-end_time ticket_field"
-			name="rsvp_end_time"
-			id="rsvp_end_time"
-			<?php echo Tribe__View_Helpers::is_24hr_format() ? 'data-format="H:i"' : ''; ?>
-			data-step="<?php echo esc_attr( $timepicker_step ); ?>"
-			data-round="<?php echo esc_attr( $timepicker_round ); ?>"
-			value="<?php echo esc_attr( $tc_rsvp ? $ticket_end_time : $default_end_time ); ?>"
-			aria-label="<?php echo esc_attr( $ticket_end_date_aria_label ); ?>"
-		/>
-		<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+			<?php esc_html_e( 'Close RSVP:', 'event-tickets' ); ?>
+		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-end_date ticket_field"
+				name="rsvp_end_date"
+				id="rsvp_end_date"
+				value="<?php echo esc_attr( $tc_rsvp ? $ticket_end_date : $default_end_date ); ?>"
+			/>
+			<span class="helper-text hide-if-js"><?php esc_html_e( 'YYYY-MM-DD', 'event-tickets' ); ?></span>
+			<span class="datetime_seperator"> <?php esc_html_e( 'at', 'event-tickets' ); ?> </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-end_time ticket_field"
+				name="rsvp_end_time"
+				id="rsvp_end_time"
+				<?php echo Tribe__View_Helpers::is_24hr_format() ? 'data-format="H:i"' : ''; ?>
+				data-step="<?php echo esc_attr( $timepicker_step ); ?>"
+				data-round="<?php echo esc_attr( $timepicker_round ); ?>"
+				value="<?php echo esc_attr( $tc_rsvp ? $ticket_end_time : $default_end_time ); ?>"
+				aria-label="<?php echo esc_attr( $ticket_end_date_aria_label ); ?>"
+			/>
+			<span class="helper-text hide-if-js"><?php esc_html_e( 'HH:MM', 'event-tickets' ); ?></span>
+		</div>
 	</div>
 </div>

--- a/src/resources/postcss/tickets-admin.pcss
+++ b/src/resources/postcss/tickets-admin.pcss
@@ -535,6 +535,22 @@
 		}
 	}
 
+	.tec-tickets-rsvp-field-row {
+
+		@media (min-width: 782px) {
+			align-items: center;
+			display: flex;
+
+			.ticket_form_left {
+				flex: 0 0 132px;
+			}
+
+			.ticket_form_right {
+				margin-left: 0;
+			}
+		}
+	}
+
 	.input_block {
 		margin-top: 1em;
 	}
@@ -604,7 +620,7 @@ h4.ticket_form_title {
 
 .tribe_soft_note,
 p.description {
-	color: #a3a3a3;
+	color: var(--tec-admin-core-grey-50);
 	font-size: inherit;
 	font-style: normal;
 }

--- a/src/resources/postcss/tickets-commerce/admin/rsvp/_panel.pcss
+++ b/src/resources/postcss/tickets-commerce/admin/rsvp/_panel.pcss
@@ -91,10 +91,10 @@
 			background-color: var(--tec-color-accent-secondary-background);
 			border-radius: var(--tec-spacer-1);
 			margin-bottom: var(--tec-spacer-3);
-			padding: var(--tec-spacer-2);
+			padding: var(--tec-spacer-1) var(--tec-spacer-2);
 
 			#rsvp_title_edit {
-				margin-bottom: var(--tec-spacer-3);
+				margin-bottom: var(--tec-spacer-1);
 			}
 		}
 

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and capacity__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and capacity__0.snapshot.html
@@ -82,77 +82,83 @@
 				/>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
-		Limit:	</label>
-	<input
-		type='text'
-		id='rsvp_limit'
-		name='rsvp_limit'
-		class="ticket_field ticket_form_right"\
-		value="50"
-		data-validation-error="RSVP type is a required field"
-	/>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
+			Limit:		</label>
+		<input
+			type='text'
+			id='rsvp_limit'
+			name='rsvp_limit'
+			class="ticket_field ticket_form_right"
+			value="50"
+			data-validation-error="RSVP type is a required field"
+		/>
+	</div>
 	<p class="description ticket_form_right">
 		Leave blank for unlimited	</p>
 </div>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
-		Open RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-start_date ticket_field"
-			name="rsvp_start_date"
-			id="rsvp_start_date"
-			value="1/2/2020"
-			data-validation-type="datepicker"
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+			Open RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-start_date ticket_field"
+				name="rsvp_start_date"
+				id="rsvp_start_date"
+				value="1/2/2020"
+				data-validation-type="datepicker"
 
-			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-start_time ticket_field"
-			name="rsvp_start_time"
-			id="rsvp_start_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="08:00:00"
-			aria-label="Ticket start date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-start_time ticket_field"
+				name="rsvp_start_time"
+				id="rsvp_start_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="08:00:00"
+				aria-label="Ticket start date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
-		Close RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-end_date ticket_field"
-			name="rsvp_end_date"
-			id="rsvp_end_date"
-			value="3/1/2050"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-end_time ticket_field"
-			name="rsvp_end_time"
-			id="rsvp_end_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="20:00:00"
-			aria-label="Ticket end date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+			Close RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-end_date ticket_field"
+				name="rsvp_end_date"
+				id="rsvp_end_date"
+				value="3/1/2050"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-end_time ticket_field"
+				name="rsvp_end_time"
+				id="rsvp_end_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="20:00:00"
+				aria-label="Ticket end date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and show not going enabled__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP and show not going enabled__0.snapshot.html
@@ -82,77 +82,83 @@
 				/>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
-		Limit:	</label>
-	<input
-		type='text'
-		id='rsvp_limit'
-		name='rsvp_limit'
-		class="ticket_field ticket_form_right"\
-		value="100"
-		data-validation-error="RSVP type is a required field"
-	/>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
+			Limit:		</label>
+		<input
+			type='text'
+			id='rsvp_limit'
+			name='rsvp_limit'
+			class="ticket_field ticket_form_right"
+			value="100"
+			data-validation-error="RSVP type is a required field"
+		/>
+	</div>
 	<p class="description ticket_form_right">
 		Leave blank for unlimited	</p>
 </div>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
-		Open RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-start_date ticket_field"
-			name="rsvp_start_date"
-			id="rsvp_start_date"
-			value="1/2/2020"
-			data-validation-type="datepicker"
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+			Open RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-start_date ticket_field"
+				name="rsvp_start_date"
+				id="rsvp_start_date"
+				value="1/2/2020"
+				data-validation-type="datepicker"
 
-			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-start_time ticket_field"
-			name="rsvp_start_time"
-			id="rsvp_start_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="08:00:00"
-			aria-label="Ticket start date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-start_time ticket_field"
+				name="rsvp_start_time"
+				id="rsvp_start_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="08:00:00"
+				aria-label="Ticket start date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
-		Close RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-end_date ticket_field"
-			name="rsvp_end_date"
-			id="rsvp_end_date"
-			value="3/1/2050"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-end_time ticket_field"
-			name="rsvp_end_time"
-			id="rsvp_end_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="20:00:00"
-			aria-label="Ticket end date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+			Close RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-end_date ticket_field"
+				name="rsvp_end_date"
+				id="rsvp_end_date"
+				value="3/1/2050"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-end_time ticket_field"
+				name="rsvp_end_time"
+				id="rsvp_end_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="20:00:00"
+				aria-label="Ticket end date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post with TC-RSVP__0.snapshot.html
@@ -82,77 +82,83 @@
 				/>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
-		Limit:	</label>
-	<input
-		type='text'
-		id='rsvp_limit'
-		name='rsvp_limit'
-		class="ticket_field ticket_form_right"\
-		value="100"
-		data-validation-error="RSVP type is a required field"
-	/>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
+			Limit:		</label>
+		<input
+			type='text'
+			id='rsvp_limit'
+			name='rsvp_limit'
+			class="ticket_field ticket_form_right"
+			value="100"
+			data-validation-error="RSVP type is a required field"
+		/>
+	</div>
 	<p class="description ticket_form_right">
 		Leave blank for unlimited	</p>
 </div>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
-		Open RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-start_date ticket_field"
-			name="rsvp_start_date"
-			id="rsvp_start_date"
-			value="1/2/2020"
-			data-validation-type="datepicker"
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+			Open RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-start_date ticket_field"
+				name="rsvp_start_date"
+				id="rsvp_start_date"
+				value="1/2/2020"
+				data-validation-type="datepicker"
 
-			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-start_time ticket_field"
-			name="rsvp_start_time"
-			id="rsvp_start_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="08:00:00"
-			aria-label="Ticket start date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-start_time ticket_field"
+				name="rsvp_start_time"
+				id="rsvp_start_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="08:00:00"
+				aria-label="Ticket start date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
-		Close RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-end_date ticket_field"
-			name="rsvp_end_date"
-			id="rsvp_end_date"
-			value="3/1/2050"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-end_time ticket_field"
-			name="rsvp_end_time"
-			id="rsvp_end_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="20:00:00"
-			aria-label="Ticket end date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+			Close RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-end_date ticket_field"
+				name="rsvp_end_date"
+				id="rsvp_end_date"
+				value="3/1/2050"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-end_time ticket_field"
+				name="rsvp_end_time"
+				id="rsvp_end_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="20:00:00"
+				aria-label="Ticket end date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 

--- a/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post without RSVP__0.snapshot.html
+++ b/tests/rsvp_v2_integration/RSVP/V2/__snapshots__/Metabox_Test__it_should_render_metabox__post without RSVP__0.snapshot.html
@@ -82,77 +82,83 @@
 				/>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
-		Limit:	</label>
-	<input
-		type='text'
-		id='rsvp_limit'
-		name='rsvp_limit'
-		class="ticket_field ticket_form_right"\
-		value=""
-		data-validation-error="RSVP type is a required field"
-	/>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="rsvp_limit">
+			Limit:		</label>
+		<input
+			type='text'
+			id='rsvp_limit'
+			name='rsvp_limit'
+			class="ticket_field ticket_form_right"
+			value=""
+			data-validation-error="RSVP type is a required field"
+		/>
+	</div>
 	<p class="description ticket_form_right">
 		Leave blank for unlimited	</p>
 </div>
 
 				<div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
-		Open RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-start_date ticket_field"
-			name="rsvp_start_date"
-			id="rsvp_start_date"
-			value="{START_DATE}"
-			data-validation-type="datepicker"
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_start_date">
+			Open RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-start_date ticket_field"
+				name="rsvp_start_date"
+				id="rsvp_start_date"
+				value="{START_DATE}"
+				data-validation-type="datepicker"
 
-			data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-start_time ticket_field"
-			name="rsvp_start_time"
-			id="rsvp_start_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="00:00:00"
-			aria-label="Ticket start date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+				data-validation-error="{&quot;is-required&quot;:&quot;Start sale date cannot be empty.&quot;,&quot;is-less-or-equal-to&quot;:&quot;Start sale date cannot be greater than End Sale date&quot;}"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-start_time ticket_field"
+				name="rsvp_start_time"
+				id="rsvp_start_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="00:00:00"
+				aria-label="Ticket start date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 <div class="input_block">
-	<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
-		Close RSVP:	</label>
-	<div class="ticket_form_right">
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-datepicker tribe-field-end_date ticket_field"
-			name="rsvp_end_date"
-			id="rsvp_end_date"
-			value="{END_DATE}"
-		/>
-		<span class="helper-text hide-if-js">YYYY-MM-DD</span>
-		<span class="datetime_seperator"> at </span>
-		<input
-			autocomplete="off"
-			type="text"
-			class="tribe-timepicker tribe-field-end_time ticket_field"
-			name="rsvp_end_time"
-			id="rsvp_end_time"
-						data-step="30"
-			data-round="00:00:00"
-			value="00:00:00"
-			aria-label="Ticket end date"
-		/>
-		<span class="helper-text hide-if-js">HH:MM</span>
+	<div class="tec-tickets-rsvp-field-row">
+		<label class="ticket_form_label ticket_form_left" for="ticket_end_date">
+			Close RSVP:		</label>
+		<div class="ticket_form_right">
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-datepicker tribe-field-end_date ticket_field"
+				name="rsvp_end_date"
+				id="rsvp_end_date"
+				value="{END_DATE}"
+			/>
+			<span class="helper-text hide-if-js">YYYY-MM-DD</span>
+			<span class="datetime_seperator"> at </span>
+			<input
+				autocomplete="off"
+				type="text"
+				class="tribe-timepicker tribe-field-end_time ticket_field"
+				name="rsvp_end_time"
+				id="rsvp_end_time"
+								data-step="30"
+				data-round="00:00:00"
+				value="00:00:00"
+				aria-label="Ticket end date"
+			/>
+			<span class="helper-text hide-if-js">HH:MM</span>
+		</div>
 	</div>
 </div>
 


### PR DESCRIPTION
[SOFT-3346](https://linear.app/nexcess/issue/SOFT-3346/rsvp-metabox-ui-has-spacing-and-alignment-inconsistencies)

## Description

Cleans up several spacing/alignment inconsistencies in the RSVP V2 metabox:

- Vertically center the `Limit:`, `Open RSVP:`, and `Close RSVP:` labels against their fields (new `.tec-tickets-rsvp-field-row` flex wrapper, scoped to these RSVP-only rows so the shared `.input_block` layout used elsewhere is untouched).
- Darken the "Allow users to register..."/"Leave blank for unlimited" helper text from `#a3a3a3` to the shared `--tec-admin-core-grey-50` (`#646970`) token already defined in tribe-common.
- Tighten the Options section's top/bottom padding to better match the surrounding spacing.

Companion PRs land the matching fixes in `the-events-calendar` (metabox left-padding bug) and `event-tickets-plus` (Options box full-width bug).

## Artifacts
After: 
<img width="3070" height="1938" alt="SOFT-3346-AFTER" src="https://github.com/user-attachments/assets/34b56f7e-056a-4546-8b4b-b697da28154a" />


## Testing

- Open an event's edit screen with an RSVP ticket.
- Confirm `Limit:`/`Open RSVP:`/`Close RSVP:` labels are vertically centered with their inputs.
- Confirm the helper text under "Enable RSVP" and "Leave blank for unlimited" renders in the darker grey (`#646970`).
- Confirm the Options box vertical padding is tighter and consistent with the surrounding rows.

[skip-changelog]