### PR TITLE
Do not render the RSVP button once the migration is complete

### DIFF
--- a/src/Tickets/Blocks/Controller.php
+++ b/src/Tickets/Blocks/Controller.php
@@ -170,7 +170,9 @@ class Controller extends \TEC\Common\Contracts\Provider\Controller {
 	 * Render the New Ticket and New RSVP buttons in the metabox, as appropriate.
 	 *
 	 * @since 5.8.0
-	 * @since TBD RSVP button is always rendered, disabled when RSVP feature is off.
+	 * @since TBD RSVP button is hidden when not applicable to the post (e.g. migration completed,
+	 *            RSVP disabled, Series/recurring events); it is only rendered disabled, with a
+	 *            tooltip, while the RSVP to Tickets Commerce migration is actively in progress.
 	 *
 	 * @param int $post_id The post id.
 	 */
@@ -206,7 +208,13 @@ class Controller extends \TEC\Common\Contracts\Provider\Controller {
 		if ( ! empty( $enabled['default'] ) ) {
 			tribe( Meta::class )->render_ticket_form_toggle( $post_id );
 		}
-		tribe( Meta::class )->render_rsvp_form_toggle( $post_id, empty( $enabled['rsvp'] ) );
+
+		if ( ! empty( $enabled['rsvp'] ) ) {
+			tribe( Meta::class )->render_rsvp_form_toggle( $post_id );
+		} elseif ( ! empty( $enabled['rsvp_migrating'] ) ) {
+			// RSVP is temporarily unavailable while its migration to Tickets Commerce is running.
+			tribe( Meta::class )->render_rsvp_form_toggle( $post_id, true );
+		}
 	}
 
 	/**

--- a/src/Tickets/Blocks/Controller.php
+++ b/src/Tickets/Blocks/Controller.php
@@ -205,15 +205,17 @@ class Controller extends \TEC\Common\Contracts\Provider\Controller {
 		 */
 		$enabled = apply_filters( "tec_tickets_enabled_ticket_forms_{$post_type}", $enabled, $post_id );
 
+		$meta = tribe( Meta::class );
+
 		if ( ! empty( $enabled['default'] ) ) {
-			tribe( Meta::class )->render_ticket_form_toggle( $post_id );
+			$meta->render_ticket_form_toggle( $post_id );
 		}
 
 		if ( ! empty( $enabled['rsvp'] ) ) {
-			tribe( Meta::class )->render_rsvp_form_toggle( $post_id );
+			$meta->render_rsvp_form_toggle( $post_id );
 		} elseif ( ! empty( $enabled['rsvp_migrating'] ) ) {
 			// RSVP is temporarily unavailable while its migration to Tickets Commerce is running.
-			tribe( Meta::class )->render_rsvp_form_toggle( $post_id, true );
+			$meta->render_rsvp_form_toggle( $post_id, true );
 		}
 	}
 

