### PR TITLE
[SMTNC-1404] fix: shared capacity performance memory exhaustion

### DIFF
--- a/changelog/fix-smtnc-1404-shared-capacity-performancememory-exhaustion-for-logged-in.yaml
+++ b/changelog/fix-smtnc-1404-shared-capacity-performancememory-exhaustion-for-logged-in.yaml
@@ -1,0 +1,7 @@
+significance: patch
+type: fix
+entry: Reduced the number of queries and the memory used when rendering events
+  with shared capacity tickets by sharing the event attendees between all the
+  tickets of the same event and by caching sold out inventory results in
+  `Tribe__Tickets__Ticket_Object::inventory()`.
+timestamp: 2026-07-28T21:38:04.869Z

--- a/changelog/fix-smtnc-1404-shared-capacity-performancememory-exhaustion-for-logged-in.yaml
+++ b/changelog/fix-smtnc-1404-shared-capacity-performancememory-exhaustion-for-logged-in.yaml
@@ -1,7 +1,4 @@
 significance: patch
 type: fix
-entry: Reduced the number of queries and the memory used when rendering events
-  with shared capacity tickets by sharing the event attendees between all the
-  tickets of the same event and by caching sold out inventory results in
-  `Tribe__Tickets__Ticket_Object::inventory()`.
+entry: Reduced the number of queries and the memory used when rendering events with shared capacity tickets by sharing the event attendees between all the tickets of the same event and by caching sold out inventory results in `Tribe__Tickets__Ticket_Object::inventory()`.
 timestamp: 2026-07-28T21:38:04.869Z

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -695,7 +695,7 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				$event_id = $this->get_event()->ID;
 
 				// Share the event attendees across all the shared capacity tickets of the same event.
-				$event_attendees_key = __METHOD__ . '-event-attendees-' . $event_id;
+				$event_attendees_key = __METHOD__ . '-event-attendees-' . $provider->orm_provider . '-' . $event_id;
 				$event_attendees     = $is_ticket_cache_enabled
 					? $cache->get( $event_attendees_key, Cache::TRIGGER_SAVE_POST, null )
 					: null;

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -606,6 +606,8 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 		 *
 		 * @since 4.6
 		 * @since 4.12.3 Account for possibly inactive ticket provider.
+		 * @since TBD Cache the event attendees used by the shared capacity calculation and fix the cache hit check for
+		 *             sold out tickets.
 		 *
 		 * @return int
 		 */
