### PR TITLE
RSVP and ticket summary counts combining on events with both

### DIFF
--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -102,37 +102,6 @@ class Attendees {
 	}
 
 	/**
-	 * Filters the arguments used to count the Attendees in the Tickets View data link.
-	 *
-	 * @since TBD
-	 *
-	 * @param array<string,mixed> $args    The arguments used to count the attendees.
-	 * @param int                 $post_id The post ID the Attendees are being counted for.
-	 * @param int|null            $user_id The user ID, if any. Unused.
-	 * @param string|null         $context The context of the query.
-	 *
-	 * @return array<string,mixed> The filtered arguments.
-	 */
-	public function exclude_rsvp_tickets_from_tickets_view_data_link_count( array $args, int $post_id, ?int $user_id, ?string $context ): array {
-		if ( 'get_my_tickets_link_data' !== $context ) {
-			return $args;
-		}
-
-		// In RSVP v2 the Tickets Commerce provider is active by default; an empty provider means TC.
-		$provider = tribe_tickets_get_ticket_provider( $post_id );
-
-		// There is a provider and it's not TC, then bail.
-		if ( ! empty( $provider ) && ! $provider instanceof Module ) {
-			return $args;
-		}
-
-		// Exclude RSVP attendees from the count.
-		$args['by']['meta_not_equals'] = [ '_type', Constants::TC_RSVP_TYPE ];
-
-		return $args;
-	}
-
-	/**
 	 * Replaces the order-status label with a "Going" / "Not Going" indicator for TC RSVP attendees.
 	 *
 	 * Hooked to `tribe_tickets_attendees_table_order_status`. All RSVP attendees have a

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -184,13 +184,6 @@ class Controller extends Controller_Contract {
 			2
 		);
 
-		add_filter(
-			'tec_tickets_view_count_ticket_attendees_args',
-			$this->container->callback( Attendees::class, 'exclude_rsvp_tickets_from_tickets_view_data_link_count' ),
-			10,
-			4
-		);
-
 		// Attendees report: show Going/Not Going status and hide check-in for "not going" RSVPs.
 		add_filter(
 			'tribe_tickets_attendees_table_order_status',
@@ -307,10 +300,6 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_rsvp_get_attendees_by_id_pre',
 			$this->container->callback( Attendees::class, 'get_rsvp_attendees_by_id' )
-		);
-		remove_filter(
-			'tec_tickets_view_count_ticket_attendees_args',
-			$this->container->callback( Attendees::class, 'exclude_rsvp_tickets_from_tickets_view_data_link_count' )
 		);
 		remove_filter(
 			'tribe_tickets_attendees_table_order_status',

--- a/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
+++ b/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
@@ -69,6 +69,16 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 			],
 		];
 
+		/*
+		 * `build_query_internally()` merges `default_args` and `query_args` with a plain, non-recursive
+		 * `array_merge()`. Any `by()` filter that sets its own top-level `meta_query` entry (e.g. the base
+		 * repository's `by( 'event', $post_id )`, which goes through a `meta_in` filter) would otherwise
+		 * completely replace the RSVP scoping set above, causing this repository to match every
+		 * Tickets Commerce attendee rather than only RSVP ones. Re-merge it back in after the query args
+		 * are finalized so the scoping always survives.
+		 */
+		add_filter( "tribe_repository_{$this->filter_name}_query_args", [ $this, 'enforce_rsvp_meta_scope' ] );
+
 		// Some schema entries need to be redirected to the correct meta keys.
 		$this->add_simple_meta_schema_entry( 'user', '_tribe_tickets_attendee_user_id', 'meta_in' );
 		$this->add_simple_meta_schema_entry( 'user', Attendee::$user_relation_meta_key, 'meta_in' );
@@ -137,6 +147,28 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 		$statuses                     = [ 'yes', 'no' ];
 		self::$order_statuses         = $statuses;
 		self::$private_order_statuses = array_diff( $statuses, self::$public_order_statuses );
