### PR TITLE
Persist gap between tickets and RSVPs

### DIFF
--- a/src/resources/postcss/rsvp/_rsvp.pcss
+++ b/src/resources/postcss/rsvp/_rsvp.pcss
@@ -34,3 +34,15 @@
 		}
 	}
 }
+
+/**
+ * On single events, TEC's skeleton stylesheet pulls the second
+ * `.event-tickets` sibling after the event meta up with a negative top
+ * margin so it hugs the first one. The RSVP block is a standalone card,
+ * so that pull collapses the gap between it and the Tickets block. Undo
+ * it and let the wrapper's own top margin space the two cards apart.
+ */
+.tribe-events-event-meta + .event-tickets:has(.tribe-tickets__rsvp-wrapper) + .event-tickets,
+.tribe-events-event-meta + .event-tickets + .event-tickets:has(.tribe-tickets__rsvp-wrapper) {
+	margin-top: 0;
+}


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4169 comment](https://linear.app/nexcess/issue/SOFT-4169/rsvp-does-not-display-on-the-front-end-if-the-event-also-has-tickets#comment-b4e1e963)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

On an incognito window viewing an event with a ticket and an RSVP, the gap between the ticket and the RSVP was not persisting after the migration. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
Before:
<img width="1860" height="1980" alt="CleanShot 2026-08-13 at 13 26 01@2x" src="https://github.com/user-attachments/assets/c4c2492a-2128-4b28-a847-6cf7bd201b7f" />

After:
<img width="3182" height="1982" alt="CleanShot 2026-08-13 at 13 26 39@2x" src="https://github.com/user-attachments/assets/dca818d5-2c6b-48d2-8c3f-23260e083593" />


### ✔️ Checklist
- [skip-changelog] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
