### PR TITLE
[SOFT-3342] "Not Going" attendees still decrement ticket inventory

### DIFF
--- a/src/Tickets/Commerce/Ticket.php
+++ b/src/Tickets/Commerce/Ticket.php
@@ -9,6 +9,7 @@ use TEC\Tickets\Commerce\Status\Status_Handler;
 use TEC\Tickets\Commerce\Status\Status_Interface;
 use TEC\Tickets\Commerce\Traits\Is_Ticket;
 use TEC\Tickets\Commerce\Utils\Value;
+use TEC\Tickets\RSVP\V2\Constants as RSVP_V2_Constants;
 use Tribe__Tickets__Global_Stock as Event_Stock;
 use Tribe__Utils__Array as Arr;
 use Tribe__Date_Utils as Date_Utils;
@@ -761,7 +762,18 @@ class Ticket extends Ticket_Data {
 
 		if ( '' !== $mode ) {
 			if ( 'update' === $save_type ) {
-				$totals         = $tickets_handler->get_ticket_totals( $ticket->ID );
+				$totals = $tickets_handler->get_ticket_totals( $ticket->ID );
+
+				/*
+				 * RSVP V2 "Not Going" attendees do not hold a seat, but the Going -> Not Going
+				 * flip only updates the RSVP status meta (never `total_sales`), so the raw figure
+				 * would over-subtract from `_stock` on every save. Mirror the exclusion
+				 * `Ticket_Object::inventory()` applies by recomputing `sold` from live Going attendees.
+				 */
+				if ( RSVP_V2_Constants::TC_RSVP_TYPE === $ticket->type() ) {
+					$totals['sold'] = $this->get_going_rsvp_attendee_count( $ticket->ID );
+				}
+
 				$data['stock'] -= $totals['pending'] + $totals['sold'];
 			}
 
@@ -1378,5 +1390,46 @@ class Ticket extends Ticket_Data {
 	 */
 	public function load_ticket_object( int $ticket_id ): ?Ticket_Object {
 		return tribe( Module::class )->get_ticket( 0, $ticket_id );
+	}
+
+	/**
+	 * Counts the live RSVP V2 "Going" attendees for a ticket.
+	 *
+	 * A ticket's `total_sales` is never decremented when an attendee flips Going to Not Going:
+	 * the flip only updates the `_tec_tickets_commerce_rsvp_status` meta (see
+	 * \TEC\Tickets\RSVP\V2\Frontend::update_attendee_data()), so the raw sales figure would
+	 * over-subtract from `_stock` on every save. This counts the attendees that actually hold a
+	 * seat instead, mirroring the exclusion `Tribe__Tickets__Ticket_Object::inventory()` applies:
+	 * an attendee whose RSVP status meta exists with a falsy value ('no') does not hold a seat.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $ticket_id The ticket post ID.
+	 *
+	 * @return int The number of Going RSVP V2 attendees for the ticket.
+	 */
+	private function get_going_rsvp_attendee_count( int $ticket_id ): int {
+		$attendee_ids = tribe( 'tickets.attendee-repository' )
+			->where( 'ticket', $ticket_id )
+			->get_ids();
+
+		if ( empty( $attendee_ids ) ) {
+			return 0;
+		}
+
+		$count = 0;
+
+		foreach ( $attendee_ids as $attendee_id ) {
+			if (
+				metadata_exists( 'post', $attendee_id, RSVP_V2_Constants::RSVP_STATUS_META_KEY )
+				&& ! tribe_is_truthy( get_post_meta( $attendee_id, RSVP_V2_Constants::RSVP_STATUS_META_KEY, true ) )
+			) {
+				continue;
+			}
+
+			++$count;
+		}
+
+		return $count;
 	}
 }

--- a/tests/rsvp_v2_integration/RSVP/V2/Stock_Capacity_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Stock_Capacity_Test.php
@@ -146,6 +146,116 @@ class Stock_Capacity_Test extends WPTestCase {
 	}
 
 	/**
+	 * Regression: saving a TC-RSVP ticket must not re-count a Going attendee that was flipped to
+	 * Not Going as sold. The flip (RSVP V2 frontend, `Frontend::update_attendee_data()`) only
+	 * updates the `_tec_tickets_commerce_rsvp_status` meta and never decrements `total_sales`, so
+	 * `Ticket::save()` would recompute `_stock` as `capacity - stale_sold` and silently reintroduce
+	 * the Not Going over-count into `available()`/`get_ticket_max_purchase()`.
+	 *
+	 * @see \TEC\Tickets\Commerce\Ticket::save()
+	 * @see \TEC\Tickets\RSVP\V2\Frontend::update_attendee_data()
+	 */
+	public function test_save_does_not_recount_flipped_not_going_attendees_as_sold(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, [ 'tribe-ticket' => [ 'capacity' => 50 ] ] );
+
+		// Going order: Decrease_Stock runs, so total_sales = 1 and _stock = 49.
+		$order     = $this->create_order( [ $ticket_id => 1 ] );
+		$attendees = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		$this->assertCount( 1, $attendees );
+		$attendee_id = $attendees[0]['attendee_id'];
+
+		// Flip the attendee to Not Going, exactly what the RSVP V2 frontend status toggle does.
+		update_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, 'no' );
+
+		// Save the ticket (e.g. a title change in the admin editor).
+		$this->save_renamed_ticket( $post_id, $ticket_id, Constants::TC_RSVP_TYPE );
+
+		$ticket = Tickets::load_ticket_object( $ticket_id );
+
+		// The flipped attendee does not hold a seat, so every counter must land at 50, not 49.
+		$this->assertEquals( 50, $ticket->available() );
+		$this->assertEquals( 50, $ticket->inventory() );
+		$this->assertEquals( 50, (int) get_post_meta( $ticket_id, '_stock', true ) );
+
+		// `total_sales` is a separate legacy counter the flip does not decrement; this fix only
+		// stops it from over-subtracting `_stock` on save.
+		$this->assertEquals( 1, $ticket->qty_sold() );
+	}
+
+	/**
+	 * Sanity: saving a TC-RSVP ticket with a directly-created Not Going attendee (which never
+	 * touched `total_sales` because `Decrease_Stock` bails for it) must keep stock correct. This
+	 * guards the fix against over-subtracting when `total_sales` already excludes the Not Going
+	 * attendee.
+	 *
+	 * @see \TEC\Tickets\Commerce\Flag_Actions\Decrease_Stock::handle()
+	 */
+	public function test_save_keeps_stock_for_directly_created_not_going_attendees(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_rsvp_ticket( $post_id, [ 'tribe-ticket' => [ 'capacity' => 50 ] ] );
+
+		// 1 going attendee (total_sales = 1, _stock = 49) + 1 directly-created Not Going attendee.
+		$this->create_order( [ $ticket_id => 1 ] );
+		$this->create_not_going_rsvp_order( $ticket_id, 1 );
+
+		$this->save_renamed_ticket( $post_id, $ticket_id, Constants::TC_RSVP_TYPE );
+
+		$ticket = Tickets::load_ticket_object( $ticket_id );
+
+		// Only the 1 going attendee holds a seat: 50 − 1 = 49.
+		$this->assertEquals( 49, $ticket->available() );
+		$this->assertEquals( 49, (int) get_post_meta( $ticket_id, '_stock', true ) );
+		$this->assertEquals( 1, $ticket->qty_sold() );
+	}
+
+	/**
+	 * Sanity: saving a regular paid Tickets Commerce ticket must keep the pre-existing `sold`
+	 * recompute untouched. The RSVP V2 Not Going exclusion only applies to TC-RSVP tickets.
+	 */
+	public function test_save_stock_unaffected_for_regular_tc_tickets(): void {
+		$post_id   = static::factory()->post->create();
+		$ticket_id = $this->create_tc_ticket( $post_id, 10, [ 'tribe-ticket' => [ 'capacity' => 50 ] ] );
+
+		$this->create_order( [ $ticket_id => 2 ] );
+
+		$this->save_renamed_ticket( $post_id, $ticket_id );
+
+		$ticket = Tickets::load_ticket_object( $ticket_id );
+
+		$this->assertEquals( 48, $ticket->available() );
+		$this->assertEquals( 48, (int) get_post_meta( $ticket_id, '_stock', true ) );
+		$this->assertEquals( 2, $ticket->qty_sold() );
+	}
+
+	/**
+	 * Saves a ticket through the real provider flow, as the admin editor does on any change.
+	 *
+	 * A no-op title change is enough to trigger the `'update'` branch of `Ticket::save()`. The
+	 * `$ticket_type` is passed through as the production `ticket_add()` flow does: `Ticket::save()`
+	 * rewrites the `_type` meta from `$raw_data['ticket_type'] ?? 'default'`, so omitting it would
+	 * strip the ticket's type (and the RSVP V2 Not Going exclusion along with it). The
+	 * `tec_tickets` wp_cache is not invalidated by the save (only `clean_post_cache()` runs), so
+	 * it is cleared here for the follow-up `load_ticket_object()` to read the freshly persisted
+	 * `_stock` rather than the pre-save cached value.
+	 */
+	private function save_renamed_ticket( int $post_id, int $ticket_id, string $ticket_type = 'default' ): void {
+		$ticket       = Tickets::load_ticket_object( $ticket_id );
+		$ticket->name = 'Renamed';
+
+		tribe( Module::class )->save_ticket(
+			$post_id,
+			$ticket,
+			[
+				'ticket_type'  => $ticket_type,
+				'tribe-ticket' => [ 'mode' => 'own', 'capacity' => 50 ],
+			]
+		);
+
+		wp_cache_delete( $ticket_id, 'tec_tickets' );
+	}
+
+	/**
 	 * Mirrors the production Order_Endpoint flow for Not Going: places a cart item with
 	 * type=tc-rsvp + order_status=no (so Decrease_Stock bails) and stamps the rsvp_status
 	 * meta on the resulting attendees (so inventory() excludes them).


### PR DESCRIPTION
[SOFT-3342](https://linear.app/nexcess/issue/SOFT-3342/not-going-attendees-still-decrement-ticket-inventory)

### 🗒️ Description

**Fix** (bug fix - capacity over-count re-introduced on ticket save)

Fixed an issue where saving an RSVP V2 ticket through the editor silently re-introduced the Not Going capacity over-count. The Going → Not Going flip only updates the RSVP status meta and never decrements `total_sales`, so `Ticket::save()` recomputed `_stock` as capacity minus stale sold, over-subtracting seats held by Not Going attendees. For TC-RSVP tickets, `sold` is now recomputed from live Going attendees (mirroring the `inventory()` exclusion); regular Tickets Commerce ticket saves are untouched. Added 3 regression tests to `Stock_Capacity_Test`.
