### PR TITLE
[SMTNC-1897] Excessive User Capability Queries Firing on Frontend Event List Pages via user_can_manage_attendees

### DIFF
--- a/changelog/smtnc-1897-excessive-user-capability-queries-firing-on-frontend-event.yaml
+++ b/changelog/smtnc-1897-excessive-user-capability-queries-firing-on-frontend-event.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: performance
+entry: Stopped resolving the current user during bootstrap on front-end requests
+  to decide whether the admin Attendees screens should be registered.
+timestamp: 2026-08-01T04:57:46.914Z

--- a/src/Tickets/Admin/Attendees/Provider.php
+++ b/src/Tickets/Admin/Attendees/Provider.php
@@ -20,8 +20,19 @@ class Provider extends \tad_DI52_ServiceProvider {
 	 * Register the provider singletons.
 	 *
 	 * @since 5.9.1
+	 * @since TBD Skipped registration on front-end requests.
 	 */
 	public function register() {
+		/*
+		 * Everything this provider wires is admin-only. The container registers it on
+		 * `plugins_loaded`, so on the front end the capability check below would resolve
+		 * the current user - auth cookie validation plus a usermeta capabilities read -
+		 * before `init`, on every request, to reach a conclusion nothing then uses.
+		 */
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		if (
 			! tribe( 'tickets.attendees' )->user_can_manage_attendees()
 			|| ! tec_tickets_attendees_page_is_enabled()

--- a/tests/integration/TEC/Tickets/Admin/Attendees/ProviderTest.php
+++ b/tests/integration/TEC/Tickets/Admin/Attendees/ProviderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace TEC\Tickets\Admin\Attendees;
+
+/**
+ * @covers \TEC\Tickets\Admin\Attendees\Provider
+ *
+ * Regression coverage for SMTNC-1897: the provider decided whether to wire the
+ * admin-only Attendees screens by running a capability check inside register(),
+ * which the container executes while it is still being built on `plugins_loaded`.
+ * On the front end that resolved the current user - auth cookie validation plus a
+ * usermeta capabilities read - before `init`, on every single request, to reach a
+ * conclusion no front-end request ever uses.
+ */
+class ProviderTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * How many times user_can_manage_attendees() reached its capability list.
+	 *
+	 * @var int
+	 */
+	protected $cap_checks = 0;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		/*
+		 * The capability check short-circuits before the filter for a logged-out user, so
+		 * an anonymous visitor would make the counter read zero whether or not the bug is
+		 * present. Acting as an administrator keeps the filter reachable.
+		 */
+		wp_set_current_user( static::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->cap_checks = 0;
+
+		add_filter(
+			'tribe_tickets_caps_can_manage_attendees',
+			function ( $caps ) {
+				++$this->cap_checks;
+
+				return $caps;
+			}
+		);
+	}
+
+	public function tearDown(): void {
+		unset( $GLOBALS['current_screen'] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds the provider the way the container does, without registering it.
+	 *
+	 * @return Provider
+	 */
+	protected function make_provider(): Provider {
+		return new Provider( tribe() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_check_capabilities_on_front_end_requests(): void {
+		$this->assertFalse( is_admin(), 'This test only means something on a front-end request.' );
+
+		$this->make_provider()->register();
+
+		$this->assertSame(
+			0,
+			$this->cap_checks,
+			'Registering the Attendees provider on the front end must not resolve the current user to check capabilities.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_not_wire_the_admin_attendees_screens_on_front_end_requests(): void {
+		$this->make_provider()->register();
+
+		$this->assertFalse(
+			tribe()->isBound( Hooks::class ),
+			'The admin Attendees hooks are unreachable on the front end and should not be registered there.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_check_capabilities_on_admin_requests(): void {
+		set_current_screen( 'edit-post' );
+
+		$this->make_provider()->register();
+
+		$this->assertSame(
+			1,
+			$this->cap_checks,
+			'In the admin the capability check still decides whether the Attendees screens are wired.'
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_wire_the_admin_attendees_screens_for_a_permitted_admin_user(): void {
+		set_current_screen( 'edit-post' );
+
+		$this->make_provider()->register();
+
+		$this->assertTrue(
+			tribe()->isBound( Hooks::class ),
+			'An administrator in the admin should still get the Attendees screens wired.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1897] Excessive User Capability Queries Firing on Frontend Event List Pages via user_can_manage_attendees

### 🗒️ Description

Stopped the admin Attendees service provider from running a capability check while the container is built on `plugins_loaded`, which forced every front-end request to resolve the current user — auth cookie validation plus a usermeta capabilities read — before `init`, only to decide whether to wire screens that front-end requests never reach. Registration is now skipped outside the admin, and the check still runs in wp-admin where it governs access to the Attendees screens.

### 🎥 Artifacts
(https://www.loom.com/share/eed0846449d34e799ab24cc0a97af3c4)[https://www.loom.com/share/eed0846449d34e799ab24cc0a97af3c4]

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
