### PR TITLE
Restore create form in RSVP block content

### DIFF
--- a/src/modules/blocks/rsvp-v2/container-content/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-v2/container-content/__tests__/template.test.js
@@ -1,0 +1,34 @@
+jest.mock( '../../create-form/template', () => ( { clientId } ) => (
+	<div data-testid="rsvp-create-form">{ clientId }</div>
+) );
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import RSVPContainerContent from '../template';
+
+describe( 'RSVPContainerContent', () => {
+	it( 'renders the create form when add/edit is open', () => {
+		const component = renderer.create(
+			<RSVPContainerContent clientId="test-client-id" isAddEditOpen={ true } />
+		);
+		const tree = component.toJSON();
+
+		expect( tree.props[ 'data-testid' ] ).toBe( 'rsvp-create-form' );
+		expect( tree.children ).toEqual( [ 'test-client-id' ] );
+	} );
+
+	it( 'renders nothing when add/edit is closed', () => {
+		const component = renderer.create(
+			<RSVPContainerContent clientId="test-client-id" isAddEditOpen={ false } />
+		);
+
+		expect( component.toJSON() ).toBeNull();
+	} );
+} );

--- a/src/modules/blocks/rsvp-v2/container-content/template.js
+++ b/src/modules/blocks/rsvp-v2/container-content/template.js
@@ -1,23 +1,25 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
+import RSVPCreateForm from '../create-form/template';
 import '../../rsvp/container-content/style.pcss';
 
-const RSVPContainerContent = ( { isAddEditOpen } ) => {
+const RSVPContainerContent = ( { clientId, isAddEditOpen } ) => {
 	if ( ! isAddEditOpen ) {
 		return null;
 	}
 
-	// TODO: Restore <RSVPCreateForm /> when ../create-form/template lands in PR #4298.
-	return null;
+	return <RSVPCreateForm clientId={ clientId } />;
 };
 
 RSVPContainerContent.propTypes = {
+	clientId: PropTypes.string,
 	isAddEditOpen: PropTypes.bool,
 };
 


### PR DESCRIPTION
### 🎫 Ticket

[NA] - this is a minor follow-up tweak 
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Following up on the merging of the Block UI PR stack, we need this tweak to address a `TODO` to restore `<RSVPCreateForm clientId={ clientId } />;`. I also added some tests for good measure! 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
<img width="800" height="450" alt="CleanShot 2026-08-04 at 11 20 56" src="https://github.com/user-attachments/assets/23df059e-e815-4c49-ab5b-691c61b12068" />


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
