### PR TITLE
SOFT-3910: Fix Attendees table shows stale check-in state until object cache flush

### DIFF
--- a/changelog/fix-SOFT-3910-attendees-listing-page-cache
+++ b/changelog/fix-SOFT-3910-attendees-listing-page-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+The Attendees page table could show stale check-in data in some cases.

--- a/src/Tribe/Attendees_Table.php
+++ b/src/Tribe/Attendees_Table.php
@@ -1126,7 +1126,7 @@ class Tribe__Tickets__Attendees_Table extends WP_List_Table {
 		}
 
 		$this->items = $items;
-		$cache->set( $cache_key, $items, 60 );
+		$cache->set( $cache_key, $items, Tribe__Cache::NON_PERSISTENT );
 
 		$this->set_pagination_args( $pagination_args );
 	}

--- a/src/functions/commerce/attendees.php
+++ b/src/functions/commerce/attendees.php
@@ -60,6 +60,8 @@ function tec_tc_get_attendee( $attendee = null, $output = OBJECT, $filter = 'raw
 		$cache_post->post_modified,
 		// Use the `post_password` field as we show/hide some information depending on that.
 		$cache_post->post_password,
+		// Include check-in meta in the cache key so check-in/uncheck-in is reflected in the cache.
+		get_post_meta( $cache_post->ID, Attendee::$checked_in_meta_key, true ),
 		// We must include options on cache key, because options influence the hydrated data on the Order object.
 		wp_json_encode( Tribe__Settings_Manager::get_options() ),
 		wp_json_encode( [

--- a/src/functions/commerce/attendees.php
+++ b/src/functions/commerce/attendees.php
@@ -62,6 +62,8 @@ function tec_tc_get_attendee( $attendee = null, $output = OBJECT, $filter = 'raw
 		$cache_post->post_password,
 		// Include check-in meta in the cache key so check-in/uncheck-in is reflected in the cache.
 		get_post_meta( $cache_post->ID, Attendee::$checked_in_meta_key, true ),
+		// Include ticket-sent meta in the cache key so email send/resend is reflected in the cache.
+		get_post_meta( $cache_post->ID, Attendee::$ticket_sent_meta_key, true ),
 		// We must include options on cache key, because options influence the hydrated data on the Order object.
 		wp_json_encode( Tribe__Settings_Manager::get_options() ),
 		wp_json_encode( [

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Cache_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Cache_Test.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for Tickets Commerce attendee object-cache behavior.
+ *
+ * @since TBD
+ */
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Module as Commerce;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+
+/**
+ * Class Attendee_Cache_Test.
+ *
+ * @since TBD
+ */
+class Attendee_Cache_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Attendee_Maker;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Enable post as ticketable type.
+		add_filter(
+			'tribe_tickets_post_types',
+			static function () {
+				return [ 'post' ];
+			}
+		);
+
+		// Enable Tickets Commerce as a provider.
+		add_filter(
+			'tribe_tickets_get_modules',
+			static function ( $modules ) {
+				$modules[ Commerce::class ] = Commerce::class;
+
+				return $modules;
+			}
+		);
+	}
+
+	/**
+	 * It should return updated check-in status from cache after check-in without flushing.
+	 *
+	 * @test
+	 */
+	public function should_reflect_checkin_in_cached_attendee_without_flushing(): void {
+		$post_id     = static::factory()->post->create();
+		$ticket_id   = $this->create_tc_ticket( $post_id, 10 );
+		$attendee_id = $this->create_attendee_for_ticket( $ticket_id, $post_id );
+
+		// Prime the week-long `tec_tc_get_attendee` cache while unchecked.
+		$cached_before = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+		$this->assertNotEmpty( $cached_before );
+		$this->assertEmpty( $cached_before['check_in'] );
+
+		$this->assertTrue( tribe( Commerce::class )->checkin( $attendee_id ) );
+
+		$cached_after = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+
+		$this->assertNotEmpty( $cached_after );
+		$this->assertEquals(
+			1,
+			(int) $cached_after['check_in'],
+			'Check-in must invalidate the cached attendee without an object-cache flush.'
+		);
+	}
+
+	/**
+	 * It should return updated check-in status from cache after uncheck-in without flushing.
+	 *
+	 * @test
+	 */
+	public function should_reflect_uncheckin_in_cached_attendee_without_flushing(): void {
+		$post_id     = static::factory()->post->create();
+		$ticket_id   = $this->create_tc_ticket( $post_id, 10 );
+		$attendee_id = $this->create_attendee_for_ticket( $ticket_id, $post_id );
+		$commerce    = tribe( Commerce::class );
+
+		$this->assertTrue( $commerce->checkin( $attendee_id ) );
+
+		// Prime the week-long cache while checked in.
+		$cached_before = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+		$this->assertNotEmpty( $cached_before );
+		$this->assertEquals( 1, (int) $cached_before['check_in'] );
+
+		$this->assertTrue( $commerce->uncheckin( $attendee_id ) );
+
+		$cached_after = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+
+		$this->assertNotEmpty( $cached_after );
+		$this->assertEmpty(
+			$cached_after['check_in'],
+			'Uncheck-in must invalidate the cached attendee without an object-cache flush.'
+		);
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Cache_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Attendee_Cache_Test.php
@@ -8,6 +8,8 @@
 namespace TEC\Tickets\Commerce;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Communication\Email as Email_Communication;
 use TEC\Tickets\Commerce\Module as Commerce;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
@@ -99,6 +101,37 @@ class Attendee_Cache_Test extends WPTestCase {
 		$this->assertEmpty(
 			$cached_after['check_in'],
 			'Uncheck-in must invalidate the cached attendee without an object-cache flush.'
+		);
+	}
+
+	/**
+	 * It should return updated ticket-sent status from cache after the counter increments without flushing.
+	 *
+	 * @test
+	 */
+	public function should_reflect_ticket_sent_in_cached_attendee_without_flushing(): void {
+		$post_id     = static::factory()->post->create();
+		$ticket_id   = $this->create_tc_ticket( $post_id, 10 );
+		$attendee_id = $this->create_attendee_for_ticket( $ticket_id, $post_id, [ 'ticket_sent' => false ] );
+
+		// Prime the week-long `tec_tc_get_attendee` cache while the ticket email has not been sent.
+		$cached_before = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+		$this->assertNotEmpty( $cached_before );
+		$this->assertEmpty( $cached_before['ticket_sent'] );
+
+		tribe( Email_Communication::class )->update_ticket_sent_counter( $attendee_id );
+
+		$cached_after = tec_tc_get_attendee( $attendee_id, ARRAY_A );
+
+		$this->assertNotEmpty( $cached_after );
+		$this->assertEquals(
+			1,
+			(int) $cached_after['ticket_sent'],
+			'Ticket-sent counter must invalidate the cached attendee without an object-cache flush.'
+		);
+		$this->assertEquals(
+			1,
+			(int) get_post_meta( $attendee_id, Attendee::$ticket_sent_meta_key, true )
 		);
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3910]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

On Tickets → Attendees (tec-tickets-attendees), check-in / undo check-in updates correctly in the AJAX UI, but a full page reload still shows the previous status until Redis/object cache is flushed.

#### Cause
Two caches kept hydrated attendee rows with outdated check_in:

- `tec_tc_get_attendee()` — week-long cache keyed without check-in meta (check-in only updates post meta, not post_modified / save_post)
- `Attendees_Table::prepare_items()` — 60s persistent Redis cache of table rows, which can short-circuit before (1)

#### Fix
- Included the check-in meta in the `tec_tc_get_attendee cache` key
- Used `Tribe__Cache::NON_PERSISTENT` in `prepare_items()` (same-request dedupe only)

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/895dc7c799b34689a76bfa04e972c740

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
