### PR TITLE
Handle lost cookies with Stripe

### DIFF
--- a/changelog/fix-smtnc-1983-stripe-checkout.yaml
+++ b/changelog/fix-smtnc-1983-stripe-checkout.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where a Stripe checkout could leave the buyer on an
+  endless spinner with their payment taken but no order completed.
+timestamp: 2026-08-12T16:57:06.638Z

--- a/src/Tickets/Commerce/Gateways/Contracts/Abstract_REST_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/Contracts/Abstract_REST_Endpoint.php
@@ -124,7 +124,13 @@ abstract class Abstract_REST_Endpoint implements REST_Endpoint_Interface, \Tribe
 	/**
 	 * Ensures that the current request tries to edit an order id which is stored as pending edit.
 	 *
+	 * The cart-bound check is the preferred path. It depends on the visitor's cart cookie surviving the
+	 * round trip to the gateway, which is not guaranteed on every host: edge caches, proxies and
+	 * hostname mismatches can all drop it. When that happens the buyer has already been charged, so
+	 * gateways may authorize the request instead with a credential they issued for that specific order.
+	 *
 	 * @since 5.29.0.1
+	 * @since TBD Falls back to a gateway-issued, order-scoped credential when the cart cookie is gone.
 	 *
 	 * @param WP_REST_Request $request The REST Request instance.
 	 *
@@ -137,21 +143,91 @@ abstract class Abstract_REST_Endpoint implements REST_Endpoint_Interface, \Tribe
 			return false;
 		}
 
-		if ( $order_id !== $this->pending_order->get() ) {
+		if ( $this->cart_owns_pending_order( (string) $order_id ) ) {
+			return true;
+		}
+
+		return $this->request_carries_order_credential( $request, (string) $order_id );
+	}
+
+	/**
+	 * Whether the current visitor's cart is the one that registered the given gateway order id as its
+	 * pending order.
+	 *
+	 * The order id must match the pending order stored for the cart hash read from the visitor's
+	 * cookie, and a Created/Pending order carrying that same cart hash must exist.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $gateway_order_id The gateway's order id.
+	 *
+	 * @return bool
+	 */
+	protected function cart_owns_pending_order( string $gateway_order_id ): bool {
+		if ( $gateway_order_id !== $this->pending_order->get() ) {
 			return false;
 		}
 
+		// Reaching here means the pending order resolved, which already required a cart hash.
 		$existing_order = tec_tc_orders()->by_args(
 			[
-				'gateway_order_id' => $order_id,
+				'gateway_order_id' => $gateway_order_id,
 				'hash'             => $this->cart->get_cart_hash( false ),
-				'status'           => [
-					tribe( Created::class )->get_wp_slug(),
-					tribe( Pending::class )->get_wp_slug(),
-				],
+				'status'           => 'any',
 			]
 		)->first();
 
-		return ! empty( $existing_order->ID );
+		return $this->order_is_in_flight( $existing_order );
+	}
+
+	/**
+	 * Whether an order exists and is still in flight, so a gateway request may drive it to a final
+	 * status.
+	 *
+	 * The status is checked here, on the fetched post, rather than handed to the query, because the
+	 * orders ORM does neither of the things a status argument looks like it does. A list of statuses
+	 * produces no post_status clause at all, so it filters nothing; omitting the argument instead falls
+	 * back to the repository's default post_status, which is the insert status alone. Querying for
+	 * `any` and deciding here is the only combination that means what it says.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $order The order post, or anything falsy when no order was found.
+	 *
+	 * @return bool
+	 */
+	protected function order_is_in_flight( $order ): bool {
+		if ( empty( $order->ID ) ) {
+			return false;
+		}
+
+		$in_flight = [
+			tribe( Created::class )->get_wp_slug(),
+			tribe( Pending::class )->get_wp_slug(),
+		];
+
+		return in_array( $order->post_status, $in_flight, true );
+	}
+
+	/**
+	 * Whether the request carries a credential this gateway issued for the given order.
+	 *
+	 * Gateways that hand the buyer an order-scoped secret when the order is created can override this
+	 * to authorize the request on that secret alone, which keeps checkout working when the cart cookie
+	 * did not survive. Gateways with no such secret keep the cart-bound check as their only path.
+	 *
+	 * A gateway overriding this MUST compare against a value it stored for that specific order, using
+	 * a timing-safe comparison. Accepting a merely well-formed value would reduce this gate to an
+	 * existence check on the order id.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request          The REST Request instance.
+	 * @param string          $gateway_order_id The gateway's order id.
+	 *
+	 * @return bool
+	 */
+	protected function request_carries_order_credential( WP_REST_Request $request, string $gateway_order_id ): bool {
+		return false;
 	}
 }

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -73,6 +73,7 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 							'cardElementType'   => tribe( Stripe_Elements::class )->card_element_type(),
 							'publishableKey'    => tribe( Merchant::class )->get_publishable_key(),
 							'paymentIntentData' => tribe( Payment_Intent_Handler::class )->get_publishable_payment_intent_data(),
