### PR TITLE
Refresh cache to show RSVPs alongside tickets on an event

### DIFF
--- a/src/Tickets/RSVP/V2/Classic_Editor.php
+++ b/src/Tickets/RSVP/V2/Classic_Editor.php
@@ -55,6 +55,9 @@ class Classic_Editor {
 	public function do_not_show_rsvp_in_tickets_metabox( array $ticket_types ): array {
 		$ticket_types['rsvp'] = [];
 
+		// TC-RSVP tickets carry the Tickets Commerce provider, so they are bucketed under their own type.
+		$ticket_types[ Constants::TC_RSVP_TYPE ] = [];
+
 		return $ticket_types;
 	}
 

--- a/src/Tribe/Tickets.php
+++ b/src/Tribe/Tickets.php
@@ -799,6 +799,7 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 		 * @since 4.12.0 Changed from protected abstract to public with duplicated child classes' logic consolidated here.
 		 * @since 5.8.0 Added the `$context` parameter.
 		 * @since 5.29.0 Made $context explicitly nullable.
+		 * @since TBD Only cache the result when no context is passed, since a context changes which tickets are returned.
 		 *
 		 * @param int         $post_id ID of parent "event" post.
 		 * @param string|null $context The context of the request.
@@ -811,7 +812,10 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 			$cache = tribe( 'cache' );
 			$key   = self::get_tickets_cache_key( $this->orm_provider, $post_id );
 
-			if ( isset( $cache[ $key ] ) && is_array( $cache[ $key ] ) ) {
+			// Only the context-less list is cached: a context can change which tickets are returned.
+			$use_cache = null === $context;
+
+			if ( $use_cache && isset( $cache[ $key ] ) && is_array( $cache[ $key ] ) ) {
 				return $cache[ $key ];
 			}
 
@@ -850,7 +854,9 @@ if ( ! class_exists( 'Tribe__Tickets__Tickets' ) ) {
 				$tickets[] = $ticket;
 			}
 
-			$cache[ $key ] = $tickets;
+			if ( $use_cache ) {
+				$cache[ $key ] = $tickets;
+			}
 
 			return $tickets;
 		}

--- a/tests/rsvp_v2_integration/RSVP/V2/Classic_Editor_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Classic_Editor_Test.php
@@ -70,6 +70,30 @@ class Classic_Editor_Test extends WPTestCase {
 		$this->assertEmpty( $result['rsvp'], 'RSVP tickets should be removed from metabox list' );
 	}
 
+	/**
+	 * TC-RSVP tickets carry the Tickets Commerce provider, so the list panel buckets them under
+	 * their own `tc-rsvp` type rather than under `rsvp`. That bucket has to be emptied too, or the
+	 * RSVP renders its own table inside the Tickets metabox.
+	 *
+	 * @see \TEC\Tickets\RSVP\V2\Classic_Editor::do_not_show_rsvp_in_tickets_metabox()
+	 */
+	public function test_should_remove_tc_rsvp_tickets_from_metabox_list(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+
+		$rsvp_ticket_id    = $this->create_tc_rsvp_ticket( $post_id );
+		$regular_ticket_id = $this->create_tc_ticket( $post_id, 10 );
+
+		$ticket_types = [
+			Constants::TC_RSVP_TYPE => [ tec_tc_get_ticket( $rsvp_ticket_id ) ],
+			'default'               => [ tec_tc_get_ticket( $regular_ticket_id ) ],
+		];
+
+		$result = apply_filters( 'tec_tickets_editor_list_ticket_types', $ticket_types );
+
+		$this->assertEmpty( $result[ Constants::TC_RSVP_TYPE ], 'TC-RSVP tickets should be removed from metabox list' );
+		$this->assertCount( 1, $result['default'], 'Regular tickets should still be listed' );
+	}
+
 	public function test_should_preserve_other_ticket_types_in_metabox_list(): void {
 		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
 

--- a/tests/rsvp_v2_integration/RSVP/V2/Rsvp_Block_Test.php
+++ b/tests/rsvp_v2_integration/RSVP/V2/Rsvp_Block_Test.php
@@ -3,8 +3,10 @@
 namespace TEC\Tickets\RSVP\V2;
 
 use Codeception\TestCase\WPTestCase;
+use TEC\Tickets\Commerce\Module;
 use TEC\Tickets\Tests\Commerce\RSVP\V2\Ticket_Maker;
 use Tribe__Tickets__Editor__Template as Tickets_Editor_Template;
+use Tribe__Tickets__Tickets as Tickets;
 
 /**
  * Tests for RSVP block frontend rendering with TC-RSVP tickets.
@@ -54,5 +56,39 @@ class Rsvp_Block_Test extends WPTestCase {
 
 		$this->assertNotEmpty( $html, 'RSVP block should render TC-RSVP tickets on the frontend.' );
 		$this->assertStringContainsString( 'tribe-tickets__rsvp-wrapper', $html, 'RSVP block should include the RSVP wrapper markup.' );
+	}
+
+	/**
+	 * The single post view asks for the post's tickets without a context long before the ticket form
+	 * renders, and RSVPs are filtered out of that list. If that result is cached and handed back to the
+	 * front-end form request, which asks *with* a context precisely to get the RSVP included, the RSVP
+	 * silently disappears from any post that also has a regular ticket.
+	 *
+	 * @see \Tribe__Tickets__Tickets::get_tickets()
+	 */
+	public function test_front_end_form_should_render_rsvp_when_post_also_has_a_ticket(): void {
+		$post_id = static::factory()->post->create( [ 'post_status' => 'publish' ] );
+		$this->create_tc_ticket( $post_id, 10 );
+		$this->create_tc_rsvp_ticket( $post_id );
+
+		// Warm the request cache the way the single post view does, without a context.
+		Tickets::get_all_event_tickets( $post_id );
+
+		// Skip the "My Tickets" view-link; it requires a full singular post query context.
+		add_filter( 'tribe_tickets_order_link_template_already_rendered', '__return_true' );
+
+		$GLOBALS['post'] = get_post( $post_id );
+
+		ob_start();
+		tribe( Module::class )->front_end_tickets_form( '' );
+		$html = ob_get_clean();
+
+		remove_filter( 'tribe_tickets_order_link_template_already_rendered', '__return_true' );
+
+		$this->assertStringContainsString(
+			'tribe-tickets__rsvp-wrapper',
+			$html,
+			'Front-end ticket form should render the RSVP alongside the ticket.'
+		);
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4169](https://linear.app/nexcess/issue/SOFT-4169/rsvp-does-not-display-on-the-front-end-if-the-event-also-has-tickets)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Issue 1 — RSVP missing on the front end when the event also has tickets.
`Tribe__Tickets__Tickets::get_tickets()` caches its result per provider+post but ignores the `$context` argument. The single-event page asks for tickets without a context first (RSVPs are filtered out of that list by design), so the cached answer has the RSVP stripped. When `Module::front_end_tickets_form()` later asks with the front-end context — the one case where the RSVP is supposed to be included — it gets the poisoned cache back, finds no tc-rsvp ticket, and never renders the RSVP block. Events with only an RSVP escaped it because an empty result is returned before it's cached, which is exactly why deleting the ticket "fixed" it. Fix: only cache the context-less list (`src/Tribe/Tickets.php:814`).


Issue 2 — RSVP showing in the Tickets metabox.
`do_not_show_rsvp_in_tickets_metabox()` empties only the rsvp bucket. TC-RSVP tickets carry the Tickets Commerce provider class, so `list.php` buckets them under their own `tc-rsvp` key, which nothing was clearing — they rendered as a second table. Fix: empty that bucket too (`src/Tickets/RSVP/V2/Classic_Editor.php:59`).

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="1434" height="606" alt="CleanShot 2026-08-13 at 09 53 07" src="https://github.com/user-attachments/assets/8e19ebad-0c2e-44aa-a96d-a2f0374885bf" />

After:
<img width="1464" height="488" alt="CleanShot 2026-08-13 at 10 13 55" src="https://github.com/user-attachments/assets/e1c78ad9-1d17-4fd0-9476-05eaf1c275c8" />


### ✔️ Checklist
- [skip-changelog] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
