### PR TITLE
Fix attendee registration modal hang on save

### DIFF
--- a/src/Tribe/Editor/Attendee_Registration.php
+++ b/src/Tribe/Editor/Attendee_Registration.php
@@ -237,10 +237,18 @@ class Tribe__Tickets__Editor__Attendee_Registration {
 	 * URL to this standalone page
 	 *
 	 * @since 4.9
+	 * @since TBD Preserve the `tribe_events_modal` request var so the form action and
+	 *            post-save redirect keep rendering inside the block editor's modal iframe.
 	 *
 	 * @return string URL
 	 */
 	private function url() {
-		return admin_url( 'edit.php?post_type=' . $this->post->post_type . '&page=attendee-registration&ticket_id=' . $this->ticket_id );
+		$url = admin_url( 'edit.php?post_type=' . $this->post->post_type . '&page=attendee-registration&ticket_id=' . $this->ticket_id );
+
+		if ( tribe_get_request_var( 'tribe_events_modal', 0 ) ) {
+			$url = add_query_arg( 'tribe_events_modal', 1, $url );
+		}
+
+		return $url;
 	}
 }

--- a/src/modules/blocks/rsvp-shared/attendee-registration/container.js
+++ b/src/modules/blocks/rsvp-shared/attendee-registration/container.js
@@ -67,7 +67,7 @@ const mapDispatchToProps = ( dispatch ) => ( {
 		form.addEventListener( 'submit', showOverlay );
 
 		const removeListeners = () => {
-			iframeWindow.removeEventListener( 'unload', handleUnload ); // eslint-disable-line no-use-before-define,max-len
+			iframeWindow.removeEventListener( 'pagehide', handleUnload ); // eslint-disable-line no-use-before-define,max-len
 			form.removeEventListener( 'submit', showOverlay );
 			window.tribe_event_tickets_plus.rsvp.onIacChange = previousOnIacChange;
 		};
@@ -117,7 +117,9 @@ const mapDispatchToProps = ( dispatch ) => ( {
 			dispatch( actions.setRSVPIsModalOpen( false ) );
 		};
 
-		iframeWindow.addEventListener( 'unload', handleUnload );
+		// Chrome (and other modern browsers) do not reliably fire `unload` for same-origin
+		// iframe navigations triggered by a form submit; `pagehide` is the supported replacement.
+		iframeWindow.addEventListener( 'pagehide', handleUnload );
 
 		const introLink = iframeWindow.document.querySelector( '.tribe-intro > a' );
 		if ( introLink ) {


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4104](https://linear.app/nexcess/issue/SOFT-4104/rsvp-v2-block-attendee-information-modal-shows-full-admin-ui-and-hangs)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

There were two issues happening with the block editor IAC modal:
1. `tribe_events_modal=1` dropped on save/redirect

`event-tickets/src/Tribe/Editor/Attendee_Registration.php`

The admin screen at `edit.php?post_type=...&page=attendee-registration&ticket_id=...` only renders in compact "modal" mode (no wp-admin chrome) when the `tribe_events_modal=1` query var is present — see `filter_admin_body_class()`.

The iframe's initial src correctly includes `tribe_events_modal=1 (set in event-tickets/src/modules/blocks/rsvp-shared/attendee-registration/container.js`), but both the form's action attribute (`render()`, line ~154), and the post-save redirect (`maybe_handle_submission()`, line ~232) are built from `url()`, which never includes `tribe_events_modal`. So submitting the form navigates to a URL without the flag, and the reloaded page renders as a full standalone admin page inside the iframe.

Fix: `url()` now appends `tribe_events_modal=1` when it was present on the incoming request, so the flag survives the form submit → redirect round-trip.

2. Modal-close handshake relies on the deprecated/unreliable unload event

`event-tickets/src/modules/blocks/rsvp-shared/attendee-registration/container.js`

`onIframeLoad()` attaches an unload listener to the iframe's `contentWindow` to detect when the form has been submitted and the iframe is navigating away. That handler (`handleUnload`) extracts the saved field names and dispatches `setRSVPIsModalOpen(false)` to close the modal.

Fix: swapped the unload listener (and its corresponding `removeEventListener` cleanup) for `pagehide`.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="800" height="517" alt="CleanShot 2026-08-04 at 14 09 33" src="https://github.com/user-attachments/assets/ef93315f-2001-44d1-b2f8-04b85bfbe308" />

After:
<img width="800" height="517" alt="CleanShot 2026-08-04 at 15 52 22" src="https://github.com/user-attachments/assets/f862c453-4b96-403c-9442-d0fc728bb841" />



### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here] [skip-changelog](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
