### PR TITLE
Hide IAC link when ETP is deactivated

### DIFF
--- a/src/modules/blocks/rsvp-v2/container-content/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-v2/container-content/__tests__/template.test.js
@@ -1,5 +1,7 @@
-jest.mock( '../../create-form/template', () => ( { clientId } ) => (
-	<div data-testid="rsvp-create-form">{ clientId }</div>
+jest.mock( '../../create-form/template', () => ( { clientId, hasTicketsPlus } ) => (
+	<div data-testid="rsvp-create-form" data-has-tickets-plus={ String( hasTicketsPlus ) }>
+		{ clientId }
+	</div>
 ) );
 
 /**
@@ -22,6 +24,20 @@ describe( 'RSVPContainerContent', () => {
 
 		expect( tree.props[ 'data-testid' ] ).toBe( 'rsvp-create-form' );
 		expect( tree.children ).toEqual( [ 'test-client-id' ] );
+	} );
+
+	it( 'forwards the Event Tickets Plus flag to the create form', () => {
+		const withPlus = renderer.create(
+			<RSVPContainerContent clientId="test-client-id" hasTicketsPlus={ true } isAddEditOpen={ true } />
+		);
+
+		expect( withPlus.toJSON().props[ 'data-has-tickets-plus' ] ).toBe( 'true' );
+
+		const withoutPlus = renderer.create(
+			<RSVPContainerContent clientId="test-client-id" hasTicketsPlus={ false } isAddEditOpen={ true } />
+		);
+
+		expect( withoutPlus.toJSON().props[ 'data-has-tickets-plus' ] ).toBe( 'false' );
 	} );
 
 	it( 'renders nothing when add/edit is closed', () => {

--- a/src/modules/blocks/rsvp-v2/container-content/template.js
+++ b/src/modules/blocks/rsvp-v2/container-content/template.js
@@ -10,16 +10,17 @@ import PropTypes from 'prop-types';
 import RSVPCreateForm from '../create-form/template';
 import '../../rsvp/container-content/style.pcss';
 
-const RSVPContainerContent = ( { clientId, isAddEditOpen } ) => {
+const RSVPContainerContent = ( { clientId, hasTicketsPlus, isAddEditOpen } ) => {
 	if ( ! isAddEditOpen ) {
 		return null;
 	}
 
-	return <RSVPCreateForm clientId={ clientId } />;
+	return <RSVPCreateForm clientId={ clientId } hasTicketsPlus={ hasTicketsPlus } />;
 };
 
 RSVPContainerContent.propTypes = {
 	clientId: PropTypes.string,
+	hasTicketsPlus: PropTypes.bool,
 	isAddEditOpen: PropTypes.bool,
 };
 

--- a/src/modules/blocks/rsvp-v2/create-form/__tests__/template.test.js
+++ b/src/modules/blocks/rsvp-v2/create-form/__tests__/template.test.js
@@ -18,6 +18,7 @@ import RSVPCreateForm from '../template';
 describe( 'RSVPCreateForm', () => {
 	const defaultProps = {
 		clientId: 'test-client-id',
+		hasTicketsPlus: true,
 	};
 
 	it( 'should render Add RSVP title and form fields', () => {
@@ -26,9 +27,16 @@ describe( 'RSVPCreateForm', () => {
 		expect( tree ).toMatchSnapshot();
 	} );
 
-	it( 'should always render attendee registration link', () => {
+	it( 'should render attendee registration link when Event Tickets Plus is active', () => {
 		const component = renderer.create( <RSVPCreateForm { ...defaultProps } /> );
 		const json = JSON.stringify( component.toJSON() );
 		expect( json ).toContain( 'Collect attendee information' );
+	} );
+
+	it( 'should not render attendee registration link when Event Tickets Plus is inactive', () => {
+		const component = renderer.create( <RSVPCreateForm { ...defaultProps } hasTicketsPlus={ false } /> );
+		const json = JSON.stringify( component.toJSON() );
+		expect( json ).not.toContain( 'Collect attendee information' );
+		expect( json ).not.toContain( 'tribe-editor__rsvp-v2-attendee-registration-link' );
 	} );
 } );

--- a/src/modules/blocks/rsvp-v2/create-form/template.js
+++ b/src/modules/blocks/rsvp-v2/create-form/template.js
@@ -17,21 +17,24 @@ import RSVPV2DurationFields from '../duration-fields/container';
 import RSVPAttendeeRegistrationLink from '../attendee-registration-link/container';
 import './style.pcss';
 
-const RSVPCreateForm = ( { clientId } ) => (
+const RSVPCreateForm = ( { clientId, hasTicketsPlus } ) => (
 	<div className="tribe-editor__rsvp-v2-create-form">
 		<h3 className="tribe-editor__rsvp-v2-create-form__title tribe-common-h3 tribe-common-h4--min-medium">
 			{ __( 'Add RSVP', 'event-tickets' ) }
 		</h3>
 		<RSVPV2Capacity />
 		<RSVPV2DurationFields />
-		<div className="tribe-editor__rsvp-v2-attendee-registration-link">
-			<RSVPAttendeeRegistrationLink clientId={ clientId } />
-		</div>
+		{ hasTicketsPlus && (
+			<div className="tribe-editor__rsvp-v2-attendee-registration-link">
+				<RSVPAttendeeRegistrationLink clientId={ clientId } />
+			</div>
+		) }
 	</div>
 );
 
 RSVPCreateForm.propTypes = {
 	clientId: PropTypes.string,
+	hasTicketsPlus: PropTypes.bool,
 };
 
 export default RSVPCreateForm;


### PR DESCRIPTION
### 🎫 Ticket

[NA] none but I can add one if we want
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This adds the check for ETP `hasTicketsPlus` to conditionally show the 'collect attendee information' link only when ETP is available. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process) [skip-changelog]
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
