### PR TITLE
Tweaks to avoid a fatal if ET is updated before ETP

### DIFF
--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -495,14 +495,16 @@ class Module extends \Tribe__Tickets__Tickets {
 	 * order creation, cause the inventory to be decreased.
 	 *
 	 * @since 5.1.9
-	 * @since TBD Added the `$type` parameter to allow for RSVP tickets to be excluded from inventory decrease based on the RSVP status.
+	 * @since TBD Attendees marked with a `ticket_type` of RSVP are excluded from inventory
+	 *            decrease based on their RSVP status.
 	 *
-	 * @param array  $attendee The attendee.
-	 * @param string $type     The type of ticket.
+	 * @param array $attendee The attendee. May include a `ticket_type` key.
 	 *
 	 * @return bool
 	 */
-	public function attendee_decreases_inventory( array $attendee, string $type = 'default' ) {
+	public function attendee_decreases_inventory( array $attendee ) {
+		$type = $attendee['ticket_type'] ?? 'default';
+
 		if ( $type === RSVP_V2_Constants::TC_RSVP_TYPE ) {
 			$meta_exists = metadata_exists( 'post', $attendee['ID'], RSVP_V2_Constants::RSVP_STATUS_META_KEY );
 			if ( $meta_exists && ! tribe_is_truthy( get_post_meta( $attendee['ID'], RSVP_V2_Constants::RSVP_STATUS_META_KEY, true ) ) ) {

--- a/src/Tribe/Commerce/PayPal/Main.php
+++ b/src/Tribe/Commerce/PayPal/Main.php
@@ -2890,14 +2890,12 @@ class Tribe__Tickets__Commerce__PayPal__Main extends Tribe__Tickets__Tickets {
 	 * order creation, cause the inventory to be decreased.
 	 *
 	 * @since 4.7
-	 * @since TBD Added the `$type` parameter to allow for RSVP tickets to be excluded from inventory decrease based on the RSVP status.
 	 *
-	 * @param array  $attendee The attendee data.
-	 * @param string $type The type of ticket.
+	 * @param array $attendee The attendee data.
 	 *
 	 * @return bool
 	 */
-	public function attendee_decreases_inventory( array $attendee, string $type = 'default' ) {
+	public function attendee_decreases_inventory( array $attendee ) {
 		$order_status = Tribe__Utils__Array::get( $attendee, 'order_status', 'undefined' );
 		$order_id     = Tribe__Utils__Array::get( $attendee, 'order_id', false );
 		$attendee_id  = Tribe__Utils__Array::get( $attendee, 'attendee_id', false );

--- a/src/Tribe/Ticket_Object.php
+++ b/src/Tribe/Ticket_Object.php
@@ -701,7 +701,8 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 				}
 
 				// Allow providers to decide if an attendee will count toward inventory decrease or not.
-				if ( ! $provider->attendee_decreases_inventory( $attendee, $this->type() ) ) {
+				$attendee['ticket_type'] = $this->type();
+				if ( ! $provider->attendee_decreases_inventory( $attendee ) ) {
 					continue;
 				}
 
@@ -760,11 +761,13 @@ if ( ! class_exists( 'Tribe__Tickets__Ticket_Object' ) ) {
 
 					$attendee_ticket_stock_mode = $ticket_stock_modes[ (int) $attendee['product_id'] ] ?? '';
 
+					$attendee['ticket_type'] = $this->type();
+
 					// On all cases of indy stock we don't add.
 					if (
 						! $global_stock_enabled
 						|| empty( $attendee_ticket_stock_mode )
-						|| ! $provider->attendee_decreases_inventory( $attendee, $this->type() )
+						|| ! $provider->attendee_decreases_inventory( $attendee )
 						|| Tribe__Tickets__Global_Stock::OWN_STOCK_MODE === $attendee_ticket_stock_mode
 					) {
 						continue;

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -1034,14 +1034,16 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * Whether a specific attendee is valid toward inventory decrease or not.
 		 *
 		 * @since 4.7
-		 * @since TBD Added the `$type` parameter to allow for RSVP tickets to be excluded from inventory decrease based on the RSVP status.
+		 * @since TBD Attendees marked with a `ticket_type` of RSVP are excluded from inventory
+		 *            decrease based on their RSVP status.
 		 *
-		 * @param array  $attendee The attendee data.
-		 * @param string $type     The type of ticket.
+		 * @param array $attendee The attendee data. May include a `ticket_type` key.
 		 *
 		 * @return bool
 		 */
-		public function attendee_decreases_inventory( array $attendee, string $type = 'default' ) {
+		public function attendee_decreases_inventory( array $attendee ) {
+			$type = $attendee['ticket_type'] ?? 'default';
+
 			if ( $type === Constants::TC_RSVP_TYPE ) {
 				$meta_exists = metadata_exists( 'post', $attendee['ID'], Constants::RSVP_STATUS_META_KEY );
 				return ! $meta_exists || tribe_is_truthy( get_post_meta( $attendee['ID'], Constants::RSVP_STATUS_META_KEY, true ) );


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4149](https://linear.app/nexcess/issue/SOFT-4149/allow-upgrading-et-before-etp-without-triggering-a-fatal)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

There was a fatal if ET was updated before ETP, this PR safeguards against the places triggering that fatal. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
