### PR TITLE
[SMTNC-1957] Fatal error on WooCommerce order edit screen by Event Tickets 5.29.2

### DIFF
--- a/changelog/fix-smtnc-1957-fatal-error-on-woocommerce-order-edit-screen.yaml
+++ b/changelog/fix-smtnc-1957-fatal-error-on-woocommerce-order-edit-screen.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Prevented a fatal error on the WooCommerce order edit screen when
+  attendee data was read from a generator, so orders containing tickets open
+  normally again.
+timestamp: 2026-08-06T10:32:14.989Z

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1698,13 +1698,22 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @since 4.10.6
 		 * @since 5.29.2 Added cache to handle the attendees data from the current module.
+		 * @since TBD Normalized traversable input, as the attendees are read more than once here.
 		 *
-		 * @param array $attendees Attendee objects or IDs.
-		 * @param int   $post_id   Parent post ID.
+		 * @param array|Traversable $attendees Attendee objects or IDs.
+		 * @param int               $post_id   Parent post ID.
 		 *
 		 * @return array The attendee data for attendees.
 		 */
 		public function get_attendees_from_module( $attendees, $post_id = 0 ) {
+			/*
+			 * Callers may hand over a generator, e.g. from `Tribe__Repository::all( true )`, and this method
+			 * reads the set twice: once to warm the post caches and once to build the data.
+			 */
+			if ( $attendees instanceof Traversable ) {
+				$attendees = iterator_to_array( $attendees, false );
+			}
+
 			/** @var Tribe__Cache $cache */
 			$cache = tribe( 'cache' );
 

--- a/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
+++ b/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
@@ -2,6 +2,8 @@
 
 namespace Tribe\Tickets;
 
+use Faker\Factory;
+use Generator;
 use Tribe\Events\Test\Factories\Event;
 use Tribe\Tickets\Test\Commerce\Attendee_Maker;
 use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
@@ -40,7 +42,7 @@ class Get_Attendees_From_Module_Test extends \Codeception\TestCase\WPTestCase {
 
 		$generator = tribe_attendees( $module->orm_provider )->by( 'ticket', $ticket_id )->all( true );
 
-		$this->assertInstanceOf( \Generator::class, $generator, 'The ORM should hand back a generator for this test to be meaningful.' );
+		$this->assertInstanceOf( Generator::class, $generator, 'The ORM should hand back a generator for this test to be meaningful.' );
 
 		$attendees = $module->get_attendees_from_module( $generator );
 
@@ -62,7 +64,8 @@ class Get_Attendees_From_Module_Test extends \Codeception\TestCase\WPTestCase {
 	 * @return array{0: Tribe__Tickets__RSVP, 1: int, 2: int, 3: int}
 	 */
 	private function given_an_event_with_attendees(): array {
-		$count     = 3;
+		/* More than one attendee, so each internal pass over the set reads several items. */
+		$count     = Factory::create()->numberBetween( 2, 5 );
 		$event_id  = $this->factory()->event->create();
 		$ticket_id = $this->create_rsvp_ticket( $event_id );
 

--- a/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
+++ b/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tribe\Tickets;
+
+use Tribe\Events\Test\Factories\Event;
+use Tribe\Tickets\Test\Commerce\Attendee_Maker;
+use Tribe\Tickets\Test\Commerce\RSVP\Ticket_Maker as RSVP_Ticket_Maker;
+use Tribe__Tickets__RSVP;
+
+class Get_Attendees_From_Module_Test extends \Codeception\TestCase\WPTestCase {
+
+	use RSVP_Ticket_Maker;
+	use Attendee_Maker;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory()->event = new Event();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_attendee_data_when_given_an_array() {
+		[ $module, $event_id, $ticket_id, $count ] = $this->given_an_event_with_attendees();
+
+		$attendees = $module->get_attendees_from_module( tribe_attendees( $module->orm_provider )->by( 'ticket', $ticket_id )->all() );
+
+		$this->assertCount( $count, $attendees );
+	}
+
+	/**
+	 * A generator can only be traversed once, so every internal pass over the argument has to read
+	 * from the same materialised list.
+	 *
+	 * @test
+	 */
+	public function it_should_return_attendee_data_when_given_a_generator() {
+		[ $module, $event_id, $ticket_id, $count ] = $this->given_an_event_with_attendees();
+
+		$generator = tribe_attendees( $module->orm_provider )->by( 'ticket', $ticket_id )->all( true );
+
+		$this->assertInstanceOf( \Generator::class, $generator, 'The ORM should hand back a generator for this test to be meaningful.' );
+
+		$attendees = $module->get_attendees_from_module( $generator );
+
+		$this->assertCount( $count, $attendees );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_an_empty_array_for_an_empty_generator() {
+		[ $module, $event_id ] = $this->given_an_event_with_attendees();
+
+		$attendees = $module->get_attendees_from_module( tribe_attendees( $module->orm_provider )->by( 'ticket', $event_id )->all( true ), $event_id );
+
+		$this->assertSame( [], $attendees );
+	}
+
+	/**
+	 * @return array{0: Tribe__Tickets__RSVP, 1: int, 2: int, 3: int}
+	 */
+	private function given_an_event_with_attendees(): array {
+		$count     = 3;
+		$event_id  = $this->factory()->event->create();
+		$ticket_id = $this->create_rsvp_ticket( $event_id );
+
+		$this->create_many_attendees_for_ticket( $count, $ticket_id, $event_id );
+
+		return [ tribe( 'tickets.rsvp' ), $event_id, $ticket_id, $count ];
+	}
+}

--- a/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
+++ b/tests/wpunit/Tribe/Tickets/Get_Attendees_From_Module_Test.php
@@ -61,6 +61,24 @@ class Get_Attendees_From_Module_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * The cache only engages when a post ID accompanies a non-empty set.
+	 *
+	 * @test
+	 */
+	public function it_should_serve_attendee_data_from_the_cache_on_a_second_call() {
+		[ $module, $event_id, $ticket_id, $count ] = $this->given_an_event_with_attendees();
+
+		$first = $module->get_attendees_from_module( tribe_attendees( $module->orm_provider )->by( 'ticket', $ticket_id )->all( true ), $event_id );
+
+		$this->assertCount( $count, $first );
+
+		/* Recomputing this single-attendee set would return one row, so a full set proves the cache answered. */
+		$second = $module->get_attendees_from_module( [ $first[0]['attendee_id'] ], $event_id );
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
 	 * @return array{0: Tribe__Tickets__RSVP, 1: int, 2: int, 3: int}
 	 */
 	private function given_an_event_with_attendees(): array {


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1957](https://linear.app/nexcess/issue/SMTNC-1957/fatal-error-on-woocommerce-order-edit-screen-by-event-tickets-5292)

### 🗒️ Description

Resolved an issue where opening a WooCommerce order containing tickets threw `Cannot traverse an already closed generator` and made the order edit screen inaccessible. The attendee cache warm-up added in 5.29.2 introduced a second pass over the attendee set, which failed whenever a caller supplied a generator, so `Tribe__Tickets__Tickets::get_attendees_from_module()` now normalizes traversable input before reading it.

### 🎥 Artifacts
https://www.loom.com/share/38e2cf93aa9b487e95a1591da4354daa


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ x Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
