### PR TITLE
Send RSVP "Can't Go" email instead of full order emails

### DIFF
--- a/src/Tickets/Commerce/Flag_Actions/Flag_Action_Handler.php
+++ b/src/Tickets/Commerce/Flag_Actions/Flag_Action_Handler.php
@@ -41,6 +41,7 @@ class Flag_Action_Handler extends \TEC\Common\Contracts\Service_Provider {
 		Send_Email::class,
 		Send_Email_Purchase_Receipt::class,
 		Send_Email_Completed_Order::class,
+		Send_Email_RSVP_Not_Going::class,
 		End_Duplicated_Pending_Orders::class,
 	];
 

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email.php
@@ -5,6 +5,7 @@ namespace TEC\Tickets\Commerce\Flag_Actions;
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\BackgroundJobs\SendTicketEmail;
+use TEC\Tickets\RSVP\V2\Traits\Not_Going_Order;
 use function TEC\Common\StellarWP\Shepherd\shepherd;
 
 /**
@@ -15,6 +16,8 @@ use function TEC\Common\StellarWP\Shepherd\shepherd;
  * @package TEC\Tickets\Commerce\Flag_Actions
  */
 class Send_Email extends Flag_Action_Abstract {
+	use Not_Going_Order;
+
 	/**
 	 * {@inheritDoc}
 	 *
@@ -37,6 +40,10 @@ class Send_Email extends Flag_Action_Abstract {
 	 * {@inheritDoc}
 	 */
 	public function handle( Status_Interface $new_status, $old_status, \WP_Post $order ) {
+		// RSVP V2 "Not Going" orders are hidden orders for tracking only; no ticket to deliver.
+		if ( $this->is_rsvp_v2_not_going_order( $order ) ) {
+			return;
+		}
 
 		// temporary fix for manual attendees first email
 		// @todo backend review this logic

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_Purchase_Receipt.php
@@ -4,6 +4,7 @@ namespace TEC\Tickets\Commerce\Flag_Actions;
 
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
+use TEC\Tickets\RSVP\V2\Traits\Not_Going_Order;
 
 /**
  * Class Send_Email_Purchase_Receipt, normally triggered when an order is completed.
@@ -13,6 +14,8 @@ use TEC\Tickets\Commerce\Status\Status_Interface;
  * @package TEC\Tickets\Commerce\Flag_Actions
  */
 class Send_Email_Purchase_Receipt extends Flag_Action_Abstract {
+	use Not_Going_Order;
+
 	/**
 	 * {@inheritDoc}
 	 *
@@ -37,6 +40,11 @@ class Send_Email_Purchase_Receipt extends Flag_Action_Abstract {
 	public function handle( Status_Interface $new_status, $old_status, \WP_Post $order ) {
 		// Bail if tickets emails is not enabled.
 		if ( ! tec_tickets_emails_is_enabled() ) {
+			return;
+		}
+
+		// RSVP V2 "Not Going" orders are hidden orders for tracking only; no purchase to confirm.
+		if ( $this->is_rsvp_v2_not_going_order( $order ) ) {
 			return;
 		}
 

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_RSVP_Not_Going.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_RSVP_Not_Going.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Sends the RSVP "Not Going" confirmation email for RSVP V2 orders.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\Commerce\Flag_Actions
+ */
 
 namespace TEC\Tickets\Commerce\Flag_Actions;
 

--- a/src/Tickets/Commerce/Flag_Actions/Send_Email_RSVP_Not_Going.php
+++ b/src/Tickets/Commerce/Flag_Actions/Send_Email_RSVP_Not_Going.php
@@ -4,16 +4,18 @@ namespace TEC\Tickets\Commerce\Flag_Actions;
 
 use TEC\Tickets\Commerce\Order;
 use TEC\Tickets\Commerce\Status\Status_Interface;
+use TEC\Tickets\Emails\Email\RSVP_Not_Going;
 use TEC\Tickets\RSVP\V2\Traits\Not_Going_Order;
 
 /**
- * Class Send_Email_Completed_Order, normally triggered when an order is completed.
+ * Class Send_Email_RSVP_Not_Going, sends the RSVP "Not Going" confirmation email for
+ * RSVP V2 orders where the attendee indicated they will not be attending.
  *
- * @since 5.5.10
+ * @since TBD
  *
  * @package TEC\Tickets\Commerce\Flag_Actions
  */
-class Send_Email_Completed_Order extends Flag_Action_Abstract {
+class Send_Email_RSVP_Not_Going extends Flag_Action_Abstract {
 	use Not_Going_Order;
 
 	/**
@@ -43,35 +45,34 @@ class Send_Email_Completed_Order extends Flag_Action_Abstract {
 			return;
 		}
 
-		// RSVP V2 "Not Going" orders are hidden orders for tracking only; no purchase to confirm.
-		if ( $this->is_rsvp_v2_not_going_order( $order ) ) {
+		if ( ! $this->is_rsvp_v2_not_going_order( $order ) ) {
 			return;
-		}
-
-		if ( ! empty( $order->gateway ) && 'manual' === $order->gateway && empty( $order->events_in_order ) ) {
-			$order->events_in_order[] = $order;
 		}
 
 		if ( empty( $order->events_in_order ) || ! is_array( $order->events_in_order ) ) {
 			return;
 		}
 
-		/**
-		 * Filter the order before sending the email about the completed order.
-		 *
-		 * @since 5.18.0
-		 *
-		 * @param \WP_Post $order The order.
-		 */
-		$order = apply_filters( 'tec_tickets_commerce_prepare_order_for_email_send_email_completed_order', $order );
-
 		$provider  = tribe( $order->provider );
 		$attendees = $provider->get_attendees_by_order_id( $order->ID );
 
-		$email_class = tribe( \TEC\Tickets\Emails\Email\Completed_Order::class );
-		$email_class->set( 'order', $order );
-		$email_class->set( 'attendees', $attendees );
+		if ( empty( $attendees ) ) {
+			return;
+		}
 
-		return $email_class->send();
+		$to = $attendees[0]['holder_email'] ?? '';
+
+		if ( ! is_email( $to ) ) {
+			return;
+		}
+
+		$event_id = reset( $order->events_in_order );
+
+		$email_class = tribe( RSVP_Not_Going::class );
+		$email_class->set( 'post_id', $event_id );
+		$email_class->set( 'tickets', $attendees );
+		$email_class->recipient = $to;
+
+		$email_class->send();
 	}
 }

--- a/src/Tickets/RSVP/V2/Traits/Not_Going_Order.php
+++ b/src/Tickets/RSVP/V2/Traits/Not_Going_Order.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Trait Not_Going_Order.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\RSVP\V2\Traits
+ */
+
+namespace TEC\Tickets\RSVP\V2\Traits;
+
+use TEC\Tickets\RSVP\V2\Constants;
+use WP_Post;
+
+/**
+ * Trait Not_Going_Order.
+ *
+ * @since TBD
+ *
+ * @package TEC\Tickets\RSVP\V2\Traits
+ */
+trait Not_Going_Order {
+	/**
+	 * Whether the given order is a hidden RSVP V2 order created for an attendee who
+	 * indicated they will not be attending.
+	 *
+	 * These orders exist for tracking purposes only, so the generic Tickets Commerce
+	 * order emails (purchase receipt, completed order, ticket delivery) should not be
+	 * sent for them.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $order The order post object, decorated with an `items` property.
+	 *
+	 * @return bool
+	 */
+	public function is_rsvp_v2_not_going_order( WP_Post $order ): bool {
+		if ( empty( $order->items ) || ! is_array( $order->items ) ) {
+			return false;
+		}
+
+		foreach ( $order->items as $item ) {
+			if ( Constants::TC_RSVP_TYPE !== ( $item['type'] ?? '' ) ) {
+				continue;
+			}
+
+			if ( ! tribe_is_truthy( $item['extra']['order_status'] ?? 'yes' ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/tests/rsvp_v2_integration/RSVP/V2/Emails_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Emails_Test.php
@@ -13,9 +13,6 @@ use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 use Tribe\Tests\Traits\With_Uopz;
 use WP_Post;
 
-/**
- * @see https://linear.app/nexcess/issue/SOFT-3854 "Can't Go" RSVP emails are wrong.
- */
 class Emails_Test extends WPTestCase {
 	use Ticket_Maker;
 	use With_Uopz;

--- a/tests/rsvp_v2_integration/RSVP/V2/Emails_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Emails_Test.php
@@ -1,0 +1,228 @@
+<?php
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Common\StellarWP\Shepherd\Regulator;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Gateways\Free\Gateway;
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\RSVP\V2\Cart\RSVP_Cart;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe\Tests\Traits\With_Uopz;
+use WP_Post;
+
+/**
+ * @see https://linear.app/nexcess/issue/SOFT-3854 "Can't Go" RSVP emails are wrong.
+ */
+class Emails_Test extends WPTestCase {
+	use Ticket_Maker;
+	use With_Uopz;
+
+	/**
+	 * @before
+	 */
+	public function ensure_clean_cart(): void {
+		tribe( Cart::class )->clear_cart();
+	}
+
+	/**
+	 * @after
+	 */
+	public function cleanup_cart(): void {
+		tribe( Cart::class )->clear_cart();
+	}
+
+	public function use_rsvp_cart() {
+		return tribe( RSVP_Cart::class );
+	}
+
+	/**
+	 * Order emails are dispatched to a Shepherd background job for real requests. For the
+	 * purposes of this test we want them to run in the same request so we can inspect what
+	 * would have been sent via `wp_mail()`.
+	 */
+	private function run_dispatched_email_jobs_synchronously(): void {
+		$this->set_class_fn_return(
+			Regulator::class,
+			'dispatch',
+			function ( $task, $delay = 0 ) {
+				$task->process();
+			},
+			true
+		);
+	}
+
+	/**
+	 * Intercepted `wp_mail()` calls are collected in a $GLOBALS entry rather than a class
+	 * property because uopz drops all class scope (including `self::`) from the closure
+	 * that replaces the global `wp_mail()` function.
+	 */
+	private function intercept_emails(): void {
+		$GLOBALS['tec_rsvp_v2_emails_test_sent_emails'] = [];
+
+		$this->set_fn_return(
+			'wp_mail',
+			static function ( $to, $subject, $message, $headers = '', $attachments = [] ) {
+				$GLOBALS['tec_rsvp_v2_emails_test_sent_emails'][] = [
+					'to'      => $to,
+					'subject' => $subject,
+					'message' => $message,
+				];
+
+				return true;
+			},
+			true
+		);
+	}
+
+	private function sent_emails(): array {
+		return $GLOBALS['tec_rsvp_v2_emails_test_sent_emails'] ?? [];
+	}
+
+	/**
+	 * Creates and completes an RSVP V2 order, mirroring what
+	 * Order_Endpoint::process_rsvp_step() does for the "success" step.
+	 *
+	 * @param string $order_status 'yes' for Going, 'no' for Can't Go.
+	 * @param string $email        The attendee/purchaser email.
+	 *
+	 * @return WP_Post The completed, fully-decorated order.
+	 */
+	private function create_and_complete_rsvp_order( string $order_status, string $email ): WP_Post {
+		add_filter( 'tec_tickets_commerce_cart_repository', [ $this, 'use_rsvp_cart' ] );
+
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, [ 'tribe-ticket' => [ 'capacity' => 100 ] ] );
+
+		$cart = tribe( RSVP_Cart::class );
+		$cart->clear();
+		$cart->upsert_item(
+			$ticket_id,
+			1,
+			[
+				'type'         => Constants::TC_RSVP_TYPE,
+				'order_status' => $order_status,
+				'optout'       => false,
+			]
+		);
+		$cart->save();
+
+		$purchaser = tribe( Order::class )->get_purchaser_data(
+			[
+				'purchaser' => [
+					'name'  => 'Test RSVP User',
+					'email' => $email,
+				],
+			]
+		);
+
+		$order = tribe( Order::class )->create_from_cart( tribe( Gateway::class ), $purchaser, Constants::TC_RSVP_TYPE );
+
+		tribe( Order::class )->modify_status( $order->ID, Pending::SLUG );
+		tribe( Order::class )->modify_status( $order->ID, Completed::SLUG );
+
+		tribe( Cart::class )->clear_cart();
+		remove_filter( 'tec_tickets_commerce_cart_repository', [ $this, 'use_rsvp_cart' ] );
+
+		clean_post_cache( $order->ID );
+
+		return tec_tc_get_order( $order->ID );
+	}
+
+	private function subjects_containing( string $needle ): array {
+		return array_values(
+			array_filter(
+				$this->sent_emails(),
+				fn( $email ) => false !== strpos( $email['subject'], $needle )
+			)
+		);
+	}
+
+	private function emails_containing( string $needle ): array {
+		return array_values(
+			array_filter(
+				$this->sent_emails(),
+				fn( $email ) => false !== strpos( $email['subject'], $needle ) || false !== strpos( $email['message'], $needle )
+			)
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_send_purchase_and_completed_order_emails_for_going_rsvp(): void {
+		$this->run_dispatched_email_jobs_synchronously();
+		$this->intercept_emails();
+
+		$this->create_and_complete_rsvp_order( 'yes', 'going@example.com' );
+
+		$this->assertNotEmpty( $this->subjects_containing( 'purchase receipt' ) );
+		$this->assertNotEmpty( $this->subjects_containing( 'Completed order' ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_send_purchase_or_completed_order_emails_for_not_going_rsvp(): void {
+		$this->run_dispatched_email_jobs_synchronously();
+		$this->intercept_emails();
+
+		$this->create_and_complete_rsvp_order( 'no', 'notgoing@example.com' );
+
+		$this->assertEmpty(
+			$this->subjects_containing( 'purchase receipt' ),
+			'A "Can\'t Go" RSVP must not trigger the Tickets Commerce purchase receipt email.'
+		);
+		$this->assertEmpty(
+			$this->subjects_containing( 'Completed order' ),
+			'A "Can\'t Go" RSVP must not trigger the Tickets Commerce admin completed-order email.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_send_not_going_confirmation_email_for_not_going_rsvp(): void {
+		$this->run_dispatched_email_jobs_synchronously();
+		$this->intercept_emails();
+
+		$this->create_and_complete_rsvp_order( 'no', 'notgoing@example.com' );
+
+		$matches = $this->subjects_containing( 'You confirmed you will not be attending' );
+
+		$this->assertCount( 1, $matches, 'The RSVP "Not Going" confirmation email should be sent exactly once.' );
+		$this->assertSame( 'notgoing@example.com', $matches[0]['to'] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_send_not_going_confirmation_email_for_going_rsvp(): void {
+		$this->run_dispatched_email_jobs_synchronously();
+		$this->intercept_emails();
+
+		$this->create_and_complete_rsvp_order( 'yes', 'going@example.com' );
+
+		$this->assertEmpty(
+			$this->subjects_containing( 'You confirmed you will not be attending' ),
+			'A "Going" RSVP must not trigger the "Not Going" confirmation email.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_send_ticket_delivery_email_for_not_going_rsvp(): void {
+		$this->run_dispatched_email_jobs_synchronously();
+		$this->intercept_emails();
+
+		$this->create_and_complete_rsvp_order( 'no', 'notgoing4@example.com' );
+
+		$this->assertEmpty(
+			$this->emails_containing( "Here's your" ),
+			'A "Can\'t Go" RSVP must not trigger the generic ticket delivery email.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3854](https://linear.app/nexcess/issue/SOFT-3854/cant-go-rsvp-emails-are-wrong)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

RSVP V2 submissions create a real Tickets Commerce order and push it straight to Completed status regardless of "Going"/"Can't Go", which unconditionally fired TC's three generic order emails (purchase receipt, admin completed-order notice, ticket delivery). The correct "You confirmed you will not be attending" email existed in the codebase but was only wired to the old V1 RSVP path, never reachable from V2. This PR just adds a condition so the correct email is sent. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before: 
<img width="712" height="763" alt="CleanShot 2026-07-15 at 10 34 55" src="https://github.com/user-attachments/assets/a018bf03-1933-4780-b25b-d51fe8a9236b" />
<img width="737" height="794" alt="CleanShot 2026-07-15 at 10 34 27" src="https://github.com/user-attachments/assets/99717ca6-e609-42ce-8490-8a132cfa0563" />
<img width="775" height="857" alt="CleanShot 2026-07-15 at 10 34 07" src="https://github.com/user-attachments/assets/cca357c4-db82-4b65-9402-f096a9b1e783" />

After:
<img width="1906" height="934" alt="CleanShot 2026-07-15 at 13 57 02" src="https://github.com/user-attachments/assets/04fdc24e-4143-45f2-b464-6b68d2486af1" />


### ✔️ Checklist
- [-] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) Since this was introduced and fixed within the rsvp-merge bucket we can [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