+	}
+
+	/**
+	 * Re-applies the RSVP status meta scoping to the final query arguments.
+	 *
+	 * Hooked to `tribe_repository_{$this->filter_name}_query_args`, which fires after `default_args` and
+	 * `query_args` have already been merged, so the scoping set in the constructor is guaranteed to survive
+	 * regardless of what other `meta_query`-based filters (like `by( 'event', $post_id )`) ran.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $query_args The fully merged query arguments about to be used to build the query.
+	 *
+	 * @return array<string,mixed> The query arguments with the RSVP status meta scoping enforced.
+	 */
+	public function enforce_rsvp_meta_scope( array $query_args ): array {
+		$query_args['meta_query'] = \Tribe__Utils__Array::merge_recursive_query_vars(
+			$query_args['meta_query'] ?? [],
+			$this->default_args['meta_query']
+		);
+
+		return $query_args;
 	}
 
 	/**

--- a/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
+++ b/src/Tickets/RSVP/V2/Repositories/Attendee_Repository.php
@@ -76,8 +76,15 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 		 * completely replace the RSVP scoping set above, causing this repository to match every
 		 * Tickets Commerce attendee rather than only RSVP ones. Re-merge it back in after the query args
 		 * are finalized so the scoping always survives.
+		 *
+		 * This repository is bound as a factory (`bind()`, not `singleton()`), so a new instance is
+		 * created on every `tribe( 'tickets.attendee-repository.rsvp' )` call; `enforce_rsvp_meta_scope()`
+		 * is static and stateless, so `has_filter()` (rather than an instance- or even request-lifetime
+		 * flag) keeps a single registration in place without accumulating duplicate callbacks.
 		 */
-		add_filter( "tribe_repository_{$this->filter_name}_query_args", [ $this, 'enforce_rsvp_meta_scope' ] );
+		if ( ! has_filter( "tribe_repository_{$this->filter_name}_query_args", [ self::class, 'enforce_rsvp_meta_scope' ] ) ) {
+			add_filter( "tribe_repository_{$this->filter_name}_query_args", [ self::class, 'enforce_rsvp_meta_scope' ] );
+		}
 
 		// Some schema entries need to be redirected to the correct meta keys.
 		$this->add_simple_meta_schema_entry( 'user', '_tribe_tickets_attendee_user_id', 'meta_in' );
@@ -153,8 +160,10 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 	 * Re-applies the RSVP status meta scoping to the final query arguments.
 	 *
 	 * Hooked to `tribe_repository_{$this->filter_name}_query_args`, which fires after `default_args` and
-	 * `query_args` have already been merged, so the scoping set in the constructor is guaranteed to survive
-	 * regardless of what other `meta_query`-based filters (like `by( 'event', $post_id )`) ran.
+	 * `query_args` have already been merged, so the scoping is guaranteed to survive regardless of what
+	 * other `meta_query`-based filters (like `by( 'event', $post_id )`) ran. Static and stateless so a
+	 * single `has_filter()`-guarded registration (see the constructor) covers every instance without
+	 * reading the scoping off any particular instance's `default_args`.
 	 *
 	 * @since TBD
 	 *
@@ -162,10 +171,16 @@ class Attendee_Repository extends Base_Repository implements Attendee_Repository
 	 *
 	 * @return array<string,mixed> The query arguments with the RSVP status meta scoping enforced.
 	 */
