### PR TITLE
Do not lose V1 RSVP attendees before the migration is run

### DIFF
--- a/src/Tickets/RSVP/Controller.php
+++ b/src/Tickets/RSVP/Controller.php
@@ -345,8 +345,17 @@ class Controller extends Controller_Contract {
 		$rsvp_to_tc = $registry->get( 'rsvp-to-tc' );
 
 		if ( ! $rsvp_to_tc ) {
-			// Assume that it has been completed and removed in the future.
-			return self::VERSION_2;
+			/*
+			 * The migration is missing either because it was removed in a future release, or simply
+			 * because it is not registered yet: `Tribe__Tickets__Main::bind_implementations()` calls
+			 * `maybe_activate_tickets_commerce()` before registering the provider that registers it.
+			 *
+			 * Assuming it completed is only safe in the first case. In the second it permanently flips
+			 * a site holding V1 data to V2 without migrating (the result is persisted), unregistering
+			 * the V1 post types and hiding every legacy RSVP ticket and attendee. The data state tells
+			 * the two apart.
+			 */
+			return self::has_rsvp_v1_tickets() ? self::VERSION_1 : self::VERSION_2;
 		}
 
 		$migration_status = $rsvp_to_tc->get_status();
@@ -373,5 +382,28 @@ class Controller extends Controller_Contract {
 
 		// Unknown status: determine version from the actual data state.
 		return $rsvp_to_tc->is_applicable() ? self::VERSION_1 : self::VERSION_2;
+	}
+
+	/**
+	 * Checks whether the site still holds legacy V1 RSVP tickets.
+	 *
+	 * Deliberately a direct query: this runs early enough in the bootstrap that the RSVP post types
+	 * are not registered yet and no RSVP class can safely be instantiated, so `WP_Query` and the
+	 * ticket repositories are both out of reach. The post type is hard-coded for the same reason
+	 * (see `Tribe__Tickets__RSVP::$ticket_object`, mirrored in `Ticket_Cache_Controller`).
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether at least one V1 RSVP ticket exists.
+	 */
+	private static function has_rsvp_v1_tickets(): bool {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s LIMIT 1",
+				'tribe_rsvp_tickets'
+			)
+		);
 	}
 }

--- a/tests/wpunit/TEC/Tickets/RSVP/Controller_Test.php
+++ b/tests/wpunit/TEC/Tickets/RSVP/Controller_Test.php
@@ -7,7 +7,10 @@
 
 namespace TEC\Tickets\RSVP;
 
+use ReflectionMethod;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
+use TEC\Tickets\Migrations\RSVP_To_Tickets_Commerce;
+use function TEC\Common\StellarWP\Migrations\migrations;
 
 /**
  * Class Controller_Test
@@ -216,6 +219,129 @@ class Controller_Test extends Controller_Test_Case {
 		$this->assertTrue( Controller::is_migration_in_progress() );
 
 		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+	}
+
+	/**
+	 * Runs a callback with `rsvp-to-tc` absent from the registry, reproducing the state the version
+	 * detection actually runs in: `Tribe__Tickets__Main::bind_implementations()` calls
+	 * `maybe_activate_tickets_commerce()` before the provider that registers the migration.
+	 *
+	 * The migration is always restored, so a failure here cannot cascade into other tests.
+	 *
+	 * @param callable $callback The callback to run.
+	 *
+	 * @return mixed The callback return value.
+	 */
+	private function without_registered_rsvp_migration( callable $callback ) {
+		$registry = migrations()->get_registry();
+		$registry->offsetUnset( 'rsvp-to-tc' );
+
+		try {
+			return $callback();
+		} finally {
+			$registry->register( 'rsvp-to-tc', RSVP_To_Tickets_Commerce::class );
+		}
+	}
+
+	/**
+	 * Runs the private version detection.
+	 *
+	 * @return string The detected version.
+	 */
+	private function detect_version(): string {
+		$method = new ReflectionMethod( Controller::class, 'detect_version_from_migration_status' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Runs the private version resolution, which also persists the result.
+	 *
+	 * @return string The resolved version.
+	 */
+	private function resolve_and_persist_version(): string {
+		$method = new ReflectionMethod( Controller::class, 'get_version_from_migration_status' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Creates a legacy V1 RSVP ticket.
+	 *
+	 * @return int The ticket post ID.
+	 */
+	private function given_a_v1_rsvp_ticket(): int {
+		return wp_insert_post(
+			[
+				'post_type'   => 'tribe_rsvp_tickets',
+				'post_title'  => 'Legacy RSVP ticket',
+				'post_status' => 'publish',
+			]
+		);
+	}
+
+	public function test_detects_v1_when_migration_not_registered_and_v1_tickets_exist(): void {
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+		$this->given_a_v1_rsvp_ticket();
+
+		$version = $this->without_registered_rsvp_migration(
+			function () {
+				return $this->detect_version();
+			}
+		);
+
+		$this->assertSame(
+			Controller::VERSION_1,
+			$version,
+			'A site still holding V1 RSVP tickets must stay on V1 when the migration is not in the registry yet, otherwise every legacy RSVP ticket and attendee becomes unreadable.'
+		);
+	}
+
+	public function test_detects_v2_when_migration_not_registered_and_no_v1_tickets_exist(): void {
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+
+		$version = $this->without_registered_rsvp_migration(
+			function () {
+				return $this->detect_version();
+			}
+		);
+
+		$this->assertSame(
+			Controller::VERSION_2,
+			$version,
+			'With no V1 RSVP data on the site the migration is genuinely done (or gone), so V2 is correct.'
+		);
+	}
+
+	public function test_does_not_persist_v2_when_migration_not_registered_and_v1_tickets_exist(): void {
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+		$this->given_a_v1_rsvp_ticket();
+
+		$version = $this->without_registered_rsvp_migration(
+			function () {
+				return $this->resolve_and_persist_version();
+			}
+		);
+
+		$this->assertSame( Controller::VERSION_1, $version );
+		$this->assertSame(
+			Controller::VERSION_1,
+			tribe_get_option( Controller::VERSION_OPTION_KEY ),
+			'The detected version is persisted permanently, so persisting V2 here would strand the site on a version that cannot read its own RSVP data.'
+		);
+	}
+
+	public function test_detects_v1_when_migration_is_registered_and_pending(): void {
+		tribe_remove_option( Controller::VERSION_OPTION_KEY );
+		$this->given_a_v1_rsvp_ticket();
+
+		$this->assertSame(
+			Controller::VERSION_1,
+			$this->detect_version(),
+			'A registered, applicable, never-run migration is pending, which means the site is still on V1.'
+		);
 	}
 
 	public function test_register_disabled_hooks_editor_config_filter(): void {


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID] - none yet but I can add one if we want 
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Upgrading a site that still has V1 RSVP data would silently flip it to RSVP V2 without ever running the migration, unregistering the V1 post types and making every legacy RSVP ticket and attendee vanish from the site — no rows are deleted, but it reads as total data loss.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). [skip-changelog] 
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