+
 							/*
 							 * Shown when the payment succeeded but the order could not be finalized. It has to
 							 * steer the buyer away from paying again, since their card has already been charged.

--- a/src/Tickets/Commerce/Gateways/Stripe/Assets.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/Assets.php
@@ -73,6 +73,15 @@ class Assets extends \TEC\Common\Contracts\Service_Provider {
 							'cardElementType'   => tribe( Stripe_Elements::class )->card_element_type(),
 							'publishableKey'    => tribe( Merchant::class )->get_publishable_key(),
 							'paymentIntentData' => tribe( Payment_Intent_Handler::class )->get_publishable_payment_intent_data(),
+							/*
+							 * Shown when the payment succeeded but the order could not be finalized. It has to
+							 * steer the buyer away from paying again, since their card has already been charged.
+							 */
+							'updateOrderFailedMessage' => sprintf(
+								/* translators: %s: The lowercase plural tickets label. */
+								__( 'Your payment went through, but we could not finish your order. Please do not pay again. Contact the organizer to have your %s issued.', 'event-tickets' ),
+								tribe_get_ticket_label_plural_lowercase( 'stripe_checkout_update_order_failed' )
+							),
 							'elementsAppearance' => [
 								'variables' => [
 									'borderRadius'   => '4px',

--- a/src/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint.php
+++ b/src/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint.php
@@ -87,6 +87,97 @@ class Order_Endpoint extends Abstract_REST_Endpoint {
 	}
 
 	/**
+	 * Authorizes the request with the Payment Intent client secret this site issued for the order.
+	 *
+	 * The cart-bound check in the parent class is still the preferred path. It needs the visitor's cart
+	 * cookie, which does not always survive the round trip to Stripe: edge caches, proxies and
+	 * www/non-www mismatches can all drop it. Since the buyer has already been charged by the time this
+	 * route is called, losing the cookie must not strand the order.
+	 *
+	 * The client secret is a per-Payment-Intent credential Stripe issues to the buyer's browser and we
+	 * store on the order when we create the intent, so possessing it is proof the caller is the buyer
+	 * checking out. It is compared against the value stored on that specific order, never against the
+	 * request's own claims, and it travels in the request body rather than the URL.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request          The REST Request instance.
+	 * @param string          $gateway_order_id The Payment Intent ID.
+	 *
+	 * @return bool
+	 */
+	protected function request_carries_order_credential( WP_REST_Request $request, string $gateway_order_id ): bool {
+		$client_secret = $request->get_param( 'client_secret' );
+
+		if ( ! is_string( $client_secret ) || '' === $client_secret ) {
+			return false;
+		}
+
+		$order = tec_tc_orders()->by_args(
+			[
+				'gateway_order_id' => $gateway_order_id,
+				'gateway'          => Gateway::get_key(),
+				'status'           => 'any',
+			]
+		)->first();
+
+		// The status is verified here rather than in the query above; see order_is_in_flight().
+		if ( ! $this->order_is_in_flight( $order ) ) {
+			return false;
+		}
+
+		$stored_secret = $this->get_stored_client_secret( (int) $order->ID, $gateway_order_id );
+
+		if ( '' === $stored_secret ) {
+			return false;
+		}
+
+		return hash_equals( $stored_secret, $client_secret );
+	}
+
+	/**
+	 * Reads the client secret stored on an order for a given Payment Intent.
+	 *
+	 * The Payment Intent is saved to the order's gateway payload when the intent is created, and again
+	 * on every status change, so the same intent can appear under more than one status bucket. Only a
+	 * payload whose own id matches the requested Payment Intent is considered.
+	 *
+	 * @since TBD
+	 *
+	 * @param int    $order_id         The Tickets Commerce order post ID.
+	 * @param string $gateway_order_id The Payment Intent ID.
+	 *
+	 * @return string The stored client secret, or an empty string when there is none.
+	 */
+	protected function get_stored_client_secret( int $order_id, string $gateway_order_id ): string {
+		$order = tec_tc_get_order( $order_id );
+
+		if ( empty( $order->gateway_payload ) || ! is_array( $order->gateway_payload ) ) {
+			return '';
+		}
+
+		foreach ( $order->gateway_payload as $status_payloads ) {
+			foreach ( (array) $status_payloads as $payload ) {
+				if ( ! is_array( $payload ) ) {
+					continue;
+				}
+
+				if ( ( $payload['id'] ?? '' ) !== $gateway_order_id ) {
+					continue;
+				}
+
+				$stored_secret = $payload['client_secret'] ?? '';
+
+				if ( is_string( $stored_secret ) && '' !== $stored_secret ) {
+					return $stored_secret;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Handles the request that creates an order with Tickets Commerce and the Stripe gateway.
 	 *
 	 * @since 5.3.0

--- a/src/resources/js/commerce/gateway/stripe/checkout.js
+++ b/src/resources/js/commerce/gateway/stripe/checkout.js
@@ -261,6 +261,7 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	 * When a successful request is completed to our Approval endpoint.
 	 *
 	 * @since 5.3.0
+	 * @since TBD Updated to handle the case where the payment intent is not present.
 	 *
 	 * @param {Object} data Data returning from our endpoint.
 	 *
@@ -269,13 +270,7 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	obj.handlePaymentSuccess = async ( data ) => {
 		tribe.tickets.debug.log( 'stripe', 'handlePaymentSuccess', data );
 
-		const response = await obj.handleUpdateOrder( data.paymentIntent );
-
-		// Redirect the user to the success page.
-		if ( response.redirect_url && URL.canParse( response.redirect_url ) ) {
-			window.location = response.redirect_url;
-		}
-		return true;
+		return obj.handleUpdateOrderResponse( await obj.handleUpdateOrder( data.paymentIntent ) );
 	};
 
 	/**
@@ -288,14 +283,44 @@ tribe.tickets.commerce.gateway.stripe.checkout = {};
 	obj.handlePaymentDelayed = async ( data ) => {
 		tribe.tickets.debug.log( 'stripe', 'handlePaymentDelayed', data );
 
-		const response = await obj.handleUpdateOrder( data.paymentIntent );
+		return obj.handleUpdateOrderResponse( await obj.handleUpdateOrder( data.paymentIntent ) );
+	};
 
-		// Redirect the user to the success page.
-		if ( response.redirect_url && URL.canParse( response.redirect_url ) ) {
-			window.location = response.redirect_url;
+	/**
+	 * Acts on the response from the order update request.
+	 *
+	 * The buyer has already been charged by the time this runs, so a failure here must be surfaced
+	 * rather than swallowed. Previously anything without a `redirect_url` (a permission failure, a
+	 * network drop, an expired session) left the loader spinning with no message, and buyers retried
+	 * and were charged again.
+	 *
+	 * @since TBD
+	 *
+	 * @param {Object} response The parsed response from the order update endpoint.
+	 *
+	 * @return {boolean} Whether the order update succeeded.
+	 */
+	obj.handleUpdateOrderResponse = ( response ) => {
+		try {
+			// Not URL.canParse(): it is missing on older browsers, where calling it throws and leaves
+			// the checkout hanging on the loader. new URL() is everywhere and throws on bad input.
+			window.location = new URL( response.redirect_url ).href;
+
+			return true;
+		} catch ( error ) {
+			// No usable redirect, so fall through and tell the buyer.
 		}
 
-		return true;
+		tribe.tickets.loader.hide( obj.checkoutContainer );
+
+		/*
+		 * Deliberately not surfacing the server's own message here: the buyer's card has been charged,
+		 * and a raw "you are not allowed to do that" would read as a failed payment and invite a retry.
+		 * The response is already in the debug log for support.
+		 */
+		obj.showNotice( obj.checkoutContainer, '', obj.checkout.updateOrderFailedMessage );
+
+		return false;
 	};
 
 	/**

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint_Credential_Round_Trip_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint_Credential_Round_Trip_Test.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * End-to-end regression test for the Stripe order-update credential fallback.
+ *
+ * The fallback in Order_Endpoint::request_carries_order_credential() is only worth anything if the
+ * create-order handler actually persists the Payment Intent client secret on the order. This drives
+ * the real handle_create_order() and then asks the real permission callback whether a buyer who lost
+ * their cart cookie can still finalize the order they just paid for.
+ *
+ * The Stripe API is stubbed out; nothing here touches the network.
+ *
+ * @package TEC\Tickets\Commerce\Gateways\Stripe\REST
+ */
+
+namespace TEC\Tickets\Commerce\Gateways\Stripe\REST;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Gateways\Stripe\Payment_Intent_Handler;
+use TEC\Tickets\Commerce\Utils\Currency;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe\Tickets\Test\Commerce\TicketsCommerce\Ticket_Maker;
+use Tribe__Settings_Manager;
+use WP_REST_Request;
+
+class Order_Endpoint_Credential_Round_Trip_Test extends WPTestCase {
+
+	use With_Uopz;
+	use Ticket_Maker;
+
+	private const PAYMENT_INTENT = 'pi_test_roundtrip';
+	private const CLIENT_SECRET  = 'pi_test_roundtrip_secret_9f8e7d';
+
+	/**
+	 * make_cart_with_ticket() writes tribe options, which are memoized in an in-memory var the
+	 * per-test DB rollback does not touch. Clear it, and the shared cart, so later tests are not
+	 * affected.
+	 */
+	public function tearDown(): void {
+		tribe( Cart::class )->clear_cart();
+		tribe_set_var( Tribe__Settings_Manager::OPTION_CACHE_VAR_NAME, [] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Puts a single $10 ticket in the shared cart so create_from_cart() has something to work with.
+	 */
+	private function make_cart_with_ticket(): void {
+		tribe_update_option( Currency::$currency_code_option, 'USD' );
+		tribe_update_option( 'ticket-enabled-post-types', [ 'post', 'page' ] );
+
+		$post   = static::factory()->post->create( [ 'post_type' => 'page' ] );
+		$ticket = $this->create_tc_ticket( $post, 10 );
+
+		tribe( Cart::class )->get_repository()->upsert_item( $ticket, 1 );
+	}
+
+	/**
+	 * Stubs the one call that would otherwise reach Stripe, returning a Payment Intent shaped like the
+	 * real API response.
+	 */
+	private function stub_stripe_payment_intent(): void {
+		$this->set_class_fn_return(
+			Payment_Intent_Handler::class,
+			'update_payment_intent',
+			[
+				'id'            => self::PAYMENT_INTENT,
+				'client_secret' => self::CLIENT_SECRET,
+				'status'        => 'requires_payment_method',
+				'amount'        => '1000',
+				'created'       => 1786000000,
+				'currency'      => 'usd',
+			]
+		);
+	}
+
+	/**
+	 * Runs the real create-order handler for a cart with one ticket.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private function create_order() {
+		$request = new WP_REST_Request( 'POST', '/tec-tickets/v1/commerce/stripe/order' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'purchaser' => [
+						'name'  => 'Round Trip Buyer',
+						'email' => 'roundtrip-buyer@test.com',
+					],
+				]
+			)
+		);
+
+		return tribe( Order_Endpoint::class )->handle_create_order( $request );
+	}
+
+	/**
+	 * Creating an order must store the client secret on it, and a buyer presenting that secret must be
+	 * able to finalize the order after their cart cookie is gone. Before the fallback existed, that
+	 * second request answered 401 and the paid order stayed stranded in `tec-tc-created`.
+	 */
+	public function test_created_order_stores_the_secret_that_later_authorizes_the_update(): void {
+		$this->make_cart_with_ticket();
+		$this->stub_stripe_payment_intent();
+
+		$response = $this->create_order();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] ?? false, 'The order should have been created.' );
+		$this->assertSame(
+			self::CLIENT_SECRET,
+			$data['client_secret'] ?? '',
+			'The create response must hand the buyer the client secret.'
+		);
+
+		clean_post_cache( $data['order_id'] );
+
+		$order = tec_tc_get_order( $data['order_id'] );
+
+		$stored_secrets = [];
+		foreach ( (array) $order->gateway_payload as $status_payloads ) {
+			foreach ( (array) $status_payloads as $payload ) {
+				if ( is_array( $payload ) && isset( $payload['client_secret'] ) ) {
+					$stored_secrets[] = $payload['client_secret'];
+				}
+			}
+		}
+
+		$this->assertContains(
+			self::CLIENT_SECRET,
+			$stored_secrets,
+			'The order must persist the client secret, otherwise the update fallback can never match.'
+		);
+
+		// The buyer pays, comes back, and their cart cookie did not survive the round trip.
+		$this->set_class_property( tribe( Cart::class )->get_repository(), 'cart_hash', '' );
+
+		$update_request = new WP_REST_Request( 'POST', '/tec-tickets/v1/commerce/stripe/order' );
+		$update_request->set_param( 'order_id', self::PAYMENT_INTENT );
+		$update_request->set_param( 'client_secret', self::CLIENT_SECRET );
+
+		$this->assertTrue(
+			tribe( Order_Endpoint::class )->current_user_can_edit_order( $update_request ),
+			'A buyer who has paid must be able to finalize the order with the secret this site issued, even with no cart cookie.'
+		);
+
+		$update_request->set_param( 'client_secret', 'pi_test_roundtrip_secret_WRONG' );
+
+		$this->assertFalse(
+			tribe( Order_Endpoint::class )->current_user_can_edit_order( $update_request ),
+			'A mismatched client secret must still be refused.'
+		);
+	}
+}

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint_Credential_Round_Trip_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe/REST/Order_Endpoint_Credential_Round_Trip_Test.php
@@ -107,7 +107,11 @@ class Order_Endpoint_Credential_Round_Trip_Test extends WPTestCase {
 		$this->stub_stripe_payment_intent();
 
 		$response = $this->create_order();
-		$data     = $response->get_data();
+
+		// handle_create_order() can return a WP_Error, which has no get_data() and would fatal below.
+		$this->assertNotWPError( $response, 'The create-order handler must not return an error.' );
+
+		$data = $response->get_data();
 
 		$this->assertTrue( $data['success'] ?? false, 'The order should have been created.' );
 		$this->assertSame(

--- a/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe_Order_Credential_Fallback_Test.php
+++ b/tests/commerce_integration/TEC/Tickets/Commerce/Gateways/Stripe_Order_Credential_Fallback_Test.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Regression tests for the Stripe order-update credential fallback.
+ *
+ * The order-update route is gated by current_user_can_edit_order(), which depends on the visitor's
+ * cart cookie surviving the round trip to Stripe. When that cookie is dropped (edge caches, proxies,
+ * www/non-www mismatches) the buyer has already been charged but the route answers 401, the order is
+ * stranded in `tec-tc-created`, and no attendee is generated.
+ *
+ * Stripe endpoints therefore fall back to the Payment Intent client secret, which this site issued for
+ * that specific order and stored on it. These tests pin both halves of that boundary: the buyer with
+ * the real secret gets through without a cart, and everyone else still does not.
+ *
+ * @package TEC\Tickets\Commerce\Gateways
+ */
+
+namespace TEC\Tickets\Commerce\Gateways;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Common\Monolog\Logger;
+use TEC\Tickets\Commerce\Cart;
+use TEC\Tickets\Commerce\Gateways\Contracts\Abstract_REST_Endpoint;
+use TEC\Tickets\Commerce\Gateways\PayPal\REST\Order_Endpoint as PayPal_Order_Endpoint;
+use TEC\Tickets\Commerce\Gateways\Stripe\REST\Order_Endpoint as Stripe_Order_Endpoint;
+use TEC\Tickets\Commerce\Order;
+use TEC\Tickets\Commerce\Pending_Order;
+use TEC\Tickets\Commerce\Status\Completed;
+use TEC\Tickets\Commerce\Status\Created;
+use TEC\Tickets\Commerce\Status\Pending;
+use TEC\Tickets\Commerce\Status\Status_Handler;
+use Tribe\Tests\Traits\With_Uopz;
+use WP_REST_Request;
+
+class Stripe_Order_Credential_Fallback_Test extends WPTestCase {
+
+	use With_Uopz;
+
+	private const BUYER_HASH     = 'buyerhash001';
+	private const PAYMENT_INTENT = 'pi_test_buyer';
+	private const CLIENT_SECRET  = 'pi_test_buyer_secret_abc123';
+
+	/**
+	 * Registers the order post statuses with WordPress, as the plugin does on `init`.
+	 *
+	 * Without this, WP_Query drops the post_status clause entirely and every status matches, so a
+	 * lookup that wrongly relies on the orders repository's default post_status still appears to work.
+	 * Registering them makes these tests match production and fail when that reliance creeps back in.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		tribe( Status_Handler::class )->register_order_statuses();
+	}
+
+	/**
+	 * @after
+	 */
+	public function reset_pending_transients(): void {
+		delete_transient( sprintf( 'tec_tickets_commerce_pending_order_%s', self::BUYER_HASH ) );
+	}
+
+	/**
+	 * Makes get_cart_hash() resolve to the given hash for the current process, modelling an active
+	 * browser session. An empty hash models the cart cookie never reaching the REST request.
+	 */
+	private function activate_cart_hash( string $hash ): void {
+		$this->set_class_property( tribe( Cart::class )->get_repository(), 'cart_hash', $hash );
+	}
+
+	/**
+	 * Stores a gateway order id as the pending order for the currently active cart hash, mirroring what
+	 * the create-order handler does.
+	 */
+	private function store_pending_order( string $gateway_order_id ): void {
+		( new Pending_Order( tribe( Cart::class ), new Logger( 'test' ) ) )->set( $gateway_order_id );
+	}
+
+	/**
+	 * Creates a Stripe order carrying a gateway payload, the way handle_create_order() saves the
+	 * Payment Intent it just created.
+	 *
+	 * @param string $gateway_order_id The Payment Intent ID.
+	 * @param string $client_secret    The client secret to store on the order, or '' to store none.
+	 * @param string $status_slug      The Tickets Commerce status slug to create the order in.
+	 *
+	 * @return int The created order post ID.
+	 */
+	private function create_stripe_order(
+		string $gateway_order_id,
+		string $client_secret,
+		string $status_slug = Created::SLUG
+	): int {
+		$statuses = [
+			Created::SLUG   => Created::class,
+			Pending::SLUG   => Pending::class,
+			Completed::SLUG => Completed::class,
+		];
+
+		$status = tribe( $statuses[ $status_slug ] );
+
+		$order_id = wp_insert_post(
+			[
+				'post_type'   => Order::POSTTYPE,
+				'post_status' => $status->get_wp_slug(),
+				'post_title'  => 'Stripe test order',
+			]
+		);
+
+		update_post_meta( $order_id, Order::$gateway_order_id_meta_key, $gateway_order_id );
+		update_post_meta( $order_id, Order::$gateway_meta_key, 'stripe' );
+		update_post_meta( $order_id, Order::$hash_meta_key, self::BUYER_HASH );
+
+		$payload = [
+			'id'     => $gateway_order_id,
+			'status' => 'succeeded',
+		];
+
+		if ( '' !== $client_secret ) {
+			$payload['client_secret'] = $client_secret;
+		}
+
+		add_post_meta( $order_id, Order::get_gateway_payload_meta_key( $status ), $payload );
+
+		clean_post_cache( $order_id );
+
+		return $order_id;
+	}
+
+	/**
+	 * Builds a real gateway endpoint backed by a Pending_Order and the shared Cart.
+	 */
+	private function make_endpoint( string $class ): Abstract_REST_Endpoint {
+		return new $class( new Pending_Order( tribe( Cart::class ), new Logger( 'test' ) ), tribe( Cart::class ) );
+	}
+
+	/**
+	 * Builds an order-update request.
+	 *
+	 * @param string|null $order_id      The Payment Intent ID, or null to omit it.
+	 * @param string|null $client_secret The client secret, or null to omit it.
+	 */
+	private function make_request( ?string $order_id, ?string $client_secret = null ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/tec-tickets/v1/commerce/stripe/order' );
+
+		if ( null !== $order_id ) {
+			$request->set_param( 'order_id', $order_id );
+		}
+
+		if ( null !== $client_secret ) {
+			$request->set_param( 'client_secret', $client_secret );
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Both authorized paths have to work for every in-flight status, not just the one the orders
+	 * repository happens to default `post_status` to. Querying without an explicit `status` silently
+	 * narrows the lookup to that default, which strands Pending orders while Created ones sail through.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function in_flight_status_provider(): array {
+		return [
+			'created' => [ Created::SLUG ],
+			'pending' => [ Pending::SLUG ],
+		];
+	}
+
+	/**
+	 * The core regression: the buyer has paid, their cart cookie did not survive the round trip, and
+	 * they present the client secret this site issued for that Payment Intent. The order must be
+	 * finalizable rather than stranded behind a 401.
+	 *
+	 * @dataProvider in_flight_status_provider
+	 */
+	public function test_buyer_without_a_cart_cookie_can_finalize_with_the_issued_client_secret( string $status_slug ): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET, $status_slug );
+
+		// The cart cookie never reached this request, so there is no cart hash and no pending order.
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertTrue(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT, self::CLIENT_SECRET ) ),
+			'A paid buyer holding the issued client secret must be able to finalize their order without a cart cookie.'
+		);
+	}
+
+	/**
+	 * The cart-bound path still works on its own, with no client secret in the request.
+	 *
+	 * @dataProvider in_flight_status_provider
+	 */
+	public function test_cart_bound_path_still_authorizes_without_a_client_secret( string $status_slug ): void {
+		$this->activate_cart_hash( self::BUYER_HASH );
+		$this->store_pending_order( self::PAYMENT_INTENT );
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET, $status_slug );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertTrue(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT ) ),
+			'The cart-bound check must keep authorizing the buyer in an intact session.'
+		);
+	}
+
+	/**
+	 * Knowing the Payment Intent ID is not enough. This is the difference between checking the secret
+	 * and merely checking that some in-flight order exists for the id.
+	 */
+	public function test_payment_intent_id_alone_does_not_authorize(): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT ) ),
+			'A Payment Intent ID with no client secret must not authorize the update.'
+		);
+	}
+
+	/**
+	 * A wrong or empty secret is rejected.
+	 *
+	 * @dataProvider bad_client_secret_provider
+	 */
+	public function test_wrong_client_secret_does_not_authorize( string $client_secret, string $message ): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT, $client_secret ) ),
+			$message
+		);
+	}
+
+	/**
+	 * @return array<string,array{0:string,1:string}>
+	 */
+	public function bad_client_secret_provider(): array {
+		return [
+			'empty'          => [ '', 'An empty client secret must never authorize the update.' ],
+			'wrong value'    => [ 'pi_test_buyer_secret_WRONG', 'A client secret that does not match the stored one must be rejected.' ],
+			'prefix only'    => [ 'pi_test_buyer_secret_', 'A partial client secret must be rejected.' ],
+			'other order id' => [ 'pi_other_order_secret_zzz999', 'Another order\'s client secret must not authorize this one.' ],
+		];
+	}
+
+	/**
+	 * An order with no stored client secret cannot be unlocked by supplying any value, including an
+	 * empty one, so a malformed create cannot silently open the route.
+	 */
+	public function test_order_without_a_stored_secret_cannot_be_unlocked(): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, '' );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT, self::CLIENT_SECRET ) ),
+			'An order with no stored client secret must not be editable through the fallback.'
+		);
+	}
+
+	/**
+	 * The fallback only covers orders still in flight. A completed order cannot be re-opened with the
+	 * client secret, which stays valid on Stripe's side after the payment succeeds.
+	 */
+	public function test_completed_order_cannot_be_reopened_with_the_client_secret(): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET, Completed::SLUG );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT, self::CLIENT_SECRET ) ),
+			'A completed order must not be editable, even with the correct client secret.'
+		);
+	}
+
+	/**
+	 * A secret stored against one Payment Intent must not authorize an update for another, even when
+	 * both payloads live on the same order.
+	 */
+	public function test_secret_from_a_different_payment_intent_on_the_same_order_is_rejected(): void {
+		$order_id = $this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET );
+
+		// An earlier, superseded Payment Intent for the same order.
+		add_post_meta(
+			$order_id,
+			Order::get_gateway_payload_meta_key( tribe( Created::class ) ),
+			[
+				'id'            => 'pi_test_stale',
+				'client_secret' => 'pi_test_stale_secret_xyz',
+			]
+		);
+		clean_post_cache( $order_id );
+
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order(
+				$this->make_request( self::PAYMENT_INTENT, 'pi_test_stale_secret_xyz' )
+			),
+			'The secret belonging to a different Payment Intent must not authorize this one.'
+		);
+	}
+
+	/**
+	 * Gateways that issue no order-scoped secret keep the cart-bound check as their only path, so a
+	 * stray client_secret param cannot widen them.
+	 */
+	public function test_paypal_has_no_credential_fallback(): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( PayPal_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( self::PAYMENT_INTENT, self::CLIENT_SECRET ) ),
+			'PayPal must not gain a credential fallback it never issues credentials for.'
+		);
+	}
+
+	/**
+	 * A request with no order id is still rejected outright, before any fallback runs.
+	 */
+	public function test_request_without_order_id_is_still_rejected(): void {
+		$this->create_stripe_order( self::PAYMENT_INTENT, self::CLIENT_SECRET );
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( null, self::CLIENT_SECRET ) ),
+			'A missing order id must never be treated as authorized.'
+		);
+	}
+
+	/**
+	 * A client secret cannot conjure an order that does not exist.
+	 */
+	public function test_unknown_payment_intent_is_rejected(): void {
+		$this->activate_cart_hash( '' );
+
+		$endpoint = $this->make_endpoint( Stripe_Order_Endpoint::class );
+
+		$this->assertFalse(
+			$endpoint->current_user_can_edit_order( $this->make_request( 'pi_does_not_exist', self::CLIENT_SECRET ) ),
+			'A Payment Intent with no backing order must not authorize the update.'
+		);
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1983](https://linear.app/nexcess/issue/SMTNC-1983/event-tickets-stripe-checkout-never-completes-order-update-rest-route)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We strengthened a part of Tickets Commerce for security purposes, but ended up locking out legit purchasers who have their cart cookie get lost in the roundtrip authorization journey to Stripe, which can happen based on different site configurations. 

This PR completes Stripe orders whose cart cookie was lost in transit by authorizing the order-update request with the Payment Intent secret this site issued for that order, and replaces the endless checkout spinner with a real error message when the update still fails.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/f3556dd607a04ad183fdfe2846654aa2

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
