### PR TITLE
[SOFT-4152] Fix RSVP tickets not rendering on the frontend and My Tickets page

### DIFF
--- a/src/Tickets/Commerce/Module.php
+++ b/src/Tickets/Commerce/Module.php
@@ -315,7 +315,7 @@ class Module extends \Tribe__Tickets__Tickets {
 	public function front_end_tickets_form( $unused_content ) {
 
 		$post    = $GLOBALS['post'];
-		$tickets = $this->get_tickets( $post->ID );
+		$tickets = $this->get_tickets( $post->ID, RSVP_V2_Constants::FRONT_END_TICKETS_FORM_CONTEXT );
 
 		foreach ( $tickets as $index => $ticket ) {
 			if ( __CLASS__ !== $ticket->provider_class ) {
@@ -327,7 +327,17 @@ class Module extends \Tribe__Tickets__Tickets {
 			return;
 		}
 
-		tribe( Tickets_View::class )->get_tickets_block( $post->ID );
+		$tickets_view = tribe( Tickets_View::class );
+
+		$tickets_view->get_tickets_block( $post->ID );
+
+		// TC-RSVP tickets are rendered by the RSVP block: render it when RSVP tickets are present.
+		foreach ( $tickets as $ticket ) {
+			if ( RSVP_V2_Constants::TC_RSVP_TYPE === $ticket->type ) {
+				$tickets_view->get_rsvp_block( $post );
+				break;
+			}
+		}
 	}
 
 	/**

--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -137,6 +137,71 @@ class Attendees {
 	}
 
 	/**
+	 * Provides the TC-RSVP attendee data for a user and event.
+	 *
+	 * The RSVP V1 handler cannot build attendee data for TC-RSVP attendees: this method
+	 * queries the RSVP attendee repository and builds the data through the Tickets Commerce
+	 * module, shaping it like the RSVP V1 data the My Tickets templates expect.
+	 *
+	 * Hooked to `tec_tickets_rsvp_get_attendees_by_user_id_pre`.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|array<array<string,mixed>> $attendees Null by default.
+	 * @param int                             $user_id   The user ID.
+	 * @param int                             $post_id   The post ID.
+	 *
+	 * @return array|null Either the attendee data, or null to let the default logic run.
+	 */
+	public function get_rsvp_attendees_by_user_id( $attendees, $user_id, $post_id ): ?array {
+		if ( $attendees !== null ) {
+			// Already filtered, bail.
+			return $attendees;
+		}
+
+		if ( empty( $post_id ) ) {
+			// Let the default logic run.
+			return null;
+		}
+
+		$repository = tribe( 'tickets.attendee-repository.rsvp' );
+
+		$attendee_ids = iterator_to_array(
+			$repository
+				->where( 'user', $user_id )
+				->where( 'event', $post_id )
+				->order_by( 'ID', 'ASC' )
+				->get_ids( true ),
+			false
+		);
+
+		if ( empty( $attendee_ids ) ) {
+			return [];
+		}
+
+		$commerce = tribe( Module::class );
+
+		$attendee_data = [];
+
+		foreach ( $attendee_ids as $attendee_id ) {
+			$data = $commerce->get_attendee( $attendee_id, $post_id );
+
+			if ( ! $data ) {
+				continue;
+			}
+
+			// The My Tickets RSVP templates expect RSVP V1-shaped attendee data.
+			$data['order_status']  = 'no' === get_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, true ) ? 'no' : 'yes';
+			$data['purchase_time'] = get_the_date( 'Y-m-d H:i:s', $attendee_id );
+			$data['ticket_exists'] = true;
+
+			$attendee_data[] = $data;
+		}
+
+		return $attendee_data;
+	}
+
+	/**
 	 * Replaces the order-status label with a "Going" / "Not Going" indicator for TC RSVP attendees.
 	 *
 	 * Hooked to `tribe_tickets_attendees_table_order_status`. All RSVP attendees have a

--- a/src/Tickets/RSVP/V2/Attendees.php
+++ b/src/Tickets/RSVP/V2/Attendees.php
@@ -166,18 +166,11 @@ class Attendees {
 
 		$repository = tribe( 'tickets.attendee-repository.rsvp' );
 
-		$attendee_ids = iterator_to_array(
-			$repository
-				->where( 'user', $user_id )
-				->where( 'event', $post_id )
-				->order_by( 'ID', 'ASC' )
-				->get_ids( true ),
-			false
-		);
-
-		if ( empty( $attendee_ids ) ) {
-			return [];
-		}
+		$attendee_ids = $repository
+			->where( 'user', $user_id )
+			->where( 'event', $post_id )
+			->order_by( 'ID', 'ASC' )
+			->get_ids( true );
 
 		$commerce = tribe( Module::class );
 

--- a/src/Tickets/RSVP/V2/Constants.php
+++ b/src/Tickets/RSVP/V2/Constants.php
@@ -36,6 +36,15 @@ class Constants {
 	public const TYPE_META_QUERY_KEY = 'tc-rsvp-type';
 
 	/**
+	 * The repository request context used when fetching tickets for the front-end ticket form.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const FRONT_END_TICKETS_FORM_CONTEXT = 'front_end_tickets_form';
+
+	/**
 	 * Meta key for storing the "show not going" option.
 	 *
 	 * @since TBD

--- a/src/Tickets/RSVP/V2/Controller.php
+++ b/src/Tickets/RSVP/V2/Controller.php
@@ -163,7 +163,9 @@ class Controller extends Controller_Contract {
 		);
 		add_filter(
 			'tribe_repository_tc_tickets_query_args',
-			$this->container->callback( Repository_Filters::class, 'maybe_include_rsvp_tickets' )
+			$this->container->callback( Repository_Filters::class, 'maybe_include_rsvp_tickets' ),
+			10,
+			3
 		);
 
 		add_filter(
@@ -206,6 +208,12 @@ class Controller extends Controller_Contract {
 			$this->container->callback( Attendees::class, 'get_rsvp_attendees_by_id' ),
 			10,
 			2
+		);
+		add_filter(
+			'tec_tickets_rsvp_get_attendees_by_user_id_pre',
+			$this->container->callback( Attendees::class, 'get_rsvp_attendees_by_user_id' ),
+			10,
+			3
 		);
 
 		// Attendees report: show Going/Not Going status and hide check-in for "not going" RSVPs.
@@ -344,7 +352,8 @@ class Controller extends Controller_Contract {
 		);
 		remove_filter(
 			'tribe_repository_tc_tickets_query_args',
-			$this->container->callback( Repository_Filters::class, 'maybe_include_rsvp_tickets' )
+			$this->container->callback( Repository_Filters::class, 'maybe_include_rsvp_tickets' ),
+			10
 		);
 		remove_filter(
 			'tec_tickets_commerce_cart_repository',
@@ -375,6 +384,10 @@ class Controller extends Controller_Contract {
 		remove_filter(
 			'tec_tickets_rsvp_get_attendees_by_id_pre',
 			$this->container->callback( Attendees::class, 'get_rsvp_attendees_by_id' )
+		);
+		remove_filter(
+			'tec_tickets_rsvp_get_attendees_by_user_id_pre',
+			$this->container->callback( Attendees::class, 'get_rsvp_attendees_by_user_id' )
 		);
 		remove_filter(
 			'tribe_tickets_attendees_table_order_status',
@@ -631,7 +644,7 @@ class Controller extends Controller_Contract {
 			}
 		}
 
-		if ( $context === 'front_end_tickets_form' ) {
+		if ( $context === Constants::FRONT_END_TICKETS_FORM_CONTEXT ) {
 			// Include RSVP tickets from the list.
 			return $query_args;
 		}

--- a/src/Tickets/RSVP/V2/Frontend.php
+++ b/src/Tickets/RSVP/V2/Frontend.php
@@ -221,7 +221,8 @@ class Frontend {
 			return;
 		}
 
-		$attendee_status = 'going' === $attendee_data['order_status'] ? 'yes' : 'no';
+		// The RSVP V2 form posts `going` / `not_going`, while the legacy My Tickets selector posts `yes` / `no`.
+		$attendee_status = in_array( $attendee_data['order_status'], [ 'going', 'yes' ], true ) ? 'yes' : 'no';
 
 		$current_status = metadata_exists( 'post', $attendee_id, Constants::RSVP_STATUS_META_KEY ) ? get_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, true ) : 'yes';
 

--- a/src/Tickets/RSVP/V2/Repository_Filters.php
+++ b/src/Tickets/RSVP/V2/Repository_Filters.php
@@ -81,8 +81,8 @@ class Repository_Filters {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string,mixed>     $query_args The arguments used to fetch tickets.
-	 * @param mixed                   $query      The query object, unused.
+	 * @param array<string,mixed>       $query_args The arguments used to fetch tickets.
+	 * @param mixed                     $query      The query object, unused.
 	 * @param Repository_Interface|null $repository The repository instance.
 	 *
 	 * @return array<string,mixed> The modified arguments.

--- a/src/Tickets/RSVP/V2/Repository_Filters.php
+++ b/src/Tickets/RSVP/V2/Repository_Filters.php
@@ -76,15 +76,25 @@ class Repository_Filters {
 
 	/**
 	 * Filter the arguments used to fetch Tickets Commerce tickets to remove the RSVP tickets
-	 * default exclusion if the request is for a specific ticket by ID or for the RSVP type.
+	 * default exclusion if the request is for a specific ticket by ID, for the RSVP type, or
+	 * for the front-end ticket form (which renders RSVP tickets through the RSVP block).
 	 *
 	 * @since TBD
 	 *
-	 * @param array<string,mixed> $query_args The arguments used to fetch tickets.
+	 * @param array<string,mixed>     $query_args The arguments used to fetch tickets.
+	 * @param mixed                   $query      The query object, unused.
+	 * @param Repository_Interface|null $repository The repository instance.
 	 *
 	 * @return array<string,mixed> The modified arguments.
 	 */
-	public function maybe_include_rsvp_tickets( array $query_args ): array {
+	public function maybe_include_rsvp_tickets( array $query_args, $query = null, $repository = null ): array {
+		if ( $repository instanceof Repository_Interface && Constants::FRONT_END_TICKETS_FORM_CONTEXT === $repository->get_request_context() ) {
+			// The front-end ticket form renders RSVP tickets through the RSVP block: include them.
+			unset( $query_args['meta_query'][ Constants::TYPE_META_QUERY_KEY ] );
+
+			return $query_args;
+		}
+
 		if ( isset( $query_args['p'] ) ) {
 			// The query is for a specific ticket ID, include RSVP.
 			unset( $query_args['meta_query'][ Constants::TYPE_META_QUERY_KEY ] );

--- a/src/Tribe/RSVP.php
+++ b/src/Tribe/RSVP.php
@@ -2059,7 +2059,12 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 
 		// Set cache after filter is applied.
 		if ( $ticket instanceof \Tribe__Tickets__Ticket_Object ) {
-			wp_cache_set( (int) $ticket->ID, $ticket->to_array(), 'tec_tickets' );
+			// Do not cache TC-RSVP tickets: they are owned by the Tickets Commerce provider, and caching
+			// the legacy RSVP representation here would poison the shared `tec_tickets` cache with a
+			// mismatching provider class for Tickets Commerce reads.
+			if ( ! ( RSVP_V2_Constants::TC_RSVP_TYPE === $ticket->type() ) ) {
+				wp_cache_set( (int) $ticket->ID, $ticket->to_array(), 'tec_tickets' );
+			}
 		}
 
 		return $ticket;
@@ -2253,6 +2258,39 @@ class Tribe__Tickets__RSVP extends Tribe__Tickets__Tickets {
 		$repository = tribe_attendees( $this->orm_provider );
 
 		return $repository->by( 'event', $post_id )->by( 'user', $user_id )->by( 'rsvp_status', 'no' )->found();
+	}
+
+	/**
+	 * Get attendees for a ticket by user ID.
+	 *
+	 * Allows implementations (e.g. RSVP V2) to provide the attendee data for TC-RSVP attendees,
+	 * which the RSVP V1 handler cannot build.
+	 *
+	 * @since TBD
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $post_id Post or Event ID.
+	 *
+	 * @return array List of attendees.
+	 */
+	public function get_attendees_by_user_id( int $user_id, int $post_id = 0 ) {
+		/**
+		 * Filters the RSVP Attendees by user ID before the default logic runs.
+		 * Non-null values returned by applied filters will be returned to the caller.
+		 *
+		 * @since TBD
+		 *
+		 * @param null|array<array<string,mixed>> $attendees Null by default.
+		 * @param int                             $user_id   The user ID.
+		 * @param int                             $post_id   The post ID.
+		 */
+		$attendees = apply_filters( 'tec_tickets_rsvp_get_attendees_by_user_id_pre', null, $user_id, $post_id );
+
+		if ( null !== $attendees ) {
+			return $attendees;
+		}
+
+		return parent::get_attendees_by_user_id( $user_id, $post_id );
 	}
 
 	/**

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -982,7 +982,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 *
 		 * @return array List of attendees.
 		 */
-		public function get_attendees_by_user_id( $user_id, $post_id = 0 ) {
+		public function get_attendees_by_user_id( int $user_id, int $post_id = 0 ) {
 			/** @var Tribe__Tickets__Attendee_Repository $repository */
 			$repository = tribe_attendees( $this->orm_provider );
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -324,7 +324,7 @@ class Tribe__Tickets__Tickets_View {
 		// Loop back to the Event, this page is only for Logged users.
 		// The `tribe_redirected` query arg prevents TEC from stopping the redirect on non-view URLs
 		// (see `Tribe\Events\Views\V2\Hooks::filter_redirect_canonical`).
-		wp_redirect( add_query_arg( 'tribe_redirected', 1, get_permalink() ) );
+		wp_safe_redirect( add_query_arg( 'tribe_redirected', 1, get_permalink() ) );
 		exit;
 	}
 

--- a/src/Tribe/Tickets_View.php
+++ b/src/Tribe/Tickets_View.php
@@ -321,8 +321,10 @@ class Tribe__Tickets__Tickets_View {
 			return;
 		}
 
-		// Loop back to the Event, this page is only for Logged users
-		wp_redirect( get_permalink() );
+		// Loop back to the Event, this page is only for Logged users.
+		// The `tribe_redirected` query arg prevents TEC from stopping the redirect on non-view URLs
+		// (see `Tribe\Events\Views\V2\Hooks::filter_redirect_canonical`).
+		wp_redirect( add_query_arg( 'tribe_redirected', 1, get_permalink() ) );
 		exit;
 	}
 

--- a/src/views/tickets/orders-rsvp.php
+++ b/src/views/tickets/orders-rsvp.php
@@ -15,6 +15,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
+
+use TEC\Tickets\RSVP\V2\Constants;
+
 $view      = Tribe__Tickets__Tickets_View::instance();
 $post_id   = get_the_ID();
 $post      = get_post( $post_id );
@@ -57,7 +60,8 @@ $attendee_groups = $view->get_event_rsvp_attendees_by_purchaser( $post_id, $user
 		</div>
 		<?php
 			$this->template( 'tickets/my-tickets/title', [
-				'title'  => tribe_get_rsvp_label_plural( basename( __FILE__ ) ),
+				'title'       => tribe_get_rsvp_label_plural( basename( __FILE__ ) ),
+				'ticket_type' => Constants::TC_RSVP_TYPE,
 			] );
 		?>
 		<div class="tec__tickets-my-tickets-rsvp-attendee-list-wrapper">

--- a/tests/rsvp_v2_integration/RSVP/V2/Frontend_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Frontend_Test.php
@@ -374,6 +374,57 @@ class Frontend_Test extends WPTestCase {
 			},
 		];
 
+		yield 'updates status from going to not-going with legacy yes/no values' => [
+			function () {
+				$fixture = $this->create_rsvp_order_with_attendee( 'yes' );
+
+				// The legacy My Tickets selector posts `yes` / `no`.
+				$attendee_data = [ 'order_status' => 'no' ];
+
+				return [
+					$attendee_data,
+					$fixture['attendee_id'],
+					$fixture['user_id'],
+					'no', // Should be updated from 'yes' to 'no'.
+					true,  // Expect update.
+				];
+			},
+		];
+
+		yield 'updates status from not-going to going with legacy yes/no values' => [
+			function () {
+				$fixture = $this->create_rsvp_order_with_attendee( 'no' );
+
+				// The legacy My Tickets selector posts `yes` / `no`.
+				$attendee_data = [ 'order_status' => 'yes' ];
+
+				return [
+					$attendee_data,
+					$fixture['attendee_id'],
+					$fixture['user_id'],
+					'yes', // Should be updated from 'no' to 'yes'.
+					true,   // Expect update.
+				];
+			},
+		];
+
+		yield 'does not update when legacy value matches current status' => [
+			function () {
+				$fixture = $this->create_rsvp_order_with_attendee( 'yes' );
+
+				// The legacy My Tickets selector posts `yes` / `no`.
+				$attendee_data = [ 'order_status' => 'yes' ];
+
+				return [
+					$attendee_data,
+					$fixture['attendee_id'],
+					$fixture['user_id'],
+					'yes', // Already 'yes', so no change.
+					false,  // Expect no update.
+				];
+			},
+		];
+
 		yield 'defaults to yes when no meta exists and going is submitted (no change)' => [
 			function () {
 				$fixture = $this->create_rsvp_order_with_attendee( 'yes' );

--- a/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_RSVP_List_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/My_Tickets_RSVP_List_Test.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace TEC\Tickets\RSVP\V2;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Module;
+use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Order_Maker;
+use Tribe__Tickets__Tickets_View as Tickets_View;
+
+/**
+ * Regression tests for the classic My Tickets RSVP list flow
+ * (the `tickets/orders-rsvp.php` template) when the event has TC-RSVP tickets.
+ *
+ * The RSVP V1 handler cannot build attendee data for TC-RSVP attendees: the V2
+ * `Attendees::get_rsvp_attendees_by_user_id` implementation provides it through the
+ * `tec_tickets_rsvp_get_attendees_by_user_id_pre` filter. These tests lock that flow.
+ */
+class My_Tickets_RSVP_List_Test extends WPTestCase {
+	use Ticket_Maker;
+	use Order_Maker;
+
+	/**
+	 * The value of `$GLOBALS['post']` before the test modified it, to restore in `tearDown()`.
+	 *
+	 * @var \WP_Post|null
+	 */
+	private $original_post;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_post = $GLOBALS['post'] ?? null;
+	}
+
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		$GLOBALS['post'] = $this->original_post;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a user, a post, a TC-RSVP ticket, an order (owned by the user) and its attendees.
+	 *
+	 * Creates a regular TC ticket first (so that Order_Maker can generate attendees), then
+	 * retroactively sets the _type meta to tc-rsvp.
+	 *
+	 * @param string $rsvp_status    The RSVP status to set on the attendees ('yes' or 'no').
+	 * @param string $purchaser_name The purchaser name for the order.
+	 *
+	 * @return array{user_id: int, post_id: int, ticket_id: int, order_id: int, attendee_ids: int[]}
+	 */
+	private function create_rsvp_fixture( string $rsvp_status = 'yes', string $purchaser_name = 'Test User' ): array {
+		$user_id = static::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		// Create as a regular TC ticket (price 0) so the cart-based order creation works.
+		$ticket_id = $this->create_tc_ticket( $post_id, 0 );
+
+		$order = $this->create_order(
+			[ $ticket_id => 2 ],
+			[
+				'purchaser_user_id'    => $user_id,
+				'purchaser_full_name'  => $purchaser_name,
+				'purchaser_first_name' => 'Test',
+				'purchaser_last_name'  => 'User',
+				'purchaser_email'      => 'test@example.com',
+			]
+		);
+
+		// Retroactively set the ticket type to TC-RSVP.
+		update_post_meta( $ticket_id, '_type', Constants::TC_RSVP_TYPE );
+
+		$attendees    = tribe( Module::class )->get_attendees_by_order_id( $order->ID );
+		$attendee_ids = array_map( static fn( $attendee ) => (int) $attendee['attendee_id'], $attendees );
+
+		foreach ( $attendee_ids as $attendee_id ) {
+			update_post_meta( $attendee_id, Constants::RSVP_STATUS_META_KEY, $rsvp_status );
+		}
+
+		return [
+			'user_id'      => $user_id,
+			'post_id'      => $post_id,
+			'ticket_id'    => $ticket_id,
+			'order_id'     => (int) $order->ID,
+			'attendee_ids' => $attendee_ids,
+		];
+	}
+
+	/**
+	 * Renders the My Tickets RSVP template the way the tickets page does: as the current user,
+	 * with the post set as the global post.
+	 *
+	 * @param int $post_id The post ID.
+	 * @param int $user_id The user ID to render as.
+	 *
+	 * @return string The rendered template HTML.
+	 */
+	private function render_orders_rsvp_template( int $post_id, int $user_id ): string {
+		wp_set_current_user( $user_id );
+
+		$GLOBALS['post'] = get_post( $post_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		return tribe( 'tickets.editor.template' )->template( 'tickets/orders-rsvp', [], false );
+	}
+
+	public function test_should_return_tc_rsvp_attendees_for_user_and_event(): void {
+		// Arrange.
+		$fixture = $this->create_rsvp_fixture( 'yes' );
+
+		// Act.
+		$attendees = tribe( 'tickets.rsvp' )->get_attendees_by_user_id( $fixture['user_id'], $fixture['post_id'] );
+
+		// Assert.
+		$this->assertCount( 2, $attendees, 'Both TC-RSVP attendees should be returned' );
+
+		$first = $attendees[0];
+		$this->assertSame( 'yes', $first['order_status'], 'Going attendees should map to the RSVP "yes" status' );
+		$this->assertTrue( $first['ticket_exists'], 'The attendee ticket should exist' );
+		$this->assertNotEmpty( $first['purchase_time'], 'The purchase time should be populated' );
+		$this->assertSame( $fixture['order_id'], (int) $first['order_id'], 'The order ID should be the Tickets Commerce order' );
+		$this->assertSame( get_post( $fixture['ticket_id'] )->post_title, $first['ticket'], 'The ticket name should be the ticket title' );
+	}
+
+	/**
+	 * Data provider for the RSVP status mapping scenarios.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function rsvp_status_provider(): array {
+		return [
+			'going'     => [ 'yes', 'yes' ],
+			'not going' => [ 'no', 'no' ],
+		];
+	}
+
+	/**
+	 * @dataProvider rsvp_status_provider
+	 */
+	public function test_should_map_the_rsvp_status( string $rsvp_status, string $expected_order_status ): void {
+		// Arrange.
+		$fixture = $this->create_rsvp_fixture( $rsvp_status );
+
+		// Act.
+		$attendees = tribe( 'tickets.rsvp' )->get_attendees_by_user_id( $fixture['user_id'], $fixture['post_id'] );
+
+		// Assert.
+		$this->assertCount( 2, $attendees );
+		$this->assertSame( $expected_order_status, $attendees[0]['order_status'], 'The RSVP status meta should map to the order status' );
+	}
+
+	public function test_should_return_empty_when_user_has_no_rsvp_attendees(): void {
+		// Arrange.
+		$fixture       = $this->create_rsvp_fixture( 'yes' );
+		$other_user_id = static::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		// Act.
+		$attendees = tribe( 'tickets.rsvp' )->get_attendees_by_user_id( $other_user_id, $fixture['post_id'] );
+
+		// Assert.
+		$this->assertSame( [], $attendees, 'A user without RSVPs for the event should get an empty list' );
+	}
+
+	public function test_should_group_rsvp_attendees_by_purchaser(): void {
+		// Arrange.
+		$fixture = $this->create_rsvp_fixture( 'yes', 'Jane Doe' );
+
+		// Act.
+		$groups = Tickets_View::instance()->get_event_rsvp_attendees_by_purchaser( $fixture['post_id'], $fixture['user_id'] );
+
+		// Assert.
+		$this->assertCount( 1, $groups, 'Both attendees of the same purchaser should be in one group' );
+
+		$group = reset( $groups );
+		$this->assertCount( 2, $group );
+		$this->assertSame( 'Jane Doe', $group[0]['purchaser_name'] );
+	}
+
+	public function test_should_render_tc_rsvp_attendees_in_the_orders_rsvp_template(): void {
+		// Arrange.
+		$fixture = $this->create_rsvp_fixture( 'yes' );
+
+		// Act.
+		$html = $this->render_orders_rsvp_template( $fixture['post_id'], $fixture['user_id'] );
+
+		// Assert.
+		$this->assertStringContainsString( 'tribe-rsvp-list', $html, 'The RSVP list should be rendered' );
+		$this->assertStringContainsString( 'Attendee 1', $html, 'The attendee label should be rendered' );
+		$this->assertStringContainsString( 'RSVPs', $html, 'The RSVP title should be rendered' );
+		$this->assertStringContainsString( 'tribe-answer-select', $html, 'The RSVP status selector should be rendered' );
+		$this->assertStringContainsString( 'Test User', $html, 'The purchaser name should be rendered' );
+	}
+
+	public function test_should_not_render_the_rsvp_list_for_users_without_rsvps(): void {
+		// Arrange.
+		$fixture       = $this->create_rsvp_fixture( 'yes' );
+		$other_user_id = static::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		// Act.
+		$html = $this->render_orders_rsvp_template( $fixture['post_id'], $other_user_id );
+
+		// Assert.
+		$this->assertSame( '', $html, 'The template should not render for users without RSVPs' );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4152](https://linear.app/nexcess/issue/SOFT-4152/rsvp-tickets-are-not-rendered-on-frontend)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fixed an issue where TC-RSVP tickets saved to an event were not rendered on the frontend event page or on the event's My Tickets page. The frontend form now queries tickets in a dedicated context that includes RSVP tickets and renders the RSVP block, and the My Tickets RSVP list now builds TC-RSVP attendee data through the Tickets Commerce module, matching the legacy RSVP shape. Also resolved a blank page for anonymous visitors to the tickets page by flagging the redirect so The Events Calendar does not suppress it, and fixed status updates from the classic selector being inverted on save.

### 🎥 Artifacts <!-- if applicable-->

**Bug**
https://github.com/user-attachments/assets/f3451e8e-d2a1-4892-a2f7-1a180b62419a

**Fix**
<img width="930" height="613" alt="Screenshot 2026-08-07 at 21 09 57" src="https://github.com/user-attachments/assets/a9e52dc2-0ffb-4ec5-9156-c78a61b9f065" />

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
