### PR TITLE
[SOFT-3894] Change order status to voided for deleted Attendees

### DIFF
--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -12,6 +12,7 @@ namespace TEC\Tickets\RSVP\V2;
 use TEC\Tickets\Commerce\Attendee;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Voided;
 use TEC\Tickets\Commerce\Ticket as Commerce_Ticket;
 
 /**
@@ -215,5 +216,45 @@ class Attendees {
 
 		// Only an explicit "no" counts as not going; anything else is treated as going.
 		return 'no' === get_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, true ) ? 'no' : 'yes';
+	}
+
+	/**
+	 * Voids the hidden TC-RSVP Order once its last Attendee is deleted.
+	 *
+	 * TC-RSVP Orders are backend-only Orders created to back RSVP attendee records; nothing else marks
+	 * them as no-longer-relevant once every Attendee is gone, so they are otherwise left behind as
+	 * permanently "Completed" orphans.
+	 *
+	 * Hooked to `tec_tickets_commerce_attendee_before_delete`, which fires before the Attendee post (and
+	 * its meta) is removed, so the Ticket/Order relation is still readable here.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $attendee_id The Attendee post ID about to be deleted.
+	 *
+	 * @return void
+	 */
+	public function void_order_after_last_attendee_deleted( int $attendee_id ): void {
+		$ticket_id = (int) get_post_meta( $attendee_id, Attendee::$ticket_relation_meta_key, true );
+
+		if ( ! $ticket_id || ! tribe( Ticket::class )->is_rsvp( $ticket_id ) ) {
+			return;
+		}
+
+		$order_id = wp_get_post_parent_id( $attendee_id );
+
+		if ( ! $order_id ) {
+			return;
+		}
+
+		// `order_id` is only a valid alias for *updates* on this repository; `post_parent` is the real query filter.
+		$remaining_attendees = tec_tc_attendees()->by( 'post_parent', $order_id )->count();
+
+		if ( $remaining_attendees > 1 ) {
+			// Other Attendees still exist on this Order; leave its status alone.
+			return;
+		}
+
+		tribe( Order::class )->modify_status( $order_id, Voided::SLUG );
 	}
 }

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -208,6 +208,12 @@ class Controller extends Controller_Contract {
 			'tec_tickets_commerce_single_order_details_metabox_after',
 			$this->container->callback( Metabox::class, 'add_rsvp_status_to_single_order_details_metabox' )
 		);
+
+		// Void the hidden TC-RSVP Order once its last Attendee is deleted.
+		add_action(
+			'tec_tickets_commerce_attendee_before_delete',
+			$this->container->callback( Attendees::class, 'void_order_after_last_attendee_deleted' )
+		);
 	}
 
 	/**
@@ -316,6 +322,10 @@ class Controller extends Controller_Contract {
 		remove_action(
 			'tec_tickets_commerce_single_order_details_metabox_after',
 			$this->container->callback( Metabox::class, 'add_rsvp_status_to_single_order_details_metabox' ),
+		);
+		remove_action(
+			'tec_tickets_commerce_attendee_before_delete',
+			$this->container->callback( Attendees::class, 'void_order_after_last_attendee_deleted' )
 		);
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -190,6 +190,49 @@ class Attendees_Test extends WPTestCase {
 		$this->assertSame( $pre_filtered_value, $result );
 	}
 
+	public function test_deleting_the_last_rsvp_attendee_voids_the_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$order     = $this->create_order( [ $ticket_id => 1 ] );
+
+		$attendee_ids = tec_tc_attendees()->by( 'post_parent', $order->ID )->order_by( 'ID', 'ASC' )->get_ids();
+
+		$this->assertCount( 1, $attendee_ids );
+
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( 'tec-tc-voided', get_post_status( $order->ID ) );
+	}
+
+	public function test_deleting_one_of_several_rsvp_attendees_does_not_void_the_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+		$order     = $this->create_order( [ $ticket_id => 3 ] );
+
+		$attendee_ids = tec_tc_attendees()->by( 'post_parent', $order->ID )->order_by( 'ID', 'ASC' )->get_ids();
+
+		$this->assertCount( 3, $attendee_ids );
+
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( 'tec-tc-completed', get_post_status( $order->ID ) );
+		$this->assertCount( 2, tec_tc_attendees()->by( 'post_parent', $order->ID )->get_ids() );
+	}
+
+	public function test_deleting_a_regular_ticket_attendee_does_not_void_its_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+		$order     = $this->create_order( [ $ticket_id => 1 ] );
+
+		$attendee_ids = tec_tc_attendees()->by( 'post_parent', $order->ID )->get_ids();
+
+		$this->assertCount( 1, $attendee_ids );
+
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( 'tec-tc-completed', get_post_status( $order->ID ) );
+	}
+
 	/**
 	 * Creates a TC RSVP attendee and returns an attendees-table row item pointing at it.
 	 *


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3894](https://linear.app/nexcess/issue/SOFT-3894/rsvp-v2-hidden-tc-order-not-transitioned-to-removedvoided-when-admin)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Per the Miro board, when an admin deletes attendee(s), the "RSVP order status should be changed to _Removed_". Now when all attendees within one order are deleted, the order status is changed to `tec-tc-voided` instead of just being orphaned with the `tec-tc-completed` status. Note that I use the language 'Voided' instead of 'Removed' because voided is an existing order status (used within Stripe, etc) instead of creating a new 'Removed' status just for this specific use case.

### 🎥 Artifacts <!-- if applicable-->

https://github.com/user-attachments/assets/170f5741-f564-4e6d-ba82-d1c57367c365



### ✔️ Checklist
- [-] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