@@ -618,7 +620,8 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 			if ( $is_ticket_cache_enabled ) {
 				$cached = $cache->get( $cache_key, Cache::TRIGGER_SAVE_POST, null );
 
-				if ( $cached && is_int( $cached ) ) {
+				// A sold out ticket has an inventory of `0`, which is a valid cache hit.
+				if ( is_int( $cached ) ) {
 					return $cached;
 				}
 			}
@@ -689,22 +692,53 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				Tribe__Tickets__Global_Stock::GLOBAL_STOCK_MODE === $this->global_stock_mode()
 				|| Tribe__Tickets__Global_Stock::CAPPED_STOCK_MODE === $this->global_stock_mode()
 			) {
-				$event_id              = $this->get_event()->ID;
-				$event_attendees       = $provider->get_attendees_by_id( $event_id );
+				$event_id = $this->get_event()->ID;
+
+				// Share the event attendees across all the shared capacity tickets of the same event.
+				$event_attendees_key = __METHOD__ . '-event-attendees-' . $event_id;
+				$event_attendees     = $is_ticket_cache_enabled
+					? $cache->get( $event_attendees_key, Cache::TRIGGER_SAVE_POST, null )
+					: null;
+
+				if ( ! is_array( $event_attendees ) ) {
+					$event_attendees = $provider->get_attendees_by_id( $event_id );
+
+					if ( $is_ticket_cache_enabled ) {
+						$cache->set( $event_attendees_key, $event_attendees, Tribe__Cache::NON_PERSISTENT, Cache::TRIGGER_SAVE_POST );
+					}
+				}
+
+				$product_ids = [];
+				foreach ( $event_attendees as $attendee ) {
+					if ( ! empty( $attendee['product_id'] ) && (int) $attendee['event_id'] === (int) $event_id ) {
+						$product_ids[] = (int) $attendee['product_id'];
+					}
+				}
+
+				$ticket_stock_modes = [];
+				foreach ( array_unique( $product_ids ) as $pid ) {
+					$ticket_stock_modes[ $pid ] = get_post_meta( $pid, Tribe__Tickets__Global_Stock::TICKET_STOCK_MODE, true );
+				}
+
+				$global_stock_enabled = tribe_is_truthy(
+					get_post_meta( $event_id, Tribe__Tickets__Global_Stock::GLOBAL_STOCK_ENABLED, true )
+				);
+
 				$event_attendees_count = 0;
 
 				foreach ( $event_attendees as $attendee ) {
-					$attendee_ticket_stock = new Tribe__Tickets__Global_Stock( $attendee['event_id'] );
+					$attendee_event_id = (int) $attendee['event_id'];
+
 					// Bypass any potential weirdness (RSVPs or such).
-					if ( empty( $attendee['product_id'] ) || (int) $attendee['event_id'] !== (int) $event_id ) {
+					if ( empty( $attendee['product_id'] ) || $attendee_event_id !== (int) $event_id ) {
 						continue;
 					}
 
-					$attendee_ticket_stock_mode = get_post_meta( $attendee['product_id'], Tribe__Tickets__Global_Stock::TICKET_STOCK_MODE, true );
+					$attendee_ticket_stock_mode = $ticket_stock_modes[ (int) $attendee['product_id'] ] ?? '';
 
-					// On all cases of indy stock we don't add
+					// On all cases of indy stock we don't add.
 					if (
-						! $attendee_ticket_stock->is_enabled()
+						! $global_stock_enabled
 						|| empty( $attendee_ticket_stock_mode )
 						|| ! $provider->attendee_decreases_inventory( $attendee )
 						|| Tribe__Tickets__Global_Stock::OWN_STOCK_MODE === $attendee_ticket_stock_mode
@@ -712,8 +746,8 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 						continue;
 					}
 
-					// All the others we add to the count
-					$event_attendees_count++;
+					// All the others we add to the count.
+					++$event_attendees_count;
 				}
 
 				$inventory[] = tribe_tickets_get_capacity( $event_id ) - $event_attendees_count;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1,6 +1,7 @@
 <?php
 
 use TEC\Events\Custom_Tables\V1\Models\Occurrence;
+use Tribe__Cache_Listener as Cache;
 use Tribe__Utils__Array as Arr;
 
 if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
@@ -1704,13 +1705,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return array The attendee data for attendees.
 		 */
 		public function get_attendees_from_module( $attendees, $post_id = 0 ) {
+			/** @var Tribe__Cache $cache */
+			$cache = tribe( 'cache' );
+
 			if ( $post_id && ! empty( $attendees ) ) {
-				/** @var Tribe__Cache $cache */
-				$cache     = tribe( 'cache' );
 				$cache_key = __METHOD__ . '-' . $this->orm_provider . '-' . $post_id;
 
-				if ( isset( $cache[ $cache_key ] ) ) {
-					return $cache[ $cache_key ];
+				$cached_attendees = $cache->get( $cache_key, Cache::TRIGGER_SAVE_POST, null );
+
+				if ( is_array( $cached_attendees ) ) {
+					return $cached_attendees;
 				}
 			}
 
@@ -1741,8 +1745,8 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$attendees_from_module[] = $attendee_data;
 			}
 
-			if ( $post_id && ! empty( $attendees_from_module ) ) {
-				$cache[ $cache_key ] = $attendees_from_module;
+			if ( $post_id && ! empty( $attendees_from_module ) && ! empty( $cache_key ) ) {
+				$cache->set( $cache_key, $attendees_from_module, Tribe__Cache::NON_PERSISTENT, Cache::TRIGGER_SAVE_POST );
 			}
 
 			return $attendees_from_module;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1696,6 +1696,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * Get attendee data for attendees from the current module.
 		 *
 		 * @since 4.10.6
+		 * @since TBD Added cache to handle the attendees data from the current module.
 		 *
 		 * @param array $attendees Attendee objects or IDs.
 		 * @param int   $post_id   Parent post ID.

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1703,7 +1703,30 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @return array The attendee data for attendees.
 		 */
 		public function get_attendees_from_module( $attendees, $post_id = 0 ) {
+			if ( $post_id && ! empty( $attendees ) ) {
+				/** @var Tribe__Cache $cache */
+				$cache     = tribe( 'cache' );
+				$cache_key = __METHOD__ . '-' . $post_id;
+
+				if ( isset( $cache[ $cache_key ] ) ) {
+					return $cache[ $cache_key ];
+				}
+			}
+
 			$attendees_from_module = [];
+
+			$attendee_ids = [];
+			foreach ( $attendees as $attendee ) {
+				$attendee_id = $attendee instanceof WP_Post ? $attendee->ID : (int) $attendee;
+				if ( $attendee_id ) {
+					$attendee_ids[] = $attendee_id;
+				}
+			}
+			$attendee_ids = array_unique( $attendee_ids );
+
+			if ( $attendee_ids ) {
+				tribe( 'cache' )->warmup_post_caches( $attendee_ids, true );
+			}
 
 			foreach ( $attendees as $attendee ) {
 				$attendee_data = $this->get_attendee( $attendee, $post_id );
@@ -1712,10 +1735,13 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 					continue;
 				}
 
-				// Set the `ticket_exists` flag on attendees if the ticket they are associated with does not exist.
 				$attendee_data['ticket_exists'] = ! empty( $attendee_data['product_id'] ) && get_post( $attendee_data['product_id'] );
 
 				$attendees_from_module[] = $attendee_data;
+			}
+
+			if ( $post_id && ! empty( $attendees_from_module ) ) {
+				$cache[ $cache_key ] = $attendees_from_module;
 			}
 
 			return $attendees_from_module;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1707,7 +1707,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			if ( $post_id && ! empty( $attendees ) ) {
 				/** @var Tribe__Cache $cache */
 				$cache     = tribe( 'cache' );
-				$cache_key = __METHOD__ . '-' . $post_id;
+				$cache_key = __METHOD__ . '-' . $this->orm_provider . '-' . $post_id;
 
 				if ( isset( $cache[ $cache_key ] ) ) {
 					return $cache[ $cache_key ];

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
@@ -37,7 +37,7 @@ class Shared_Capacity_Inventory_Performance_Test extends \Codeception\TestCase\W
 		tribe_update_option( 'ticket-enabled-post-types', array_values( array_unique( $ticketable ) ) );
 	}
 
-	public function test_debug_dump_of_attendee_queries(): void {
+	public function test_should_not_make_n_plus_one_attendee_queries_when_calculating_shared_capacity_inventory(): void {
 		[ $event_id, $ticket_ids ] = $this->given_an_event_with_shared_capacity_tickets( 4 );
 
 		$tickets = array_map(
@@ -55,13 +55,14 @@ class Shared_Capacity_Inventory_Performance_Test extends \Codeception\TestCase\W
 			}
 		);
 
-		codecept_debug( 'ATTENDEE QUERY COUNT: ' . count( $queries ) );
-
-		foreach ( $queries as $i => $query ) {
-			codecept_debug( "--- [$i] " . preg_replace( '/\s+/', ' ', $query ) );
-		}
-
-		codecept_debug( 'INVENTORIES: ' . implode( ',', array_map( static fn( $t ) => $t->inventory(), $tickets ) ) );
+		// The cache shares event attendees across all tickets of the same event, so the number of
+		// attendee queries must be strictly less than the number of tickets. With N tickets making
+		// N attendee queries, the N+1 optimization is broken.
+		$this->assertLessThan(
+			count( $ticket_ids ),
+			count( $queries ),
+			'The attendee query count should be less than the number of shared capacity tickets, proving the attendee cache is working.'
+		);
 	}
 
 	/**

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
@@ -11,7 +11,7 @@ use Tribe__Tickets__Global_Stock as Global_Stock;
 use Tribe__Tickets__Ticket_Object as Ticket_Object;
 
 /**
- * Guards the shared capacity inventory calculation against the N+1 attendee fetch fixed in SMTNC-1404.
+ * Guards the shared capacity inventory calculation against the N+1 attendee fetch.
  *
  * @since TBD
  */

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
@@ -47,7 +47,8 @@ class Shared_Capacity_Inventory_Performance_Test extends \Codeception\TestCase\W
 
 		$this->given_cold_caches();
 
-		$queries = $this->when_measuring_attendee_queries(
+		// First pass: load attendees from the database (cold cache).
+		$this->when_measuring_attendee_queries(
 			static function () use ( $tickets ) {
 				foreach ( $tickets as $ticket ) {
 					$ticket->inventory();
@@ -55,13 +56,19 @@ class Shared_Capacity_Inventory_Performance_Test extends \Codeception\TestCase\W
 			}
 		);
 
-		// The cache shares event attendees across all tickets of the same event, so the number of
-		// attendee queries must be strictly less than the number of tickets. With N tickets making
-		// N attendee queries, the N+1 optimization is broken.
-		$this->assertLessThan(
-			count( $ticket_ids ),
-			count( $queries ),
-			'The attendee query count should be less than the number of shared capacity tickets, proving the attendee cache is working.'
+		// Second pass: all attendee and inventory caches should be warm.
+		$warm_queries = $this->when_measuring_attendee_queries(
+			static function () use ( $tickets ) {
+				foreach ( $tickets as $ticket ) {
+					$ticket->inventory();
+				}
+			}
+		);
+
+		$this->assertCount(
+			0,
+			$warm_queries,
+			'After the first pass populates the caches, subsequent inventory() calls should make zero attendee queries.'
 		);
 	}
 

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Stock/SharedCapacity/Shared_Capacity_Inventory_Performance_Test.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace TEC\Tickets\Commerce\Stock\SharedCapacity;
+
+use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Module;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Events__Main as TEC;
+use Tribe__Tickets__Global_Stock as Global_Stock;
+use Tribe__Tickets__Ticket_Object as Ticket_Object;
+
+/**
+ * Guards the shared capacity inventory calculation against the N+1 attendee fetch fixed in SMTNC-1404.
+ *
+ * @since TBD
+ */
+class Shared_Capacity_Inventory_Performance_Test extends \Codeception\TestCase\WPTestCase {
+
+	use Ticket_Maker;
+	use Order_Maker;
+
+	/**
+	 * The attendee queries captured during a measurement.
+	 *
+	 * @var array<string>
+	 */
+	private array $captured_queries = [];
+
+	/**
+	 * @before
+	 */
+	public function ensure_post_ticketable(): void {
+		$ticketable   = tribe_get_option( 'ticket-enabled-post-types', [] );
+		$ticketable[] = 'post';
+		$ticketable[] = TEC::POSTTYPE;
+		tribe_update_option( 'ticket-enabled-post-types', array_values( array_unique( $ticketable ) ) );
+	}
+
+	public function test_debug_dump_of_attendee_queries(): void {
+		[ $event_id, $ticket_ids ] = $this->given_an_event_with_shared_capacity_tickets( 4 );
+
+		$tickets = array_map(
+			static fn( $ticket_id ) => tribe( Module::class )->get_ticket( $event_id, $ticket_id ),
+			$ticket_ids
+		);
+
+		$this->given_cold_caches();
+
+		$queries = $this->when_measuring_attendee_queries(
+			static function () use ( $tickets ) {
+				foreach ( $tickets as $ticket ) {
+					$ticket->inventory();
+				}
+			}
+		);
+
+		codecept_debug( 'ATTENDEE QUERY COUNT: ' . count( $queries ) );
+
+		foreach ( $queries as $i => $query ) {
+			codecept_debug( "--- [$i] " . preg_replace( '/\s+/', ' ', $query ) );
+		}
+
+		codecept_debug( 'INVENTORIES: ' . implode( ',', array_map( static fn( $t ) => $t->inventory(), $tickets ) ) );
+	}
+
+	/**
+	 * Creates an Event with global stock enabled and $count shared capacity tickets, one attendee each.
+	 *
+	 * @return array{0: int, 1: array<int>} The Event ID and the ticket IDs.
+	 */
+	private function given_an_event_with_shared_capacity_tickets( int $count ): array {
+		$event_id = tribe_events()->set_args(
+			[
+				'title'      => 'Shared capacity inventory performance',
+				'status'     => 'publish',
+				'start_date' => '2020-01-01 12:00:00',
+				'duration'   => 2 * HOUR_IN_SECONDS,
+			]
+		)->create()->ID;
+
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_ENABLED, 1 );
+		update_post_meta( $event_id, Global_Stock::GLOBAL_STOCK_LEVEL, 100 );
+
+		$ticket_ids = [];
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$ticket_ids[] = $this->create_tc_ticket(
+				$event_id,
+				10 + $i,
+				[
+					'tribe-ticket' => [
+						'mode'     => 0 === $i % 2 ? Global_Stock::GLOBAL_STOCK_MODE : Global_Stock::CAPPED_STOCK_MODE,
+						'capacity' => 20,
+					],
+				]
+			);
+		}
+
+		// One attendee per ticket, so the event wide attendee loop has something to walk.
+		$this->create_order( array_fill_keys( $ticket_ids, 1 ) );
+
+		return [ $event_id, $ticket_ids ];
+	}
+
+	/**
+	 * Drops every cache layer so the measured calls start cold.
+	 */
+	private function given_cold_caches(): void {
+		tribe( 'cache' )->reset();
+		wp_cache_flush();
+	}
+
+	/**
+	 * Runs the callback while capturing the SQL queries that read the Attendee post type.
+	 *
+	 * @return array<string> The captured queries.
+	 */
+	private function when_measuring_attendee_queries( callable $callback ): array {
+		$this->captured_queries = [];
+
+		$spy = function ( $query ) {
+			if ( false !== strpos( (string) $query, Attendee::POSTTYPE ) ) {
+				$this->captured_queries[] = $query;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $spy );
+		$callback();
+		remove_filter( 'query', $spy );
+
+		return $this->captured_queries;
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1404](https://linear.app/nexcess/issue/SMTNC-1404/shared-capacity-performancememory-exhaustion-for-logged-in-users)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The problem was when the event had shared capacity tickets with numerous attendees or a server with low memory.
The problem was that we had a method that was running incrementally without cache, so, depending of the number of attendees and/or tickets it would blow the memory.
The solution was to create a cache and optimize the method, such as, remove the class creation `$attendee_ticket_stock = new Tribe__Tickets__Global_Stock( $attendee['event_id'] );` from the loop and relay on DI.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/599c5ea7a70e48129a209986cd0cf3a5

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
