### PR TITLE
Fix Promoter triggered emails failing with 403 unauthorized token

### DIFF
--- a/changelog/fix-smtnc-1632-promoter-trigger-domain
+++ b/changelog/fix-smtnc-1632-promoter-trigger-domain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Fixed triggered emails (RSVP going, ticket purchased) failing silently with a 403 "Unauthorized token" response from Promoter due to a missing `domain` claim in the trigger JWT payload.

--- a/src/Tribe/Promoter/Triggers/Dispatcher.php
+++ b/src/Tribe/Promoter/Triggers/Dispatcher.php
@@ -95,6 +95,7 @@ class Dispatcher {
 	 * Creat ea payload using the trigger object.
 	 *
 	 * @since 4.12.3
+	 * @since TBD Added the `domain` key, required by the Promoter connector to authorize the request.
 	 *
 	 * @param Triggered $trigger The trigger object creating this action.
 	 *
@@ -103,6 +104,7 @@ class Dispatcher {
 	private function get_payload( Triggered $trigger ) {
 		return [
 			'license'  => $this->license_key,
+			'domain'   => strtolower( untrailingslashit( preg_replace( '#^https?://#i', '', home_url( '/' ) ) ) ),
 			'type'     => $trigger->type(),
 			'event'    => [
 				'id' => $trigger->post()->ID,

--- a/tests/integration/Tribe/Tickets/Promoter/Triggers/DispatcherTest.php
+++ b/tests/integration/Tribe/Tickets/Promoter/Triggers/DispatcherTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tribe\Tickets\Promoter\Triggers;
+
+use TEC\Common\Firebase\JWT\JWT as TEC_JWT;
+use TEC\Common\Firebase\JWT\Key as TEC_JWT_Key;
+use Tribe__Promoter__Connector;
+use WP_Post;
+
+class DispatcherTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @test
+	 */
+	public function should_send_domain_in_trigger_payload(): void {
+		$secret_key  = 'bob';
+		$license_key = 'jan';
+
+		// Read by Tribe__Promoter__Connector::get_secret_key() when the Dispatcher is built.
+		update_option( 'tribe_promoter_auth_key', $secret_key );
+		// Read by Tribe__Promoter__PUE::get_license_info() when the Dispatcher is built.
+		update_option( 'pue_install_key_promoter', $license_key );
+
+		$connector  = tribe( Tribe__Promoter__Connector::class );
+		$pue        = tribe( 'promoter.pue' );
+		$dispatcher = new Dispatcher( $connector, $pue );
+
+		$event_id = self::factory()->post->create( [ 'post_type' => 'tribe_events' ] );
+
+		$trigger = new Stub_Triggered( get_post( $event_id ), 'ticket_purchased' );
+
+		$payload = [];
+
+		add_filter( 'pre_http_request', function ( $response, $parsed_args, $url ) use ( $secret_key, &$payload ) {
+			$token   = $parsed_args['body']['token'];
+			$key     = new TEC_JWT_Key( $secret_key, 'HS256' );
+			$payload = (array) TEC_JWT::decode( $token, $key );
+
+			return [ 'headers' => '', 'body' => 'Hello World', 'response' => '', 'cookies' => '', 'filename' => '' ];
+		}, 99, 3 );
+
+		$dispatcher->trigger( $trigger );
+
+		$this->assertArrayHasKey( 'domain', $payload );
+		$this->assertEquals( 'wordpress.test', $payload['domain'] );
+		$this->assertEquals( $license_key, $payload['license'] );
+		$this->assertEquals( 'ticket_purchased', $payload['type'] );
+		$this->assertEquals( $event_id, $payload['event']->id );
+	}
+}
+
+/**
+ * Minimal stand-in for a real trigger (e.g. Attendee_Trigger), used so this test does not have to
+ * build a full ticket/attendee pipeline just to exercise Dispatcher::get_payload().
+ */
+class Stub_Triggered implements Contracts\Triggered {
+
+	/**
+	 * @var WP_Post
+	 */
+	private $post;
+
+	/**
+	 * @var string
+	 */
+	private $type;
+
+	public function __construct( WP_Post $post, $type ) {
+		$this->post = $post;
+		$this->type = $type;
+	}
+
+	public function post() {
+		return $this->post;
+	}
+
+	public function type() {
+		return $this->type;
+	}
+
+	public function build() {
+	}
+
+	public function ticket() {
+		$ticket       = new \stdClass();
+		$ticket->ID   = 123;
+		$ticket->name = 'I am going!';
+
+		return $ticket;
+	}
+
+	public function attendee() {
+		return new Stub_Attendee();
+	}
+}
+
+class Stub_Attendee implements Contracts\Attendee_Model {
+
+	public function build() {
+	}
+
+	public function required_fields() {
+		return [];
+	}
+
+	public function id() {
+		return 456;
+	}
+
+	public function email() {
+		return 'attendee@example.com';
+	}
+
+	public function event_id() {
+		return 0;
+	}
+
+	public function product_id() {
+		return 0;
+	}
+
+	public function ticket_name() {
+		return 'I am going!';
+	}
+}


### PR DESCRIPTION
Ticket: [SMTNC-1632](https://linear.app/nexcess/issue/SMTNC-1632/promoter-triggered-emails-fail-with-403-unauthorized-token)

I need to still reproduce the bug locally and then confirm that this fix works to resolve it, but in theory this should work 🤔 

## Summary
- Triggered emails (RSVP going, ticket purchased) were failing silently with a `403 Forbidden` / `"Unauthorized token."` response from Promoter's connector, even though attendee sync succeeded.
- Root cause: the trigger JWT payload built in `Dispatcher::get_payload()` was missing the `domain` claim that Promoter's connector requires. The other three JWT payloads this plugin builds (`connect`, `connect/auth`, `connect/notify`) all include `domain`; the trigger payload for `connect/trigger` never had it added.
- Because `Connector::make_call()` swallows non-2xx responses into a debug log and returns `false` without throwing, the failure was invisible outside of `tribe_log` debug output — matching the "no Mailgun logs, sync succeeds" symptom reported by customers.

## Fix
Add the same domain derivation used elsewhere (`strtolower( untrailingslashit( preg_replace( '#^https?://#i', '', home_url( '/' ) ) ) )`) to the trigger payload in `src/Tribe/Promoter/Triggers/Dispatcher.php`.

I tested with this snippet:
```php
add_filter( 'pre_http_request', function ( $preempt, $parsed_args, $url ) {
	if ( strpos( $url, 'connect/trigger' ) === false ) {
			return $preempt;
	}

	$token   = $parsed_args['body']['token'] ?? '';
	$parts   = explode( '.', $token );
	$payload = isset( $parts[1] ) ? json_decode( base64_decode( strtr( $parts[1], '-_', '+/' ) ), true ) : null;

	error_log( 'PROMOTER TRIGGER PAYLOAD: ' . print_r( $payload, true ) );

	return $preempt; // returning false (the default) lets the real request go out too
}, 10, 3 );
```

When an attendee registered for an RSVP, this was the response with production code:
```php
PROMOTER TRIGGER PAYLOAD: Array
(
    [license] => test-license
    [type] => rsvp_going
    [event] => Array
        (
            [id] => 3747
        )

    [ticket] => Array
        (
            [id] => 3748
            [name] => RSVP V1
        )

    [attendee] => Array
        (
            [id] => 3751
            [email] => clown@email.com
        )

)
```

And this was the response with the fix in place (note that there is now the `[domain]` key):
```php
(
    [license] => test-license
    [domain] => stabledev.lndo.site
    [type] => rsvp_going
    [event] => Array
        (
            [id] => 3747
        )

    [ticket] => Array
        (
            [id] => 3748
            [name] => RSVP V1
        )

    [attendee] => Array
        (
            [id] => 3750
            [email] => sam.dokus@theeventscalendar.com
        )

)
```