--- a/src/Tickets/RSVP/Controller.php
+++ b/src/Tickets/RSVP/Controller.php
@@ -213,6 +213,11 @@ class Controller extends Controller_Contract {
 	/**
 	 * Disables the RSVP form toggle in the Classic Editor metabox.
 	 *
+	 * Also flags whether RSVP is disabled because the migration to Tickets Commerce is actively
+	 * running (or paused), so the Classic Editor can render a disabled button with an explanatory
+	 * tooltip instead of hiding it outright. In every other case (migration completed, RSVP
+	 * permanently disabled, etc.) the button should be hidden entirely.
+	 *
 	 * @since TBD
 	 *
 	 * @param array<string,bool> $enabled The enabled ticket forms.
@@ -220,9 +225,21 @@ class Controller extends Controller_Contract {
 	 * @return array<string,bool> The modified enabled ticket forms.
 	 */
 	public function disable_rsvp_form_toggle( array $enabled ): array {
-		$enabled['rsvp'] = false;
+		$enabled['rsvp']           = false;
+		$enabled['rsvp_migrating'] = self::is_migration_in_progress();
 
 		return $enabled;
+	}
+
+	/**
+	 * Checks whether the RSVP to Tickets Commerce migration is currently running or paused.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the migration is currently in progress.
+	 */
+	public static function is_migration_in_progress(): bool {
+		return self::DISABLED === tribe_get_option( self::VERSION_OPTION_KEY );
 	}
 
 	/**

--- a/tests/integration/TEC/Tickets/Blocks/ControllerTest.php
+++ b/tests/integration/TEC/Tickets/Blocks/ControllerTest.php
@@ -7,7 +7,7 @@ use TEC\Common\Tests\Provider\Controller_Test_Case;
 class ControllerTest extends Controller_Test_Case {
 	protected string $controller_class = Controller::class;
 
-	public function test_render_form_toggle_buttons_shows_disabled_rsvp_button_when_rsvp_disabled(): void {
+	public function test_render_form_toggle_buttons_hides_rsvp_button_when_rsvp_disabled(): void {
 		$post_id = static::factory()->post->create();
 
 		add_filter( 'tec_tickets_enabled_ticket_forms', static function ( array $enabled ): array {
@@ -22,7 +22,26 @@ class ControllerTest extends Controller_Test_Case {
 		$controller->render_form_toggle_buttons( $post_id );
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'id="rsvp_form_toggle"', $html, 'RSVP button should be rendered even when disabled.' );
+		$this->assertStringNotContainsString( 'id="rsvp_form_toggle"', $html, 'RSVP button should not be rendered when RSVP is not applicable (e.g. migration completed).' );
+	}
+
+	public function test_render_form_toggle_buttons_shows_disabled_rsvp_button_when_migration_in_progress(): void {
+		$post_id = static::factory()->post->create();
+
+		add_filter( 'tec_tickets_enabled_ticket_forms', static function ( array $enabled ): array {
+			$enabled['rsvp']           = false;
+			$enabled['rsvp_migrating'] = true;
+
+			return $enabled;
+		} );
+
+		$controller = $this->make_controller();
+
+		ob_start();
+		$controller->render_form_toggle_buttons( $post_id );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="rsvp_form_toggle"', $html, 'RSVP button should be rendered, disabled, while migration is in progress.' );
 		$this->assertStringContainsString( 'disabled', $html, 'RSVP button should have the disabled attribute.' );
 		$this->assertStringContainsString( 'migration is in progress', $html, 'RSVP button should show migration tooltip.' );
 	}

--- a/tests/wpunit/TEC/Tickets/RSVP/Controller_Test.php
+++ b/tests/wpunit/TEC/Tickets/RSVP/Controller_Test.php
@@ -182,6 +182,42 @@ class Controller_Test extends Controller_Test_Case {
 		$this->assertTrue( $enabled['tc'] );
 	}
 
+	public function test_disable_rsvp_form_toggle_sets_rsvp_migrating_true_while_migration_in_progress(): void {
+		tribe_update_option( Controller::VERSION_OPTION_KEY, Controller::DISABLED );
+
+		$controller = $this->make_controller();
+		$enabled    = $controller->disable_rsvp_form_toggle( [ 'rsvp' => true ] );
+
+		$this->assertTrue( $enabled['rsvp_migrating'], 'rsvp_migrating should be true while the migration is running or paused.' );
+
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+	}
+
+	public function test_disable_rsvp_form_toggle_sets_rsvp_migrating_false_when_migration_completed(): void {
+		tribe_update_option( Controller::VERSION_OPTION_KEY, Controller::VERSION_2 );
+
+		$controller = $this->make_controller();
+		$enabled    = $controller->disable_rsvp_form_toggle( [ 'rsvp' => true ] );
+
+		$this->assertFalse( $enabled['rsvp_migrating'], 'rsvp_migrating should be false once migration has completed (RSVP button should be hidden, not disabled).' );
+
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+	}
+
+	public function test_is_migration_in_progress_false_by_default(): void {
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+
+		$this->assertFalse( Controller::is_migration_in_progress() );
+	}
+
+	public function test_is_migration_in_progress_true_when_version_option_disabled(): void {
+		tribe_update_option( Controller::VERSION_OPTION_KEY, Controller::DISABLED );
+
+		$this->assertTrue( Controller::is_migration_in_progress() );
+
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+	}
+
 	public function test_register_disabled_hooks_editor_config_filter(): void {
 		add_filter( 'tec_tickets_rsvp_enabled', '__return_false' );
 		$controller = $this->make_controller();


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4096]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

After the migration to RSVP V2 is complete, the RSVP metabox shows in the classic editor and we should no longer show the disabled 'Add RSVP' button in the ticket metabox. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here] [skip-changelog](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
