### PR TITLE
[SMTNC-1811] Event Tickets 5.29.0.1 checkout shows “Oops, no tickets!”

### DIFF
--- a/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
+++ b/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where the Tickets Commerce checkout could show no tickets after selecting tickets on sites behind a full-page or edge cache, by preventing the cart-to-checkout redirect from being cached.

--- a/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
+++ b/changelog/smtnc-1811-event-tickets-52901-checkout-shows-oops-no-tickets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Resolved an issue where the Tickets Commerce checkout could show no tickets after selecting tickets on sites behind a full-page or edge cache, by preventing the cart-to-checkout redirect from being cached.
+Prevented the cart-to-checkout redirect from being cached to avoid an issue where the Tickets Commerce checkout could show 'Oops, no tickets!' after selecting tickets on sites behind a full-page or edge cache.

--- a/src/Tickets/Commerce/Cart.php
+++ b/src/Tickets/Commerce/Cart.php
@@ -557,6 +557,7 @@ class Cart {
 	 *
 	 * @since 5.1.9
 	 * @since 5.29.0.1 Stopped adding the cart hash to the checkout redirect URL. See SVUL-L34.
+	 * @since TBD Sent no-cache headers on the cart-to-checkout redirect so the cart-hash cookie survives edge caches.
 	 *
 	 * @return bool
 	 */
@@ -614,6 +615,12 @@ class Cart {
 			$redirect_url = apply_filters( 'tec_tickets_commerce_cart_to_checkout_redirect_url', $redirect_url, $data );
 
 			if ( null !== $redirect_url ) {
+				/*
+				 * The cart hash is carried to checkout only by the Set-Cookie header emitted while
+				 * processing the cart. A cacheable 302 lets full-page and edge caches (e.g. Pantheon,
+				 * Varnish) cache the redirect and strip that header, leaving checkout with no cart.
+				 */
+				nocache_headers();
 				wp_safe_redirect( $redirect_url );
 				tribe_exit();
 			}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Cart_Redirect_Cache_Headers_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Cart_Redirect_Cache_Headers_Test.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Regression test for the cart-to-checkout redirect dropping the cart-hash cookie behind edge caches.
+ *
+ * Since SVUL-L34 the cart hash is carried across the redirect only by the server-set cart cookie. A
+ * cacheable 302 lets full-page and edge caches (e.g. Pantheon, Varnish) cache the redirect and strip
+ * its Set-Cookie header, so the checkout page then loads with no cart. The redirect must therefore be
+ * sent with no-cache headers.
+ */
+
+namespace TEC\Tickets\Commerce;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+
+class Cart_Redirect_Cache_Headers_Test extends WPTestCase {
+
+	use With_Uopz;
+
+	/**
+	 * The cart-to-checkout redirect must send no-cache headers before redirecting so edge caches keep
+	 * the cart-hash Set-Cookie header intact.
+	 *
+	 * @since TBD
+	 */
+	public function test_cart_to_checkout_redirect_sends_nocache_headers_before_redirecting(): void {
+		$state = $this->run_redirect_capturing_cache_state();
+
+		$this->assertTrue(
+			$state['redirected'],
+			'The cart page in redirect mode must redirect to checkout.'
+		);
+		$this->assertSame(
+			tribe( Checkout::class )->get_url(),
+			$state['url'],
+			'The redirect must target the Tickets Commerce checkout page.'
+		);
+		$this->assertTrue(
+			$state['nocache_before_redirect'],
+			'No-cache headers must be sent before the cart-to-checkout redirect so edge caches do not strip the cart cookie.'
+		);
+	}
+
+	/**
+	 * Drives the real Cart::parse_request() redirect branch, capturing whether the no-cache headers
+	 * were emitted and whether that happened before the redirect fired.
+	 *
+	 * @since TBD
+	 *
+	 * @return array{nocache_before_redirect: bool, redirected: bool, url: string|null}
+	 */
+	private function run_redirect_capturing_cache_state(): array {
+		$state = [
+			'nocache_before_redirect' => false,
+			'redirected'              => false,
+			'url'                     => null,
+		];
+
+		$nocache_sent = false;
+
+		// parse_request() only redirects on the cart page in redirect mode; force both gates open.
+		$this->set_class_fn_return( Cart::class, 'is_current_page', true );
+		$this->set_class_fn_return( Cart::class, 'get_mode', Cart::REDIRECT_MODE );
+
+		add_filter(
+			'nocache_headers',
+			static function ( $headers ) use ( &$nocache_sent ) {
+				$nocache_sent = true;
+
+				return $headers;
+			}
+		);
+
+		$this->set_fn_return( 'tribe_exit', true );
+		$this->set_fn_return(
+			'wp_safe_redirect',
+			function ( $url ) use ( &$state, &$nocache_sent ) {
+				$state['nocache_before_redirect'] = $nocache_sent;
+				$state['redirected']              = true;
+				$state['url']                     = $url;
+
+				return true;
+			},
+			true
+		);
+
+		tribe( Cart::class )->parse_request();
+
+		return $state;
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1811](https://linear.app/nexcess/issue/SMTNC-1811/event-tickets-52901-checkout-shows-oops-no-tickets)

### 🗒️ Description
Resolved an issue where Tickets Commerce checkout showed "Oops, no tickets!" after a shopper selected tickets on sites behind a full-page or edge cache (e.g. Pantheon, Varnish).

### 🎥 Artifacts
[https://www.loom.com/share/c64b422b857244b4be7e13b14a6269dd](https://www.loom.com/share/c64b422b857244b4be7e13b14a6269dd)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
