### PR TITLE
fix(SOFT-3841): default price to 0 in get_item_value when key absent

### DIFF
--- a/src/Tickets/Commerce/Order.php
+++ b/src/Tickets/Commerce/Order.php
@@ -1134,7 +1134,7 @@ class Order extends Abstract_Order {
 	 * @return ?string
 	 */
 	public function get_item_value( $item, $original = false ): ?string {
-		$current = $item['price'];
+		$current = $item['price'] ?? 0;
 		$regular = $item['regular_price'] ?? $current;
 
 		return $original ? Value::create( $regular )->get_currency() : Value::create( $current )->get_currency();


### PR DESCRIPTION
## Summary

- `Order::get_item_value()` (line 1137) accessed `$item['price']` with no null-coalescing fallback, producing an `Undefined array key "price"` PHP warning when a gateway omits the key from item args
- Added `?? 0` fallback so any gateway that collects payment externally (e.g. Shopify) can safely omit `price` without triggering a warning
- `regular_price` already had `?? $current` on the next line — this brings `price` in line with that pattern

## Test plan

- [ ] Existing integration tests pass — `slic run integration`
- [ ] Confirm no PHP warning appears when a TEC Commerce order item is created without a `price` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oBai1V2HyXCAx4t4sD838