-	public function enforce_rsvp_meta_scope( array $query_args ): array {
+	public static function enforce_rsvp_meta_scope( array $query_args ): array {
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		$query_args['meta_query'] = \Tribe__Utils__Array::merge_recursive_query_vars(
 			$query_args['meta_query'] ?? [],
-			$this->default_args['meta_query']
+			[
+				'tc-rsvp-type' => [
+					'key'     => Constants::RSVP_STATUS_META_KEY,
+					'compare' => 'EXISTS',
+				],
+			]
 		);
 
 		return $query_args;

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -4,15 +4,19 @@ namespace TEC\Tickets\RSVP\V2;
 
 use Closure;
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Attendee;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker as TC_Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\Ticket_Maker as TC_Ticket_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe__Tickets__Tickets_View as Tickets_View;
 
 class Attendees_Test extends WPTestCase {
 	use Ticket_Maker;
 	use TC_Ticket_Maker;
 	use Attendee_Maker;
+	use TC_Attendee_Maker;
 	use Order_Maker;
 
 	public function get_rsvp_attendees_data_provider(): array {
@@ -137,103 +141,40 @@ class Attendees_Test extends WPTestCase {
 	}
 
 	/**
-	 * Each fixture returns [ $args, $post_id, $user_id, $context ]; the flag is whether the
-	 * RSVP-exclusion filter should be added for that combination.
+	 * @test
 	 */
-	public function exclude_rsvp_tickets_data_provider(): array {
-		return [
-			'unchanged for non-matching context' => [
-				function () {
-					$post_id = static::factory()->post->create();
-					$this->create_tc_rsvp_ticket( $post_id );
+	public function it_should_not_conflate_rsvp_and_ticket_counts_in_my_tickets_link_data(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$user_id = static::factory()->user->create();
 
-					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'other_context' ];
-				},
-				false,
-			],
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+		$this->create_attendee_for_ticket( $ticket_id, $post_id, [ 'user_id' => $user_id ] );
+		$this->create_attendee_for_ticket( $ticket_id, $post_id, [ 'user_id' => $user_id ] );
 
-			'unchanged for null context' => [
-				function () {
-					$post_id = static::factory()->post->create();
-					$this->create_tc_rsvp_ticket( $post_id );
+		$rsvp_ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$this->create_tc_rsvp_attendee( $rsvp_ticket_id, $post_id, [
+			'meta_input' => [ Attendee::$user_relation_meta_key => $user_id ],
+		] );
 
-					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, null ];
-				},
-				false,
-			],
+		$view = new Tickets_View();
 
-			'adds filter for tc provider' => [
-				function () {
-					$post_id = static::factory()->post->create();
-					$this->create_tc_rsvp_ticket( $post_id );
+		$this->assertSame(
+			1,
+			$view->count_rsvp_attendees( $post_id, $user_id ),
+			'RSVP count should only include the RSVP attendee, not the real ticket attendees'
+		);
+		$this->assertSame(
+			2,
+			$view->count_ticket_attendees( $post_id, $user_id, 'get_my_tickets_link_data' ),
+			'Ticket count should include real ticket attendees even in the my-tickets-link-data context'
+		);
 
-					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'get_my_tickets_link_data' ];
-				},
-				true,
-			],
+		$data = $view->get_my_tickets_link_data( $post_id, $user_id );
 
-			'preserves existing args' => [
-				function () {
-					$post_id = static::factory()->post->create();
-					$this->create_tc_rsvp_ticket( $post_id );
-
-					return [
-						[ 'by' => [ 'event' => $post_id, 'status' => 'completed' ] ],
-						$post_id,
-						null,
-						'get_my_tickets_link_data',
-					];
-				},
-				true,
-			],
-
-			'adds filter with user id' => [
-				function () {
-					$post_id = static::factory()->post->create();
-					$user_id = static::factory()->user->create();
-					$this->create_tc_rsvp_ticket( $post_id );
-
-					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, $user_id, 'get_my_tickets_link_data' ];
-				},
-				true,
-			],
-
-			'adds filter for post without provider' => [
-				function () {
-					// No ticket created, so no provider. An empty provider means TC.
-					$post_id = static::factory()->post->create();
-
-					return [ [ 'by' => [ 'event' => $post_id ] ], $post_id, null, 'get_my_tickets_link_data' ];
-				},
-				true,
-			],
-		];
-	}
-
-	/**
-	 * @dataProvider exclude_rsvp_tickets_data_provider
-	 */
-	public function test_exclude_rsvp_tickets_from_tickets_view_data_link_count( Closure $fixture, bool $adds_filter ): void {
-		[ $args, $post_id, $user_id, $context ] = $fixture();
-
-		$attendees = tribe( Attendees::class );
-
-		$result = $attendees->exclude_rsvp_tickets_from_tickets_view_data_link_count( $args, $post_id, $user_id, $context );
-
-		if ( ! $adds_filter ) {
-			$this->assertEquals( $args, $result );
-			$this->assertArrayNotHasKey( 'meta_not_equals', $result['by'] );
-
-			return;
-		}
-
-		$this->assertArrayHasKey( 'meta_not_equals', $result['by'] );
-		$this->assertEquals( [ '_type', Constants::TC_RSVP_TYPE ], $result['by']['meta_not_equals'] );
-
-		// The original `by` args are preserved alongside the added filter.
-		foreach ( $args['by'] as $key => $value ) {
-			$this->assertEquals( $value, $result['by'][ $key ] );
-		}
+		$this->assertSame( 3, $data['total_count'] );
+		$this->assertStringContainsString( '1 RSVP', $data['message'] );
+		$this->assertStringContainsString( '2 Tickets', $data['message'] );
+		$this->assertSame( 'View all', $data['link_label'] );
 	}
 
 	public function test_get_rsvp_attendees_by_id_bails_when_attendees_already_filtered(): void {

--- a/tests/rsvp_v2_integration/RSVP/V2/RSVP_Ticket_REST_Snapshot_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/RSVP_Ticket_REST_Snapshot_Test.php
@@ -53,14 +53,10 @@ class RSVP_Ticket_REST_Snapshot_Test extends REST_Test_Case {
 		// 3. RSVP ticket with show_not_going=true, 2 going + 1 not-going.
 		$rsvp_mixed = $this->create_tc_rsvp_ticket( $post_id );
 		update_post_meta( $rsvp_mixed, Constants::SHOW_NOT_GOING_META_KEY, '1' );
-		$this->create_order( [ $rsvp_mixed => 3 ] );
-		$mixed_attendee_ids = tribe( 'tickets.attendee-repository.rsvp' )
-			->by( 'event_id', $post_id )
-			->by( 'ticket_id', $rsvp_mixed )
-			->order_by( 'ID', 'DESC' )
-			->get_ids();
+		$mixed_order_id      = $this->create_order( [ $rsvp_mixed => 3 ] )->ID;
+		$mixed_attendee_ids  = array_column( tribe( TC_Provider::class )->get_attendees_by_order_id( $mixed_order_id ), 'ID' );
 		// Mark the most recent attendee as not going.
-		update_post_meta( $mixed_attendee_ids[0], Constants::RSVP_STATUS_META_KEY, 'no' );
+		update_post_meta( max( $mixed_attendee_ids ), Constants::RSVP_STATUS_META_KEY, 'no' );
 
 		// 4. RSVP ticket with show_not_going=false.
 		$rsvp_disabled = $this->create_tc_rsvp_ticket( $post_id );

--- a/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Repositories/Attendee_Repository_Test.php
@@ -49,6 +49,40 @@ class Attendee_Repository_Test extends WPTestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_not_include_non_rsvp_attendees_when_filtered_by_event(): void {
+		$post_id   = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		$rsvp_attendee_id = $this->create_tc_rsvp_attendee( $ticket_id, $post_id );
+
+		// A real ticket attendee for the same event, sharing the Tickets Commerce attendee post type
+		// but carrying no RSVP status meta at all.
+		$real_ticket_attendee_id = wp_insert_post( [
+			'post_type'   => Attendee::POSTTYPE,
+			'post_status' => 'publish',
+			'post_title'  => 'Real ticket attendee',
+			'meta_input'  => [
+				Attendee::$event_relation_meta_key  => $post_id,
+				Attendee::$ticket_relation_meta_key => $ticket_id,
+			],
+		] );
+
+		$repo      = new Attendee_Repository();
+		$attendees = $repo->by( 'event', $post_id )->all();
+
+		$attendee_ids = array_map( static fn( $attendee ) => $attendee->ID, $attendees );
+
+		$this->assertContains( $rsvp_attendee_id, $attendee_ids, 'RSVP attendee should be returned' );
+		$this->assertNotContains(
+			$real_ticket_attendee_id,
+			$attendee_ids,
+			'A non-RSVP attendee for the same event should not be returned by the RSVP repository'
+		);
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_filter_by_ticket(): void {
 		$post_id = $this->factory()->post->create( [ 'post_status' => 'publish' ] );
 


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3851](https://linear.app/nexcess/issue/SOFT-3851/events-with-rsvp-and-tickets-are-combining-the-summary-counts)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fixes the "My Tickets" summary link showing a combined count under "RSVPs" only (e.g. "You have 6 RSVPs") instead of listing both types separately (e.g. "You have 2 RSVPs and 4 Tickets") when an event has both RSVP and paid ticket attendees. 

Two bugs were compounding: the RSVP repository's attendee-type scoping was getting silently overwritten by other query filters, and a redundant ticket-count filter was checking a meta key that doesn't exist on attendee posts, always zeroing out the ticket count.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="1234" height="667" alt="image" src="https://github.com/user-attachments/assets/c7c7303e-4202-4a9a-805f-e2a750d16a32" />


After:
<img width="2392" height="1892" alt="CleanShot 2026-07-15 at 09 27 24@2x" src="https://github.com/user-attachments/assets/0316732d-7951-40a6-987b-650a1f5620b7" />


### ✔️ Checklist
- [-] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) - since this is created and fixed within the RSVP Merge bucket we can [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
