### PR TITLE
[SOFT-3894] RSVP V2: hidden TC order not transitioned to Removed/Voided when admin deletes attendee

### DIFF
--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -10,8 +10,10 @@
 namespace TEC\Tickets\RSVP\V2;
 
 use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Emails\Order_Type_Trait;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Voided;
 use TEC\Tickets\Commerce\Ticket as Commerce_Ticket;
 
 /**
@@ -24,6 +26,8 @@ use TEC\Tickets\Commerce\Ticket as Commerce_Ticket;
  * @package TEC\Tickets\RSVP\V2
  */
 class Attendees {
+	use Order_Type_Trait;
+
 	/**
 	 * The method filters the default Attendee ID fetching done in RSVP (Tribe__Tickets__RSVP) class to
 	 * use the RSVP Tickets Commerce repository instead.
@@ -215,6 +219,63 @@ class Attendees {
 		}
 
 		return (array) $actions;
+	}
+
+	/**
+	 * Voids an RSVP order once its last attendee is deleted.
+	 *
+	 * Hooked to `tec_tickets_commerce_attendee_before_delete`, which fires for every Tickets
+	 * Commerce attendee deletion — including real paid-ticket orders — so this method bails unless
+	 * the attendee's order is composed exclusively of RSVP items and no other live attendee remains
+	 * on it.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $attendee_id The ID of the attendee being deleted.
+	 *
+	 * @return void
+	 */
+	public function void_order_after_last_attendee_deleted( int $attendee_id ): void {
+		$attendee = get_post( $attendee_id );
+
+		// Bail if the attendee no longer exists, is not a TC attendee, or is not attached to an order.
+		if (
+			! $attendee instanceof \WP_Post
+			|| Attendee::POSTTYPE !== $attendee->post_type
+			|| empty( $attendee->post_parent )
+		) {
+			return;
+		}
+
+		$order = tec_tc_get_order( $attendee->post_parent );
+
+		// Bail if the parent order no longer exists.
+		if ( ! $order instanceof \WP_Post ) {
+			return;
+		}
+
+		// This hook fires for ALL Tickets Commerce attendees: never void a real paid-ticket order.
+		if ( ! $this->is_rsvp_order( $order ) ) {
+			return;
+		}
+
+		// Bail if the order was already voided or trashed.
+		if ( in_array( $order->post_status, [ tribe( Voided::class )->get_wp_slug(), 'trash' ], true ) ) {
+			return;
+		}
+
+		// Fetch the other live attendees left on the order, excluding the one being deleted.
+		$remaining_attendees = array_diff(
+			tribe( 'tickets.attendee-repository.rsvp' )->where( 'order', $order->ID )->get_ids(),
+			[ $attendee_id ]
+		);
+
+		// Keep the order alive while at least one attendee remains on it.
+		if ( ! empty( $remaining_attendees ) ) {
+			return;
+		}
+
+		tribe( Order::class )->modify_status( $order->ID, Voided::SLUG );
 	}
 
 	/**

--- a/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Attendees_Test.php
@@ -4,6 +4,15 @@ namespace TEC\Tickets\RSVP\V2;
 
 use Closure;
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Attendee;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Gateways\Free\Gateway;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\Commerce\Status\Voided;
+use TEC\Tickets\RSVP\V2\Cart\RSVP_Cart;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Attendee_Maker;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 use Tribe\Tickets\Test\Commerce\Ticket_Maker as TC_Ticket_Maker;
@@ -441,5 +450,139 @@ class Attendees_Test extends WPTestCase {
 		} else {
 			$this->assertArrayNotHasKey( 'tickets_checkin', $result );
 		}
+	}
+
+	/**
+	 * Creates an RSVP order with the given quantity and returns its ID plus the live attendee IDs.
+	 *
+	 * Builds a real TC-RSVP order through the canonical cart flow (mirrors
+	 * Order_Endpoint::create and Flag_Actions_Order_Type_Test::create_tc_rsvp_order) so the
+	 * order line items are typed `tc-rsvp` and the generated attendees carry the RSVP status
+	 * meta the RSVP attendee repository requires.
+	 *
+	 * @param int $ticket_id The RSVP ticket ID.
+	 * @param int $quantity  The number of attendees to put on the order.
+	 *
+	 * @return array{0:int,1:int[]} The order ID and the attendee IDs.
+	 */
+	private function create_rsvp_order_with_attendees( int $ticket_id, int $quantity ): array {
+		/** @var RSVP_Cart $cart */
+		$cart = tribe( RSVP_Cart::class );
+		$cart->clear();
+		$cart->upsert_item(
+			$ticket_id,
+			$quantity,
+			[
+				'type'         => Constants::TC_RSVP_TYPE,
+				'order_status' => 'yes',
+			]
+		);
+		$cart->save();
+
+		$purchaser = [
+			'purchaser_user_id'    => 0,
+			'purchaser_full_name'  => 'Test Purchaser',
+			'purchaser_first_name' => 'Test',
+			'purchaser_last_name'  => 'Purchaser',
+			'purchaser_email'      => 'attendee@example.com',
+		];
+
+		/** @var Order $orders */
+		$orders = tribe( Order::class );
+		$order  = $orders->create_from_cart( tribe( Gateway::class ), $purchaser, Constants::TC_RSVP_TYPE );
+
+		$orders->modify_status( $order->ID, Pending::SLUG );
+		$orders->modify_status( $order->ID, Completed::SLUG );
+
+		$cart->clear();
+		tribe( Cart::class )->clear_cart();
+
+		$attendees    = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		$attendee_ids = array_column( $attendees, 'attendee_id' );
+		array_map( static fn( $attendee_id ) => update_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, 'yes' ), $attendee_ids );
+
+		return [ $order->ID, $attendee_ids ];
+	}
+
+	public function test_deleting_only_rsvp_attendee_voids_the_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		[ $order_id, $attendee_ids ] = $this->create_rsvp_order_with_attendees( $ticket_id, 1 );
+		$this->assertCount( 1, $attendee_ids );
+
+		// The hook used to fatal here on the undefined `void_order_after_last_attendee_deleted()` callback.
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( tribe( Voided::class )->get_wp_slug(), get_post_status( $order_id ) );
+
+		// No live attendee remains on the order.
+		$this->assertSame(
+			[],
+			tribe( 'tickets.attendee-repository.rsvp' )->where( 'order', $order_id )->get_ids()
+		);
+
+		$attendee_status = get_post_status( $attendee_ids[0] );
+		$this->assertTrue(
+			false === $attendee_status || 'trash' === $attendee_status,
+			'The attendee should be deleted (or trashed) after the deletion.'
+		);
+	}
+
+	public function test_deleting_one_of_multiple_rsvp_attendees_keeps_order_completed(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		[ $order_id, $attendee_ids ] = $this->create_rsvp_order_with_attendees( $ticket_id, 2 );
+		$this->assertCount( 2, $attendee_ids );
+
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( tribe( Completed::class )->get_wp_slug(), get_post_status( $order_id ) );
+
+		// The remaining attendee is still live on the order.
+		$this->assertCount(
+			1,
+			tribe( 'tickets.attendee-repository.rsvp' )->where( 'order', $order_id )->get_ids()
+		);
+	}
+
+	public function test_deleting_only_attendee_of_ticket_order_does_not_void_it(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+		$order_id  = $this->create_order( [ $ticket_id => 1 ] )->ID;
+
+		$attendee_ids = tec_tc_attendees()->where( 'event_id', $post_id )->get_ids();
+		$this->assertCount( 1, $attendee_ids );
+
+		// The hook fires for ALL TC attendees: a real paid-ticket order must never be voided.
+		tribe( Attendee::class )->delete( $attendee_ids[0] );
+
+		$this->assertSame( tribe( Completed::class )->get_wp_slug(), get_post_status( $order_id ) );
+	}
+
+	public function test_void_order_after_last_attendee_deleted_direct_call_voids_rsvp_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id );
+
+		[ $order_id, $attendee_ids ] = $this->create_rsvp_order_with_attendees( $ticket_id, 1 );
+		$this->assertCount( 1, $attendee_ids );
+
+		tribe( Attendees::class )->void_order_after_last_attendee_deleted( $attendee_ids[0] );
+
+		$this->assertSame( tribe( Voided::class )->get_wp_slug(), get_post_status( $order_id ) );
+	}
+
+	public function test_void_order_after_last_attendee_deleted_direct_call_bails_for_ticket_order(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_ticket( $post_id, 10 );
+		$order_id  = $this->create_order( [ $ticket_id => 1 ] )->ID;
+
+		$attendee_ids = tec_tc_attendees()->where( 'event_id', $post_id )->get_ids();
+		$this->assertCount( 1, $attendee_ids );
+
+		tribe( Attendees::class )->void_order_after_last_attendee_deleted( $attendee_ids[0] );
+
+		$this->assertSame( tribe( Completed::class )->get_wp_slug(), get_post_status( $order_id ) );
 	}
 }


### PR DESCRIPTION
[SOFT-3894](https://linear.app/nexcess/issue/SOFT-3894/rsvp-v2-hidden-tc-order-not-transitioned-to-removedvoided-when-admin)

### 🗒️ Description

**Fix** (bug fix - PHP fatal on attendee deletion)

The fix that @sdokus did was reverted on the Stack PR merge putting it back again

Fixed a PHP fatal thrown when deleting any RSVP V2 attendee: the `tec_tickets_commerce_attendee_before_delete` hook referenced a `void_order_after_last_attendee_deleted()` method that did not exist anywhere in the codebase. Re-implemented the method (the SOFT-3894 behavior introduced by PR #4332 was dropped by a later refactor, commit `6ffd03c605`) so the hidden Tickets Commerce order backing an RSVP is transitioned to `Voided` once its last attendee is deleted, while real paid-ticket orders are never affected.