### PR TITLE
Fix: RSVP tickets leak into wp-admin All Tickets list

### DIFF
--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -155,6 +155,10 @@ class Controller extends Controller_Contract {
 			2
 		);
 		add_filter(
+			'tec_tickets_admin_tickets_table_query_args',
+			$this->container->callback( Repository_Filters::class, 'exclude_rsvp_tickets_from_list_table' )
+		);
+		add_filter(
 			'tec_tickets_commerce_is_ticket',
 			$this->container->callback( Repository_Filters::class, 'rsvp_are_tickets' ),
 			10,
@@ -336,6 +340,10 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_commerce_repository_ticket_query_args',
 			$this->container->callback( Repository_Filters::class, 'exclude_rsvp_tickets_from_repository_queries' )
+		);
+		remove_filter(
+			'tec_tickets_admin_tickets_table_query_args',
+			$this->container->callback( Repository_Filters::class, 'exclude_rsvp_tickets_from_list_table' )
 		);
 		remove_filter(
 			'tec_tickets_commerce_is_ticket',

--- a/src/Tickets/RSVP/V2/Repository_Filters.php
+++ b/src/Tickets/RSVP/V2/Repository_Filters.php
@@ -61,6 +61,47 @@ class Repository_Filters {
 	}
 
 	/**
+	 * Excludes RSVP tickets from the Tickets Admin list table query args.
+	 *
+	 * Hooks into `tec_tickets_admin_tickets_table_query_args` to exclude TC-RSVP tickets from the
+	 * All Tickets list table, which runs a raw `WP_Query` and does not go through the Tickets
+	 * Commerce repository.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $args The query args to be used to fetch the tickets.
+	 *
+	 * @return array<string,mixed> The modified query args.
+	 */
+	public function exclude_rsvp_tickets_from_list_table( array $args ): array {
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		$args['meta_query'] = isset( $args['meta_query'] ) && is_array( $args['meta_query'] ) ?
+			$args['meta_query']
+			: [];
+
+		// Let's make sure the meta query is not being added twice.
+		foreach ( $args['meta_query'] as $meta_query ) {
+			if (
+				isset( $meta_query['key'], $meta_query['value'] )
+				&& $meta_query['key'] === '_type'
+				&& $meta_query['value'] === Constants::TC_RSVP_TYPE
+			) {
+				// The meta query has already been filtered to either exclude or include RSVP tickets, bail.
+				return $args;
+			}
+		}
+
+		// Exclude RSVP tickets from the list.
+		$args['meta_query'][ Constants::TYPE_META_QUERY_KEY ] = [
+			'key'     => '_type',
+			'compare' => '!=',
+			'value'   => Constants::TC_RSVP_TYPE,
+		];
+
+		return $args;
+	}
+
+	/**
 	 * Marks RSVP tickets as proper tickets in the ticket detection logic in Tickets Commerce.
 	 *
 	 * @since TBD

--- a/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/List_Table_Test.php
@@ -7,6 +7,7 @@ use TEC\Tickets\Admin\Tickets\List_Table;
 use TEC\Tickets\Commerce as TicketsCommerce;
 use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use WP_Query;
 
 /**
  * Tests for All Tickets list table behavior with TC-RSVP tickets.
@@ -46,5 +47,65 @@ class List_Table_Test extends WPTestCase {
 		$expected_label = _x( 'RSVP', 'Default TC-RSVP ticket name in the All Tickets list', 'event-tickets' );
 
 		$this->assertStringContainsString( esc_html( $expected_label ), $html );
+	}
+
+	public function test_exclude_rsvp_tickets_from_list_table_adds_type_meta_query(): void {
+		$args = [
+			'post_type'   => TicketsCommerce\Ticket::POSTTYPE,
+			'post_status' => 'any',
+		];
+
+		$filtered = tribe( Repository_Filters::class )->exclude_rsvp_tickets_from_list_table( $args );
+
+		$this->assertArrayHasKey( 'meta_query', $filtered );
+		$this->assertIsArray( $filtered['meta_query'] );
+		$this->assertArrayHasKey( Constants::TYPE_META_QUERY_KEY, $filtered['meta_query'] );
+		$this->assertSame(
+			[
+				'key'     => '_type',
+				'compare' => '!=',
+				'value'   => Constants::TC_RSVP_TYPE,
+			],
+			$filtered['meta_query'][ Constants::TYPE_META_QUERY_KEY ]
+		);
+	}
+
+	public function test_exclude_rsvp_tickets_from_list_table_is_idempotent(): void {
+		$args = [
+			'post_type'   => TicketsCommerce\Ticket::POSTTYPE,
+			'post_status' => 'any',
+		];
+
+		$once  = tribe( Repository_Filters::class )->exclude_rsvp_tickets_from_list_table( $args );
+		$twice = tribe( Repository_Filters::class )->exclude_rsvp_tickets_from_list_table( $once );
+
+		$this->assertCount( 1, $twice['meta_query'] );
+		$this->assertSame(
+			$once['meta_query'][ Constants::TYPE_META_QUERY_KEY ],
+			$twice['meta_query'][ Constants::TYPE_META_QUERY_KEY ]
+		);
+	}
+
+	public function test_list_table_query_args_exclude_rsvp_tickets(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		// Create one TC-RSVP ticket and one regular TC ticket.
+		$rsvp_ticket_id    = $this->create_tc_rsvp_ticket( $post_id );
+		$regular_ticket_id = $this->create_tc_ticket( $post_id, 10 );
+
+		// Run the same query path the List_Table uses (raw WP_Query, filtered args).
+		$args  = apply_filters(
+			'tec_tickets_admin_tickets_table_query_args',
+			[
+				'post_type'      => TicketsCommerce\Ticket::POSTTYPE,
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+			]
+		);
+		$query = new WP_Query( $args );
+		$ids   = wp_list_pluck( $query->posts, 'ID' );
+
+		$this->assertContains( $regular_ticket_id, $ids, 'Regular TC ticket should appear in the All Tickets list' );
+		$this->assertNotContains( $rsvp_ticket_id, $ids, 'TC-RSVP ticket should be excluded from the All Tickets list' );
 	}
 }


### PR DESCRIPTION
### Description

**Fix** — Consumes the dormant `tec_tickets_admin_tickets_table_query_args` filter to exclude TC-RSVP tickets from the raw WP_Query in `List_Table::prepare_items()`, which bypasses the repository-level exclusion. Mirrors `Repository_Filters::exclude_rsvp_tickets_from_repository_queries()`.